### PR TITLE
ci: limit test workflow to main push and pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- `push:` without branch filter was triggering CI on every branch push, causing duplicate runs (push + PR open + merge)
- Limit to `main` branch pushes only — PRs still trigger via `pull_request:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv