### PR TITLE
refactor: extract useLocalHistory hook + unify UI atoms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,12 @@ import { NewVarModal } from "./components/NewVarModal/NewVarModal";
 import { Sidebar } from "./components/Sidebar/Sidebar";
 import { SnapshotPanel } from "./components/SnapshotPanel/SnapshotPanel";
 import { StagedModal } from "./components/StagedModal/StagedModal";
+import { IconButton } from "./components/ui/IconButton";
 import { Modal } from "./components/ui/Modal";
 import { ThemeContext } from "./context/ThemeContext";
 import { useUndo } from "./contexts/UndoContext";
 import { useEnvVars } from "./hooks/useEnvVars";
-import { useStaged } from "./hooks/useStaged";
+import { useStaged, type StagedChange } from "./hooks/useStaged";
 import { useStagingHandlers } from "./hooks/useStagingHandlers";
 import { useTheme } from "./hooks/useTheme";
 import { applyAccepted, computeDiff, snapshotsEqual } from "./lib/diff";
@@ -22,7 +23,7 @@ import type { EnvSnapshot, EnvVar, VarScope } from "./types";
 
 type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | null;
 
-function stagedToDiff(staged: Map<string, import("./hooks/useStaged").StagedChange>): DiffEntry[] {
+function stagedToDiff(staged: Map<string, StagedChange>): DiffEntry[] {
   return Array.from(staged.values()).map((c): DiffEntry => {
     if (c.kind === "delete")
       return { kind: "removed", name: c.name, scope: c.scope, value: c.originalValue! };
@@ -212,14 +213,7 @@ export default function App() {
             <div className="w-[380px] shrink-0 flex flex-col border-l border-rim bg-panel overflow-hidden">
               <div className="flex items-center justify-between px-5 py-3 border-b border-rim shrink-0">
                 <span className="text-sm font-semibold text-fg">Snapshots</span>
-                <button
-                  type="button"
-                  onClick={() => setSnapshotsOpen(false)}
-                  className="text-dim hover:text-fg transition-colors text-lg leading-none px-1"
-                  aria-label="Close snapshots"
-                >
-                  ×
-                </button>
+                <IconButton aria-label="Close snapshots" icon="×" onClick={() => setSnapshotsOpen(false)} />
               </div>
               <div className="flex-1 overflow-hidden">
                 <SnapshotPanel onStageSnapshot={handleStageSnapshot} />

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -89,29 +89,15 @@ export function AppHeader({
         {elevated && (
           <span className="text-xs text-success opacity-60">🛡 Administrator</span>
         )}
-        <button
-          type="button"
-          onClick={() => openUrl("https://github.com/iray-tno/envarly")}
-          className="text-muted hover:text-fg transition-colors text-xs px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-panel"
-          title="View on GitHub"
-        >
+        <Button variant="ghost" size="xs" onClick={() => openUrl("https://github.com/iray-tno/envarly")} title="View on GitHub">
           ↗ GitHub
-        </button>
-        <button
-          type="button"
-          onClick={onToggleTheme}
-          title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-          className="px-2 py-1 rounded text-muted hover:bg-hover hover:text-fg transition-colors text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas"
-        >
+        </Button>
+        <Button variant="ghost" size="xs" onClick={onToggleTheme} title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}>
           {theme === "dark" ? "☀" : "🌙"}
-        </button>
-        <button
-          type="button"
-          onClick={onLicenses}
-          className="text-dim hover:text-muted transition-colors text-xs px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-panel"
-        >
+        </Button>
+        <Button variant="ghost" size="xs" onClick={onLicenses} className="text-dim">
           Licenses
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocalHistory } from "../../hooks/useLocalHistory";
 import type { StagedChange } from "../../hooks/useStaged";
 import { stagedKey } from "../../hooks/useStaged";
 import type { EnvVar, VarScope } from "../../types";
@@ -21,55 +22,27 @@ interface Props {
 }
 
 export function DetailPanel({ variable, allVars, elevated, staged, onStage, onStageDelete, onUnstage, onRegisterLocalUndo }: Props) {
-  const [value, setValue] = useState("");
-  const [dirty, setDirty] = useState(false);
   const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | null>(null);
   const prevVarRef = useRef<{ name: string; scope: string } | null>(null);
-  // Checkpoints pushed AFTER each structural op (drag/add/remove). Text edits don't push.
-  const localHistory = useRef<string[]>([]);
-  // Stale-closure-safe mirror of value state, read inside handleDiscard.
-  const valueRef = useRef("");
-  // Set by onBeforeReorder; consumed in handleValueChange to push checkpoints.
-  const structuralChangeRef = useRef(false);
-  // Value captured at onBeforeReorder time (pre-op snapshot including any text edits).
-  const preOpValueRef = useRef("");
 
+  const {
+    value,
+    dirty,
+    onChange: handleValueChange,
+    discard: handleDiscard,
+    onBeforeStructuralChange,
+    reset,
+  } = useLocalHistory(variable?.value ?? "");
+
+  // Reset overrideSeparator only when the variable identity changes (not on value-only updates).
   useEffect(() => {
     if (!variable) return;
     const isSameVar =
       prevVarRef.current?.name === variable.name &&
       prevVarRef.current?.scope === variable.scope;
-    setValue(variable.value);
-    valueRef.current = variable.value;
-    setDirty(false);
-    localHistory.current = [];
     if (!isSameVar) setOverrideSeparator(null);
     prevVarRef.current = { name: variable.name, scope: variable.scope };
-  }, [variable?.name, variable?.scope, variable?.value]);
-
-  // Must be before the early return to comply with Rules of Hooks.
-  const handleDiscard = useCallback(() => {
-    const original = variable?.value ?? "";
-    const current = valueRef.current;
-    if (localHistory.current.length === 0) {
-      setValue(original); valueRef.current = original; setDirty(false);
-      return;
-    }
-    const lastCheckpoint = localHistory.current[localHistory.current.length - 1];
-    if (current !== lastCheckpoint) {
-      // Text edits on top of checkpoint → revert to checkpoint only
-      setValue(lastCheckpoint); valueRef.current = lastCheckpoint;
-      setDirty(lastCheckpoint !== original);
-    } else {
-      // Already at checkpoint → undo the structural op itself
-      localHistory.current = localHistory.current.slice(0, -1);
-      const prev = localHistory.current.length > 0
-        ? localHistory.current[localHistory.current.length - 1]
-        : original;
-      setValue(prev); valueRef.current = prev;
-      setDirty(prev !== original);
-    }
-  }, [variable?.value]);
+  }, [variable?.name, variable?.scope]);
 
   useEffect(() => {
     if (!onRegisterLocalUndo) return;
@@ -100,26 +73,8 @@ export function DetailPanel({ variable, allVars, elevated, staged, onStage, onSt
   const isStagedDelete = stagedChange?.kind === "delete";
   const isStagedSet = stagedChange?.kind === "set";
 
-  const handleValueChange = (newVal: string) => {
-    if (structuralChangeRef.current) {
-      // Push pre-op value (with any text edits) then post-op value as checkpoints.
-      // Skip pre-op if it equals the original or is already the top (avoid redundant entries).
-      const preOp = preOpValueRef.current;
-      const top = localHistory.current[localHistory.current.length - 1];
-      const next = [...localHistory.current];
-      if (preOp !== variable.value && preOp !== top) next.push(preOp);
-      next.push(newVal);
-      localHistory.current = next;
-      structuralChangeRef.current = false;
-    }
-    setValue(newVal);
-    valueRef.current = newVal;
-    setDirty(newVal !== variable.value);
-  };
-
   const handleApply = () => {
     onStage(variable.name, variable.scope, value);
-    setDirty(false);
   };
 
   const handleDelete = () => {
@@ -129,9 +84,7 @@ export function DetailPanel({ variable, allVars, elevated, staged, onStage, onSt
 
   const handleUnstage = () => {
     onUnstage(variable.name, variable.scope);
-    const original = stagedChange?.originalValue ?? variable.value;
-    setValue(original);
-    setDirty(false);
+    reset(stagedChange?.originalValue ?? variable.value);
   };
 
   /** Auto-detect list separator from pasted text. */
@@ -248,7 +201,7 @@ export function DetailPanel({ variable, allVars, elevated, staged, onStage, onSt
               readOnly={readOnly}
               allVars={allVars}
               skipPathValidation={variable.name.toUpperCase() === "PATHEXT"}
-              onBeforeReorder={() => { structuralChangeRef.current = true; preOpValueRef.current = valueRef.current; }}
+              onBeforeReorder={onBeforeStructuralChange}
             />
           ) : effectiveSeparator === "," ? (
             <ListEditor separator="," rawValue={value} onChange={handleValueChange} readOnly={readOnly} />

--- a/src/components/DiffPanel/DiffPanel.tsx
+++ b/src/components/DiffPanel/DiffPanel.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import type { DiffEntry } from "../../lib/diff";
+import { Button } from "../ui/Button";
+import { IconButton } from "../ui/IconButton";
 import { EntryRow } from "./EntryRow";
 
 interface Props {
@@ -45,12 +47,7 @@ export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
       <div className="px-5 py-4 border-b border-rim shrink-0">
         <div className="flex items-center justify-between mb-1">
           <h2 className="text-sm font-semibold text-fg">External changes detected</h2>
-          <button
-            onClick={onDismiss}
-            className="text-dim hover:text-fg text-lg leading-none transition-colors"
-          >
-            ×
-          </button>
+          <IconButton aria-label="Close" icon="×" onClick={onDismiss} />
         </div>
         <p className="text-xs text-muted mb-3">
           The registry was modified outside Envarly.{" "}
@@ -66,21 +63,13 @@ export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
         </div>
 
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => toggleAll(true)}
-            disabled={allChecked}
-            className="text-xs text-muted hover:text-fg disabled:opacity-30 transition-colors"
-          >
+          <Button variant="link" size="xs" onClick={() => toggleAll(true)} disabled={allChecked}>
             Select all
-          </button>
+          </Button>
           <span className="text-dim">·</span>
-          <button
-            onClick={() => toggleAll(false)}
-            disabled={noneChecked}
-            className="text-xs text-muted hover:text-fg disabled:opacity-30 transition-colors"
-          >
+          <Button variant="link" size="xs" onClick={() => toggleAll(false)} disabled={noneChecked}>
             Deselect all
-          </button>
+          </Button>
           <span className="text-dim ml-auto text-xs">{acceptedCount}/{entries.length} selected</span>
         </div>
       </div>
@@ -97,19 +86,10 @@ export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
       </div>
 
       <div className="px-5 py-3 border-t border-rim shrink-0 flex gap-2 justify-end">
-        <button
-          onClick={onDismiss}
-          className="px-3 py-1.5 rounded text-muted text-xs hover:bg-hover hover:text-fg transition-colors"
-        >
-          Dismiss
-        </button>
-        <button
-          onClick={handleApply}
-          disabled={busy}
-          className="px-4 py-1.5 rounded bg-accent text-canvas text-xs font-medium hover:bg-accent-hi disabled:opacity-50 transition-colors"
-        >
+        <Button variant="ghost" size="sm" onClick={onDismiss}>Dismiss</Button>
+        <Button variant="primary" size="sm" onClick={handleApply} disabled={busy}>
           {busy ? "Applying…" : `Apply (${acceptedCount} accepted, ${entries.length - acceptedCount} reverted)`}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -16,9 +16,9 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMemo, useState } from "react";
-import { cn } from "../../lib/cn";
 import { Button } from "../ui/Button";
 import { IconButton } from "../ui/IconButton";
+import { cn } from "../../lib/cn";
 
 export interface ListEntry {
   id: string;
@@ -198,13 +198,7 @@ export function SortableListEditor({
       {!readOnly && dupCount > 0 && (
         <div className="flex items-center justify-between px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs">
           <span>{dupCount} duplicate {dupCount === 1 ? "entry" : "entries"}</span>
-          <button
-            type="button"
-            onClick={handleDedup}
-            className="font-medium hover:underline focus:outline-none focus-visible:underline"
-          >
-            Remove
-          </button>
+          <Button variant="link" size="xs" onClick={handleDedup}>Remove</Button>
         </div>
       )}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/src/components/NewVarModal/NewVarModal.tsx
+++ b/src/components/NewVarModal/NewVarModal.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useState } from "react";
-import { cn } from "../../lib/cn";
 import type { EnvVar, VarScope } from "../../types";
 import { Button } from "../ui/Button";
+import { SegmentedControl } from "../ui/SegmentedControl";
 
 interface NewVarModalProps {
   vars: EnvVar[];
@@ -54,25 +54,15 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
 
       <div className="flex flex-col gap-1.5">
         <p className="text-xs font-semibold text-muted uppercase tracking-wide">Scope</p>
-        <div className="flex gap-2">
-          {(["User", "System"] as VarScope[]).map((s) => (
-            <button
-              key={s}
-              type="button"
-              disabled={s === "System" && !elevated}
-              onClick={() => setScope(s)}
-              className={cn(
-                "px-3 py-1 rounded text-xs font-medium border transition-colors",
-                scope === s
-                  ? "bg-accent text-white border-accent"
-                  : "bg-surface text-muted border-rim hover:border-accent",
-                s === "System" && !elevated && "opacity-40 cursor-not-allowed",
-              )}
-            >
-              {s}{s === "System" && !elevated && " (admin)"}
-            </button>
-          ))}
-        </div>
+        <SegmentedControl
+          aria-label="Variable scope"
+          options={[
+            { value: "User" as VarScope, label: "User" },
+            { value: "System" as VarScope, label: elevated ? "System" : "System (admin)", disabled: !elevated },
+          ]}
+          value={scope}
+          onChange={setScope}
+        />
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/src/components/SnapshotPanel/SnapshotPanel.test.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.test.tsx
@@ -86,7 +86,7 @@ describe("SnapshotPanel", () => {
     const user = userEvent.setup();
     render(<SnapshotPanel onStageSnapshot={onStageSnapshot} />);
     await screen.findByText("Before Node update");
-    await user.click(screen.getByRole("button", { name: "×" }));
+    await user.click(screen.getByRole("button", { name: "Delete snapshot" }));
     await waitFor(() => screen.getByRole("button", { name: /^delete$/i }));
     await user.click(screen.getByRole("button", { name: /^delete$/i }));
     await waitFor(() => {

--- a/src/components/SnapshotPanel/SnapshotPanel.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { cn } from "../../lib/cn";
 import { computeDiff } from "../../lib/diff";
+import type { DiffEntry } from "../../lib/diff";
 import type { EnvSnapshot, SnapshotMeta } from "../../types";
 import { Button } from "../ui/Button";
+import { IconButton } from "../ui/IconButton";
 import { TextInput } from "../ui/TextInput";
 import { SnapshotCompare } from "./SnapshotCompare";
 import { SnapshotPreview } from "./SnapshotPreview";
-import type { DiffEntry } from "../../lib/diff";
 
 interface Props {
   onStageSnapshot: (snap: EnvSnapshot) => void;
@@ -169,13 +170,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
           {comparingFrom && (
             <div className="flex items-center justify-between px-2.5 py-1.5 rounded border border-accent/30 bg-accent/10 text-accent text-xs">
               <span>Select a snapshot to compare with <strong>{comparingFrom.label}</strong></span>
-              <button
-                type="button"
-                onClick={handleCancelCompare}
-                className="font-medium hover:underline focus:outline-none focus-visible:underline"
-              >
-                Cancel
-              </button>
+              <Button variant="link" size="xs" onClick={handleCancelCompare}>Cancel</Button>
             </div>
           )}
           {snapshots.length === 0 && (
@@ -232,14 +227,13 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                         <Button variant="ghost" size="sm" onClick={() => setConfirmDeleteId(null)}>Cancel</Button>
                       </>
                     ) : (
-                      <button
-                        type="button"
+                      <IconButton
+                        aria-label="Delete snapshot"
+                        icon="×"
+                        variant="danger"
                         onClick={() => setConfirmDeleteId(s.id)}
-                        className="px-2 py-1 rounded text-dim text-sm hover:text-danger hover:bg-danger/10 transition-colors"
                         title="Delete snapshot"
-                      >
-                        ×
-                      </button>
+                      />
                     )
                   )}
                 </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,8 +1,8 @@
 import type { ButtonHTMLAttributes } from "react";
 import { cn } from "../../lib/cn";
 
-type Variant = "primary" | "secondary" | "ghost" | "danger" | "warn";
-type Size = "sm" | "md";
+type Variant = "primary" | "secondary" | "ghost" | "danger" | "warn" | "link";
+type Size = "xs" | "sm" | "md";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
@@ -15,9 +15,11 @@ const variantCls: Record<Variant, string> = {
   ghost:     "text-muted hover:bg-hover hover:text-fg",
   danger:    "bg-danger/15 text-danger border border-danger/30 hover:bg-danger/25",
   warn:      "border border-warn/40 text-warn hover:bg-warn/10",
+  link:      "text-muted hover:text-fg hover:underline",
 };
 
 const sizeCls: Record<Size, string> = {
+  xs: "px-2 py-1 text-xs",
   sm: "px-4 py-2.5 text-sm",
   md: "px-5 py-3 text-sm font-medium",
 };

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -4,6 +4,7 @@ interface Option<T extends string> {
   value: T;
   label: string;
   count?: number;
+  disabled?: boolean;
 }
 
 interface Props<T extends string> {
@@ -29,10 +30,12 @@ export function SegmentedControl<T extends string>({
           type="button"
           role="radio"
           aria-checked={value === opt.value}
+          disabled={opt.disabled}
           onClick={() => onChange(opt.value)}
           className={cn(
             "flex items-center gap-1.5 px-4 py-2 rounded text-sm transition-colors",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas",
+            "disabled:opacity-40 disabled:cursor-not-allowed",
             value === opt.value
               ? "bg-surface text-fg"
               : "text-muted hover:bg-hover hover:text-fg",

--- a/src/hooks/useLocalHistory.ts
+++ b/src/hooks/useLocalHistory.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseLocalHistoryResult {
+  value: string;
+  dirty: boolean;
+  onChange: (newVal: string) => void;
+  discard: () => void;
+  onBeforeStructuralChange: () => void;
+  reset: (newValue: string) => void;
+}
+
+/**
+ * Manages a local edit history for a single string value.
+ * Tracks two kinds of changes:
+ *   - Structural (drag/add/remove): pushed as checkpoints via onBeforeStructuralChange → onChange.
+ *   - Text edits: live, no checkpoint. Discard reverts to the last checkpoint or original.
+ */
+export function useLocalHistory(originalValue: string): UseLocalHistoryResult {
+  const [value, setValue] = useState(originalValue);
+  const [dirty, setDirty] = useState(false);
+  const localHistory = useRef<string[]>([]);
+  const valueRef = useRef(originalValue);
+  const structuralChangeRef = useRef(false);
+  const preOpValueRef = useRef("");
+
+  useEffect(() => {
+    setValue(originalValue);
+    valueRef.current = originalValue;
+    setDirty(false);
+    localHistory.current = [];
+  }, [originalValue]);
+
+  const onChange = useCallback((newVal: string) => {
+    if (structuralChangeRef.current) {
+      const preOp = preOpValueRef.current;
+      const top = localHistory.current[localHistory.current.length - 1];
+      const next = [...localHistory.current];
+      if (preOp !== originalValue && preOp !== top) next.push(preOp);
+      next.push(newVal);
+      localHistory.current = next;
+      structuralChangeRef.current = false;
+    }
+    setValue(newVal);
+    valueRef.current = newVal;
+    setDirty(newVal !== originalValue);
+  }, [originalValue]);
+
+  const discard = useCallback(() => {
+    const current = valueRef.current;
+    if (localHistory.current.length === 0) {
+      setValue(originalValue);
+      valueRef.current = originalValue;
+      setDirty(false);
+      return;
+    }
+    const lastCheckpoint = localHistory.current[localHistory.current.length - 1];
+    if (current !== lastCheckpoint) {
+      setValue(lastCheckpoint);
+      valueRef.current = lastCheckpoint;
+      setDirty(lastCheckpoint !== originalValue);
+    } else {
+      localHistory.current = localHistory.current.slice(0, -1);
+      const prev = localHistory.current.length > 0
+        ? localHistory.current[localHistory.current.length - 1]
+        : originalValue;
+      setValue(prev);
+      valueRef.current = prev;
+      setDirty(prev !== originalValue);
+    }
+  }, [originalValue]);
+
+  const onBeforeStructuralChange = useCallback(() => {
+    structuralChangeRef.current = true;
+    preOpValueRef.current = valueRef.current;
+  }, []);
+
+  const reset = useCallback((newValue: string) => {
+    setValue(newValue);
+    valueRef.current = newValue;
+    setDirty(newValue !== originalValue);
+    localHistory.current = [];
+  }, [originalValue]);
+
+  return { value, dirty, onChange, discard, onBeforeStructuralChange, reset };
+}


### PR DESCRIPTION
## Summary

- **`useLocalHistory` hook**: DetailPanel のローカル undo ロジック（checkpoint 管理・structural/text change 区別）を `src/hooks/useLocalHistory.ts` に抽出。コンポーネントから refs が一掃され、フック単体でユニットテスト可能に
- **Button atom 拡張**: `variant="link"` (hover:underline パターン) と `size="xs"` を追加。`hover:underline` の素 button を 4 箇所、AppHeader の小ボタン 3 箇所を Button に統一
- **SegmentedControl 拡張**: Option に `disabled?: boolean` を追加。NewVarModal の scope 選択ボタンを SegmentedControl に置き換え
- **IconButton 統一**: App, DiffPanel, SnapshotPanel の × ボタンを IconButton に置き換え
- **DiffPanel footer**: 素の button → `Button variant="primary/ghost"` に統一

## Test plan

- [x] `vitest run` 139/139 passed
- [ ] アプリ起動して動作確認（PATH 編集 undo、Snapshot 削除、New variable scope 切り替え、DiffPanel dismiss）

🤖 Generated with [Claude Code](https://claude.com/claude-code)