### PR TITLE
feat(cli): add IaC formats to export subcommand

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -56,6 +56,10 @@ enum ExportFormat {
     #[default]
     Json,
     Reg,
+    Ps1,
+    DscV2,
+    DscV3,
+    Ansible,
 }
 
 /// Parse CLI args and execute the subcommand. Never returns — exits the process.
@@ -133,8 +137,12 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
                 ScopeArg::All => "All",
             };
             let content = match format {
-                ExportFormat::Json => export::to_json(&snapshot, scope_str),
-                ExportFormat::Reg => export::to_reg(&snapshot, scope_str),
+                ExportFormat::Json    => export::to_json(&snapshot, scope_str),
+                ExportFormat::Reg     => export::to_reg(&snapshot, scope_str),
+                ExportFormat::Ps1     => export::to_ps1(&snapshot, scope_str),
+                ExportFormat::DscV2   => export::to_dsc_v2(&snapshot, scope_str),
+                ExportFormat::DscV3   => export::to_dsc_v3(&snapshot, scope_str),
+                ExportFormat::Ansible => export::to_ansible(&snapshot, scope_str),
             };
             match output {
                 Some(path) => std::fs::write(&path, content.as_bytes())


### PR DESCRIPTION
## Summary

Extends `envarly export --format` with the 4 IaC formats added in the GUI (PR #4):

```
envarly export --format ps1      # PowerShell script
envarly export --format dsc-v2   # PowerShell DSC v2
envarly export --format dsc-v3   # DSC v3 YAML
envarly export --format ansible  # Ansible playbook
```

Calls the same `export.rs` generators used by the GUI — no logic duplication.

Closes #5

## Test plan

- [x] `cargo test` passes (52/52)
- [ ] `envarly export --format ps1` outputs a PowerShell script to stdout
- [ ] `envarly export --format ansible --output out.yml` writes a file
- [ ] `envarly export --help` shows the new format options

🤖 Generated with [Claude Code](https://claude.com/claude-code)