### PR TITLE
fix(installer-ux): PATH cleanup, CLI fixes, and MSI installer improvements

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tauri-plugin-dialog = "2.7.1"
 winreg = "0.55"
 windows-sys = { version = "0.59", features = [
   "Win32_UI_WindowsAndMessaging",
+  "Win32_UI_Shell",
   "Win32_Foundation",
   "Win32_Security_Cryptography",
   "Win32_System_Console",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,4 +36,5 @@ windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_Security_Cryptography",
   "Win32_System_Console",
+  "Win32_Storage_FileSystem",
 ] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,4 +35,5 @@ windows-sys = { version = "0.59", features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_Foundation",
   "Win32_Security_Cryptography",
+  "Win32_System_Console",
 ] }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -36,7 +36,11 @@ enum Command {
     },
     /// Internal: remove Envarly install directory from PATH. Called by the uninstaller.
     #[command(name = "path-cleanup", hide = true)]
-    PathCleanup,
+    PathCleanup {
+        /// Print what would change without modifying the registry.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Clone, ValueEnum, Default)]
@@ -132,8 +136,8 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
             }
         }
 
-        Command::PathCleanup => {
-            crate::path_manage::cleanup_path();
+        Command::PathCleanup { dry_run } => {
+            crate::path_manage::cleanup_path(dry_run);
         }
 
         Command::Export { scope, format, output } => {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -75,21 +75,25 @@ pub fn is_elevated() -> bool {
 pub fn restart_as_admin(app: tauri::AppHandle) -> Result<(), EnvarlyError> {
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         let exe = std::env::current_exe().map_err(EnvarlyError::Registry)?;
-        std::process::Command::new("powershell")
-            .args([
-                "-NoProfile",
-                "-WindowStyle",
-                "Hidden",
-                "-Command",
-                &format!("Start-Process '{}' -Verb RunAs", exe.display()),
-            ])
-            .creation_flags(CREATE_NO_WINDOW)
-            .spawn()
-            .map_err(EnvarlyError::Registry)?;
-        app.exit(0);
+        let exe_wide: Vec<u16> = exe.to_string_lossy().encode_utf16().chain(Some(0)).collect();
+        let verb: Vec<u16> = "runas\0".encode_utf16().collect();
+        // ShellExecuteW with "runas" verb triggers UAC elevation directly
+        // without needing an intermediate PowerShell process.
+        let result = unsafe {
+            windows_sys::Win32::UI::Shell::ShellExecuteW(
+                std::ptr::null_mut(),
+                verb.as_ptr(),
+                exe_wide.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
+            )
+        };
+        // ShellExecuteW returns > 32 on success
+        if result as usize > 32 {
+            app.exit(0);
+        }
     }
     #[cfg(not(target_os = "windows"))]
     let _ = app;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -209,9 +209,27 @@ pub fn validate_paths(paths: Vec<String>) -> Vec<bool> {
         .iter()
         .map(|p| {
             let cleaned = p.trim_matches(|c: char| c.is_whitespace() || c == '\0');
-            std::path::Path::new(&expand_env_vars(cleaned)).exists()
+            let expanded = expand_env_vars(cleaned);
+            dir_exists(&expanded)
         })
         .collect()
+}
+
+/// Check whether a directory path exists using GetFileAttributesW directly.
+/// This matches PowerShell's Test-Path behavior and avoids false negatives
+/// that Rust's Path::exists() (which uses GetFileAttributesExW) can produce
+/// under certain Windows filesystem filter drivers or security software.
+#[cfg(windows)]
+fn dir_exists(path: &str) -> bool {
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let attrs = unsafe { windows_sys::Win32::Storage::FileSystem::GetFileAttributesW(wide.as_ptr()) };
+    // INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF means the call failed (path not found etc.)
+    attrs != u32::MAX
+}
+
+#[cfg(not(windows))]
+fn dir_exists(path: &str) -> bool {
+    std::path::Path::new(path).exists()
 }
 
 pub(crate) fn expand_env_vars(s: &str) -> String {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -207,7 +207,10 @@ pub async fn export_custom(
 pub fn validate_paths(paths: Vec<String>) -> Vec<bool> {
     paths
         .iter()
-        .map(|p| std::path::Path::new(&expand_env_vars(p.trim())).exists())
+        .map(|p| {
+            let cleaned = p.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+            std::path::Path::new(&expand_env_vars(cleaned)).exists()
+        })
         .collect()
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,8 +1,19 @@
 // Prevents an extra console window in release GUI builds.
-// CLI subcommands work fine in debug builds or when launched from an existing terminal.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Release builds use the "windows" subsystem and have no console by default.
+    // When CLI args are present, attach to the parent terminal so stdout/stderr
+    // are visible (e.g. `envarly --help`, `envarly list`).
+    #[cfg(all(windows, not(debug_assertions)))]
+    if std::env::args().len() > 1 {
+        unsafe {
+            windows_sys::Win32::System::Console::AttachConsole(
+                windows_sys::Win32::System::Console::ATTACH_PARENT_PROCESS,
+            );
+        }
+    }
+
     // If a CLI subcommand is present (e.g. `envarly get PATH`), handle it and exit.
     // With no args, this returns and the GUI launches below.
     #[cfg(windows)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,13 +5,14 @@
 fn main() {
     #[cfg(windows)]
     if std::env::args().len() <= 1 {
-        // GUI mode: hide the console window that Windows allocated for us, then
-        // detach from it so it doesn't linger.
+        // GUI mode: detach from the console Windows allocated so its window
+        // closes without a minimize/hide animation, then restore focus to
+        // whatever was active before our console stole it.
         unsafe {
-            let hwnd = windows_sys::Win32::System::Console::GetConsoleWindow();
-            if !hwnd.is_null() {
-                windows_sys::Win32::UI::WindowsAndMessaging::ShowWindow(hwnd, 0); // SW_HIDE
-                windows_sys::Win32::System::Console::FreeConsole();
+            let prev = windows_sys::Win32::UI::WindowsAndMessaging::GetForegroundWindow();
+            windows_sys::Win32::System::Console::FreeConsole();
+            if !prev.is_null() {
+                windows_sys::Win32::UI::WindowsAndMessaging::SetForegroundWindow(prev);
             }
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,21 +1,23 @@
-// Prevents an extra console window in release GUI builds.
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// Build as a console subsystem app so the shell waits for the process when CLI
+// args are present. For GUI-only launches (no args), we hide the console window
+// immediately so users never see a flash.
 
 fn main() {
-    // Release builds use the "windows" subsystem and have no console by default.
-    // When CLI args are present, attach to the parent terminal so stdout/stderr
-    // are visible (e.g. `envarly --help`, `envarly list`).
-    #[cfg(all(windows, not(debug_assertions)))]
-    if std::env::args().len() > 1 {
+    #[cfg(windows)]
+    if std::env::args().len() <= 1 {
+        // GUI mode: hide the console window that Windows allocated for us, then
+        // detach from it so it doesn't linger.
         unsafe {
-            windows_sys::Win32::System::Console::AttachConsole(
-                windows_sys::Win32::System::Console::ATTACH_PARENT_PROCESS,
-            );
+            let hwnd = windows_sys::Win32::System::Console::GetConsoleWindow();
+            if !hwnd.is_null() {
+                windows_sys::Win32::UI::WindowsAndMessaging::ShowWindow(hwnd, 0); // SW_HIDE
+                windows_sys::Win32::System::Console::FreeConsole();
+            }
         }
     }
 
-    // If a CLI subcommand is present (e.g. `envarly get PATH`), handle it and exit.
-    // With no args, this returns and the GUI launches below.
+    // If a CLI subcommand is present (e.g. `envarly --help`, `envarly list`),
+    // handle it and exit. The console subsystem ensures the shell waits for us.
     #[cfg(windows)]
     envarly_lib::try_run_cli();
     #[cfg(windows)]

--- a/src-tauri/src/path_manage.rs
+++ b/src-tauri/src/path_manage.rs
@@ -153,26 +153,42 @@ pub fn propose_add(user: bool) -> Result<Option<String>, EnvarlyError> {
 }
 
 /// Remove the install dir from User PATH and/or System PATH (if elevated).
-/// Always returns Ok — partial failures are logged but not fatal so the
-/// uninstaller can proceed.
+/// When `dry_run` is true, prints what would change without modifying the registry.
 #[cfg(windows)]
-pub fn cleanup_path() {
+pub fn cleanup_path(dry_run: bool) {
     let dir = match install_dir() {
         Some(d) => d.to_string_lossy().into_owned(),
-        None => return,
+        None => {
+            eprintln!("path-cleanup: could not determine install directory");
+            return;
+        }
     };
+    println!("install dir: {}", dir);
 
-    for user in [true, false] {
-        let Ok(key) = open_path_key(user, true) else { continue };
+    for (user, label) in [(true, "User"), (false, "System")] {
+        let Ok(key) = open_path_key(user, !dry_run) else {
+            println!("{} PATH: (no access, skipping)", label);
+            continue;
+        };
         let current = read_path_str(&key);
-        if let Some(new_val) = compute_remove(&current, &dir) {
-            let _ = write_path_str(&key, &new_val);
+        match compute_remove(&current, &dir) {
+            None => println!("{} PATH: not present, nothing to remove", label),
+            Some(new_val) => {
+                if dry_run {
+                    println!("{} PATH: would remove '{}'", label, dir);
+                } else {
+                    match write_path_str(&key, &new_val) {
+                        Ok(()) => println!("{} PATH: removed '{}'", label, dir),
+                        Err(e) => eprintln!("{} PATH: write failed: {}", label, e),
+                    }
+                }
+            }
         }
     }
 
-    // Notify running processes that environment changed
-    #[cfg(windows)]
-    crate::env_store::broadcast_settings_change();
+    if !dry_run {
+        crate::env_store::broadcast_settings_change();
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
       "wix": {
         "bannerPath": "wix/banner.bmp",
         "dialogImagePath": "wix/dialog.bmp",
-        "fragmentPaths": ["wix/path_cleanup.wxs"]
+        "template": "wix/main.wxs"
       },
       "nsis": {
         "headerImage": "nsis/header.bmp",

--- a/src-tauri/wix/main.wxs
+++ b/src-tauri/wix/main.wxs
@@ -1,0 +1,400 @@
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?elseif $(sys.BUILDARCH)="arm64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product
+            Id="*"
+            Name="{{product_name}}"
+            UpgradeCode="{{upgrade_code}}"
+            Language="!(loc.TauriLanguage)"
+            Manufacturer="{{manufacturer}}"
+            Version="{{version}}">
+
+        <Package Id="*"
+                 Keywords="Installer"
+                 InstallerVersion="450"
+                 Languages="0"
+                 Compressed="yes"
+                 InstallScope="perMachine"
+                 SummaryCodepage="!(loc.TauriCodepage)"/>
+
+        <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
+        <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
+        <Property Id="REINSTALLMODE" Value="amus" />
+
+        <!-- Auto launch app after installation, useful for passive mode which usually used in updates -->
+        <Property Id="AUTOLAUNCHAPP" Secure="yes" />
+        <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
+        <Property Id="LAUNCHAPPARGS" Secure="yes" />
+
+        {{#if allow_downgrades}}
+            <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        {{else}}
+            <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" AllowSameVersionUpgrades="yes" />
+        {{/if}}
+
+        <!--
+          Two-step PATH cleanup on uninstall:
+            SetPathCleanupExe (immediate) captures [INSTALLDIR]envarly.exe into a
+            property while the file table is still resolvable.
+            PathCleanup (deferred Type-50) runs it before RemoveFiles deletes the exe.
+        -->
+        <CustomAction Id="SetPathCleanupExe"
+                      Property="PathCleanup"
+                      Value="[INSTALLDIR]envarly.exe"
+                      Execute="immediate" />
+        <CustomAction Id="PathCleanup"
+                      Property="PathCleanup"
+                      ExeCommand="path-cleanup"
+                      Execute="deferred"
+                      Impersonate="yes"
+                      Return="ignore" />
+
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+            <Custom Action="SetPathCleanupExe" Before="PathCleanup">Installed AND REMOVE="ALL"</Custom>
+            <Custom Action="PathCleanup" Before="RemoveFiles">Installed AND REMOVE="ALL"</Custom>
+        </InstallExecuteSequence>
+
+        <Media Id="1" Cabinet="app.cab" EmbedCab="yes" />
+
+        {{#if banner_path}}
+        <WixVariable Id="WixUIBannerBmp" Value="{{banner_path}}" />
+        {{/if}}
+        {{#if dialog_image_path}}
+        <WixVariable Id="WixUIDialogBmp" Value="{{dialog_image_path}}" />
+        {{/if}}
+        {{#if license}}
+        <WixVariable Id="WixUILicenseRtf" Value="{{license}}" />
+        {{/if}}
+
+        <Icon Id="ProductIcon" SourceFile="{{icon_path}}"/>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
+        <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
+        <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
+
+        {{#if homepage}}
+        <Property Id="ARPURLINFOABOUT" Value="{{homepage}}"/>
+        <Property Id="ARPHELPLINK" Value="{{homepage}}"/>
+        <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
+        {{/if}}
+
+        <!-- NOTE: The order of RegistrySearch elements below matters. In WIX, when multiple
+             RegistrySearch elements are listed under a single Property, the LAST successful
+             match wins. We list the NSIS default-key search first and the MSI InstallDir
+             search second so that the MSI-specific path takes priority when both keys exist. -->
+        <Property Id="INSTALLDIR">
+          <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
+
+          <!-- Second attempt: Search for "InstallDir" which takes priority if found (this is how the msi installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
+        </Property>
+
+        <!-- launch app checkbox -->
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
+        <CustomAction Id="LaunchApplication" Impersonate="yes" FileKey="Path" ExeCommand="[LAUNCHAPPARGS]" Return="asyncNoWait" />
+
+        <UI>
+            <!-- launch app checkbox -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+
+            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+            {{#unless license}}
+            <!-- Skip license dialog -->
+            <Publish Dialog="WelcomeDlg"
+                     Control="Next"
+                     Event="NewDialog"
+                     Value="InstallDirDlg"
+                     Order="2">1</Publish>
+            <Publish Dialog="InstallDirDlg"
+                     Control="Back"
+                     Event="NewDialog"
+                     Value="WelcomeDlg"
+                     Order="2">1</Publish>
+            {{/unless}}
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="ApplicationShortcutDesktop" Guid="*">
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <RemoveFolder Id="DesktopFolder" On="uninstall" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
+                </Component>
+            </Directory>
+            <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
+                <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{product_name}}"/>
+            </Directory>
+        </Directory>
+
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+                <!-- Change the Root to HKCU for perUser installations -->
+                {{#each deep_link_protocols as |protocol| ~}}
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
+                    <RegistryValue Type="string" Name="URL Protocol" Value=""/>
+                    <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
+                    <RegistryKey Key="DefaultIcon">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
+                    </RegistryKey>
+                    <RegistryKey Key="shell\open\command">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
+                    </RegistryKey>
+                </RegistryKey>
+                {{/each~}}
+            </Component>
+            <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>
+                {{#each file_associations as |association| ~}}
+                {{#each association.ext as |ext| ~}}
+                <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
+                    <Extension Id="{{ext}}" Advertise="yes">
+                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                    </Extension>
+                </ProgId>
+                {{/each~}}
+                {{/each~}}
+            </Component>
+            {{#each binaries as |bin| ~}}
+            <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{#if enable_elevated_update_task}}
+            <Component Id="UpdateTask" Guid="C492327D-9720-4CD5-8DB8-F09082AF44BE" Win64="$(var.Win64)">
+                <File Id="UpdateTask" Source="update.xml" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskInstaller" Guid="011F25ED-9BE3-50A7-9E9B-3519ED2B9932" Win64="$(var.Win64)">
+                <File Id="UpdateTaskInstaller" Source="install-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskUninstaller" Guid="D4F6CC3F-32DC-5FD0-95E8-782FFD7BBCE1" Win64="$(var.Win64)">
+                <File Id="UpdateTaskUninstaller" Source="uninstall-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            {{/if}}
+            {{resources}}
+            <Component Id="CMP_UninstallShortcut" Guid="*">
+
+                <Shortcut Id="UninstallShortcut"
+						  Name="Uninstall {{product_name}}"
+						  Description="Uninstalls {{product_name}}"
+						  Target="[System64Folder]msiexec.exe"
+						  Arguments="/x [ProductCode]" />
+
+				<RemoveFolder Id="INSTALLDIR"
+							  On="uninstall" />
+
+				<RegistryValue Root="HKCU"
+							   Key="Software\\{{manufacturer}}\\{{product_name}}"
+							   Name="Uninstaller Shortcut"
+							   Type="integer"
+							   Value="1"
+							   KeyPath="yes" />
+            </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="*">
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="{{product_name}}"
+                    Description="Runs {{product_name}}"
+                    Target="[!Path]"
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}"/>
+                </Shortcut>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
+        </DirectoryRef>
+
+        {{#each merge_modules as |msm| ~}}
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="{{ msm.name }}" SourceFile="{{ msm.path }}" DiskId="1" Language="!(loc.TauriLanguage)" />
+        </DirectoryRef>
+
+        <Feature Id="{{ msm.name }}" Title="{{ msm.name }}" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="{{ msm.name }}"/>
+        </Feature>
+        {{/each~}}
+
+        <Feature
+                Id="MainProgram"
+                Title="Application"
+                Description="!(loc.InstallAppFeature)"
+                Level="1"
+                ConfigurableDirectory="INSTALLDIR"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
+
+            {{#each resource_file_ids as |resource_file_id| ~}}
+                <ComponentRef Id="{{ resource_file_id }}"/>
+            {{/each~}}
+
+            {{#if enable_elevated_update_task}}
+                <ComponentRef Id="UpdateTask" />
+                <ComponentRef Id="UpdateTaskInstaller" />
+                <ComponentRef Id="UpdateTaskUninstaller" />
+            {{/if}}
+
+            <Feature Id="ShortcutsFeature"
+                Title="Shortcuts"
+                Level="1">
+                <ComponentRef Id="Path"/>
+                <ComponentRef Id="CMP_UninstallShortcut" />
+                <ComponentRef Id="ApplicationShortcut" />
+                <ComponentRef Id="ApplicationShortcutDesktop" />
+            </Feature>
+
+            <Feature
+                Id="Environment"
+                Title="PATH Environment Variable"
+                Description="!(loc.PathEnvVarFeature)"
+                Level="1"
+                Absent="allow">
+            <ComponentRef Id="Path"/>
+            {{#each binaries as |bin| ~}}
+            <ComponentRef Id="{{ bin.id }}"/>
+            {{/each~}}
+            </Feature>
+        </Feature>
+
+        <Feature Id="External" AllowAdvertise="no" Absent="disallow">
+            {{#each component_group_refs as |id| ~}}
+            <ComponentGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each component_refs as |id| ~}}
+            <ComponentRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_group_refs as |id| ~}}
+            <FeatureGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_refs as |id| ~}}
+            <FeatureRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each merge_refs as |id| ~}}
+            <MergeRef Id="{{ id }}"/>
+            {{/each~}}
+        </Feature>
+
+        {{#if install_webview}}
+        <!-- WebView2 -->
+        <Property Id="INSTALLED_WEBVIEW2_VERSION">
+            <RegistrySearch Id="Webview2VersionSystemx64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionSystemx86" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw"/>
+        </Property>
+
+        {{#if download_bootstrapper}}
+        <!-- Download webview bootstrapper mode -->
+        <CustomAction Id='DownloadAndInvokeBootstrapper' Directory="INSTALLDIR" Execute="deferred" ExeCommand='powershell.exe -NoProfile -windowstyle hidden try [\{] [\[]Net.ServicePointManager[\]]::SecurityProtocol = [\[]Net.SecurityProtocolType[\]]::Tls12 [\}] catch [\{][\}]; Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" ; Start-Process -FilePath "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" -ArgumentList ({{webview_installer_args}} &apos;/install&apos;) -Wait' Return='check'/>
+        <InstallExecuteSequence>
+            <Custom Action='DownloadAndInvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_bootstrapper_path}}
+        <!-- Embedded webview bootstrapper mode -->
+        <Binary Id="MicrosoftEdgeWebview2Setup.exe" SourceFile="{{webview2_bootstrapper_path}}"/>
+        <CustomAction Id='InvokeBootstrapper' BinaryKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_installer_path}}
+        <!-- Embedded offline installer -->
+        <Binary Id="MicrosoftEdgeWebView2RuntimeInstaller.exe" SourceFile="{{webview2_installer_path}}"/>
+        <CustomAction Id='InvokeStandalone' BinaryKey='MicrosoftEdgeWebView2RuntimeInstaller.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeStandalone' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if minimum_webview2_version}}
+        <!-- Update WebView2 if minimum version requirement not met -->
+        <Property Id="MINIMUM_WEBVIEW2_VERSION" Value="{{minimum_webview2_version}}" />
+        <Property Id="EDGEUPDATE_PATH">
+            <RegistrySearch Id="EdgeUpdateLocalMachine64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" Name="path" Type="raw" />
+            <RegistrySearch Id="EdgeUpdateLocalMachine32" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+            <RegistrySearch Id="EdgeUpdateCurrentUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+        </Property>
+        <!-- Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md -->
+        <!-- Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath" -->
+        <CustomAction Id="UpdateWebView2ViaEdgeUpdate" Execute="deferred" Property="EDGEUPDATE_PATH" Return="check" Impersonate="no" ExeCommand="/install appguid={F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}&amp;needsadmin=true" />
+        <InstallExecuteSequence>
+            <Custom Action='UpdateWebView2ViaEdgeUpdate' Before='InstallFinalize'>
+                <![CDATA[
+                  NOT REMOVE
+                  AND INSTALLED_WEBVIEW2_VERSION
+                  AND (INSTALLED_WEBVIEW2_VERSION < MINIMUM_WEBVIEW2_VERSION)
+                ]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{/if}}
+
+        {{#if enable_elevated_update_task}}
+        <!-- Install an elevated update task within Windows Task Scheduler -->
+        <CustomAction
+            Id="CreateUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            Execute="commit"
+            Impersonate="yes"
+            ExeCommand="powershell.exe -WindowStyle hidden .\install-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action='CreateUpdateTask' Before='InstallFinalize'>
+                NOT(REMOVE)
+            </Custom>
+        </InstallExecuteSequence>
+        <!-- Remove elevated update task during uninstall -->
+        <CustomAction
+            Id="DeleteUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            ExeCommand="powershell.exe -WindowStyle hidden .\uninstall-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action="DeleteUpdateTask" Before='InstallFinalize'>
+                (REMOVE = "ALL") AND NOT UPGRADINGPRODUCTCODE
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <InstallExecuteSequence>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
+        </InstallExecuteSequence>
+
+        <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
+    </Product>
+</Wix>

--- a/src-tauri/wix/path_cleanup.wxs
+++ b/src-tauri/wix/path_cleanup.wxs
@@ -2,16 +2,31 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
     <!--
-      Remove Envarly install dir from PATH before files are deleted.
+      A component must be referenced from a Feature for this fragment to be
+      considered "reachable" by the WiX linker. Without it, the linker silently
+      strips the entire fragment — including the CustomAction table entries —
+      even though the build succeeds without errors.
 
-      Two-step pattern required for deferred CAs:
-        1. SetPathCleanupExe  (immediate) — captures [INSTALLDIR]envarly.exe into
-           a property while the file table is still resolvable.
-        2. PathCleanup        (deferred)  — runs the captured path with "path-cleanup"
-           before RemoveFiles deletes the exe.
+      This component serves as the anchor. The Environment feature already exists
+      in the generated main.wxs (Level=1, Absent=allow), so referencing it here
+      is enough to make this whole fragment live.
+    -->
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="EnvarlyPathAnchor" Guid="{DE0349D9-7C95-464D-9A66-977A3D3E03B3}">
+        <RegistryValue Root="HKCU" Key="Software\envarly\Envarly"
+                       Name="PathManaged" Value="1" Type="integer" KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+    <FeatureRef Id="MainProgram">
+      <ComponentRef Id="EnvarlyPathAnchor" />
+    </FeatureRef>
 
-      Return="ignore" lets the uninstaller continue even if cleanup fails
-      (worst case: a harmless dead PATH entry remains).
+    <!--
+      Two-step pattern for reliable uninstall PATH cleanup:
+        1. SetPathCleanupExe (immediate) — resolves [INSTALLDIR]envarly.exe into
+           a property while the file table is still valid.
+        2. PathCleanup (deferred Type-50) — runs the captured exe with
+           "path-cleanup" before RemoveFiles deletes it.
     -->
     <CustomAction Id="SetPathCleanupExe"
                   Property="PathCleanup"

--- a/src-tauri/wix/path_cleanup.wxs
+++ b/src-tauri/wix/path_cleanup.wxs
@@ -10,8 +10,7 @@
     <CustomAction Id="PathCleanup"
                   FileKey="Path"
                   ExeCommand="path-cleanup"
-                  Execute="deferred"
-                  Impersonate="yes"
+                  Execute="immediate"
                   Return="ignore" />
     <InstallExecuteSequence>
       <Custom Action="PathCleanup" Before="RemoveFiles">REMOVE~="ALL"</Custom>

--- a/src-tauri/wix/path_cleanup.wxs
+++ b/src-tauri/wix/path_cleanup.wxs
@@ -3,17 +3,31 @@
   <Fragment>
     <!--
       Remove Envarly install dir from PATH before files are deleted.
-      Return="ignore" means the uninstaller proceeds even if cleanup fails
+
+      Two-step pattern required for deferred CAs:
+        1. SetPathCleanupExe  (immediate) — captures [INSTALLDIR]envarly.exe into
+           a property while the file table is still resolvable.
+        2. PathCleanup        (deferred)  — runs the captured path with "path-cleanup"
+           before RemoveFiles deletes the exe.
+
+      Return="ignore" lets the uninstaller continue even if cleanup fails
       (worst case: a harmless dead PATH entry remains).
-      FileKey="Path" matches the Id of envarly.exe in the generated main.wxs.
     -->
+    <CustomAction Id="SetPathCleanupExe"
+                  Property="PathCleanup"
+                  Value="[INSTALLDIR]envarly.exe"
+                  Execute="immediate" />
+
     <CustomAction Id="PathCleanup"
-                  FileKey="Path"
+                  Property="PathCleanup"
                   ExeCommand="path-cleanup"
-                  Execute="immediate"
+                  Execute="deferred"
+                  Impersonate="yes"
                   Return="ignore" />
+
     <InstallExecuteSequence>
-      <Custom Action="PathCleanup" Before="RemoveFiles">REMOVE~="ALL"</Custom>
+      <Custom Action="SetPathCleanupExe" Before="PathCleanup">Installed AND REMOVE="ALL"</Custom>
+      <Custom Action="PathCleanup" Before="RemoveFiles">Installed AND REMOVE="ALL"</Custom>
     </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,8 @@ export default function App() {
   const [elevated, setElevated] = useState(false);
   const [dialog, setDialog] = useState<Dialog>(null);
   const [snapshotsOpen, setSnapshotsOpen] = useState(false);
-  const [pathInEnv, setPathInEnv] = useState(true);
+  const [userPathInEnv, setUserPathInEnv] = useState(true);
+  const [systemPathInEnv, setSystemPathInEnv] = useState(true);
   const [pathBannerDismissed, setPathBannerDismissed] = useState(
     () => localStorage.getItem("envarly.pathBannerDismissed") === "1",
   );
@@ -76,7 +77,8 @@ export default function App() {
       try { isAdmin = await api.isElevated(); setElevated(isAdmin); } catch { }
       try {
         const ps = await api.getPathStatus();
-        setPathInEnv(isAdmin ? ps.systemHasEntry : ps.userHasEntry);
+        setUserPathInEnv(ps.userHasEntry);
+        setSystemPathInEnv(ps.systemHasEntry);
       } catch { }
       refresh();
     })();
@@ -175,7 +177,8 @@ export default function App() {
       const proposed = await api.getPathProposal(scope);
       if (proposed === null) return; // already in PATH
       stageSet("Path", scope, proposed);
-      setPathInEnv(true); // optimistic: suppress banner after staging
+      if (scope === "User") setUserPathInEnv(true);
+      else setSystemPathInEnv(true);
     } catch (err) {
       console.error("Failed to get PATH proposal", err);
     }
@@ -194,7 +197,8 @@ export default function App() {
           stagedCount={staged.size}
           diffCount={diffEntries.length}
           elevated={elevated}
-          pathInEnv={pathInEnv}
+          userPathInEnv={userPathInEnv}
+          systemPathInEnv={systemPathInEnv}
           snapshotsOpen={snapshotsOpen}
           theme={theme}
           onRefresh={handleRefresh}
@@ -205,12 +209,14 @@ export default function App() {
           onToggleSnapshots={() => setSnapshotsOpen((o) => !o)}
           onToggleTheme={toggleTheme}
           onLicenses={() => setDialog("licenses")}
-          onStageAddToPath={() => handleStageAddToPath(elevated ? "System" : "User")}
+          onStageAddToPath={handleStageAddToPath}
         />
 
-        {!pathInEnv && !pathBannerDismissed && (
+        {(!userPathInEnv || (elevated && !systemPathInEnv)) && !pathBannerDismissed && (
           <PathBanner
             elevated={elevated}
+            userPathInEnv={userPathInEnv}
+            systemPathInEnv={systemPathInEnv}
             onStageAddToPath={handleStageAddToPath}
             onDismiss={handleDismissPathBanner}
           />
@@ -237,12 +243,13 @@ export default function App() {
               variable={effectiveSelected}
               allVars={effectiveVars}
               elevated={elevated}
-              pathInEnv={pathInEnv}
+              userPathInEnv={userPathInEnv}
+              systemPathInEnv={systemPathInEnv}
               staged={staged}
               onStage={handleStage}
               onStageDelete={handleStageDelete}
               onUnstage={handleUnstage}
-              onStageAddToPath={() => handleStageAddToPath(elevated ? "System" : "User")}
+              onStageAddToPath={handleStageAddToPath}
               onRegisterLocalUndo={handleRegisterLocalUndo}
             />
           </div>

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -7,7 +7,8 @@ interface AppHeaderProps {
   stagedCount: number;
   diffCount: number;
   elevated: boolean;
-  pathInEnv: boolean;
+  userPathInEnv: boolean;
+  systemPathInEnv: boolean;
   snapshotsOpen: boolean;
   theme: "dark" | "light";
   onRefresh: () => void;
@@ -18,11 +19,11 @@ interface AppHeaderProps {
   onToggleSnapshots: () => void;
   onToggleTheme: () => void;
   onLicenses: () => void;
-  onStageAddToPath: () => void;
+  onStageAddToPath: (scope: "User" | "System") => void;
 }
 
 export function AppHeader({
-  loading, stagedCount, diffCount, elevated, pathInEnv, snapshotsOpen, theme,
+  loading, stagedCount, diffCount, elevated, userPathInEnv, systemPathInEnv, snapshotsOpen, theme,
   onRefresh, onApplyStaged, onDiscard, onShowChanges, onImportExport,
   onToggleSnapshots, onToggleTheme, onLicenses, onStageAddToPath,
 }: AppHeaderProps) {
@@ -91,14 +92,24 @@ export function AppHeader({
         {elevated && (
           <span className="text-xs text-success opacity-60">🛡 Administrator</span>
         )}
-        {!pathInEnv && (
+        {!userPathInEnv && (
           <Button
             variant="ghost"
             size="xs"
-            onClick={onStageAddToPath}
-            title="Stage adding Envarly to PATH so it can be run from a terminal"
+            onClick={() => onStageAddToPath("User")}
+            title="Stage adding Envarly to User PATH so it can be run from a terminal"
           >
-            + PATH
+            + User PATH
+          </Button>
+        )}
+        {elevated && !systemPathInEnv && (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => onStageAddToPath("System")}
+            title="Stage adding Envarly to System PATH"
+          >
+            + System PATH
           </Button>
         )}
         <Button variant="ghost" size="xs" onClick={() => openUrl("https://github.com/iray-tno/envarly")} title="View on GitHub">

--- a/src/components/DetailPanel/DetailPanel.test.tsx
+++ b/src/components/DetailPanel/DetailPanel.test.tsx
@@ -45,6 +45,8 @@ describe("DetailPanel", () => {
       <DetailPanel
         variable={variable}
         elevated={elevated}
+        userPathInEnv={true}
+        systemPathInEnv={true}
         staged={staged}
         onStage={onStage}
         onStageDelete={onStageDelete}
@@ -107,7 +109,7 @@ describe("DetailPanel", () => {
   it("hides edit controls for System variable when not elevated", () => {
     const sysVar: EnvVar = { ...simpleVar, scope: "System" };
     render_(sysVar, false);
-    expect(screen.getByText(/requires admin/i)).toBeInTheDocument();
+    expect(screen.getByText(/restart as admin/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
   });
 

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "../../api";
 import { useLocalHistory } from "../../hooks/useLocalHistory";
 import type { StagedChange } from "../../hooks/useStaged";
 import { stagedKey } from "../../hooks/useStaged";
@@ -13,17 +14,18 @@ interface Props {
   variable: EnvVar | null;
   allVars: EnvVar[];
   elevated: boolean;
-  pathInEnv: boolean;
+  userPathInEnv: boolean;
+  systemPathInEnv: boolean;
   staged: Map<string, StagedChange>;
   onStage: (name: string, scope: VarScope, value: string) => void;
   onStageDelete: (name: string, scope: VarScope) => void;
   onUnstage: (name: string, scope: VarScope) => void;
-  onStageAddToPath: () => void;
+  onStageAddToPath: (scope: "User" | "System") => void;
   /** Called with a discard fn when dirty, null when clean. Lets App wire Ctrl+Z. */
   onRegisterLocalUndo?: (fn: (() => void) | null) => void;
 }
 
-export function DetailPanel({ variable, allVars, elevated, pathInEnv, staged, onStage, onStageDelete, onUnstage, onStageAddToPath, onRegisterLocalUndo }: Props) {
+export function DetailPanel({ variable, allVars, elevated, userPathInEnv, systemPathInEnv, staged, onStage, onStageDelete, onUnstage, onStageAddToPath, onRegisterLocalUndo }: Props) {
   const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | null>(null);
   const prevVarRef = useRef<{ name: string; scope: string } | null>(null);
 
@@ -102,7 +104,9 @@ export function DetailPanel({ variable, allVars, elevated, pathInEnv, staged, on
   const effectiveSeparator = overrideSeparator ?? variable.listSeparator;
   const readOnly = variable.scope === "System" && !elevated;
   const isPathVar = variable.name.toUpperCase() === "PATH";
-  const showAddToPathHint = isPathVar && !pathInEnv && !isStagedDelete;
+  const pathInEnvForScope = variable.scope === "System" ? systemPathInEnv : userPathInEnv;
+  const showAddToPathHint = isPathVar && !pathInEnvForScope && !isStagedDelete
+    && (variable.scope === "User" || elevated);
 
   const editorLabel =
     effectiveSeparator === ";" ? "Path entries (drag to reorder)" :
@@ -123,7 +127,17 @@ export function DetailPanel({ variable, allVars, elevated, pathInEnv, staged, on
             {variable.scope}
           </Badge>
           {readOnly && (
-            <Badge variant="readonly">read-only · requires admin</Badge>
+            <>
+              <Badge variant="readonly">read-only</Badge>
+              <button
+                type="button"
+                onClick={() => api.restartAsAdmin()}
+                className="text-[10px] text-accent/70 hover:text-accent px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors shrink-0"
+                title="Restart as administrator to edit system variables"
+              >
+                🛡 Restart as admin →
+              </button>
+            </>
           )}
           {isStagedSet && !dirty && (
             <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent shrink-0">
@@ -172,7 +186,7 @@ export function DetailPanel({ variable, allVars, elevated, pathInEnv, staged, on
               {showAddToPathHint && (
                 <button
                   type="button"
-                  onClick={onStageAddToPath}
+                  onClick={() => onStageAddToPath(variable.scope as "User" | "System")}
                   className="text-[10px] text-accent/70 hover:text-accent px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors"
                   title="Stage adding Envarly install directory to this PATH variable"
                 >

--- a/src/components/PathBanner/PathBanner.tsx
+++ b/src/components/PathBanner/PathBanner.tsx
@@ -2,25 +2,39 @@ import { Button } from "../ui/Button";
 
 interface PathBannerProps {
   elevated: boolean;
+  userPathInEnv: boolean;
+  systemPathInEnv: boolean;
   onStageAddToPath: (scope: "User" | "System") => void;
   onDismiss: () => void;
 }
 
-export function PathBanner({ elevated, onStageAddToPath, onDismiss }: PathBannerProps) {
-  const scope: "User" | "System" = elevated ? "System" : "User";
+export function PathBanner({ elevated, userPathInEnv, systemPathInEnv, onStageAddToPath, onDismiss }: PathBannerProps) {
+  const missingUser = !userPathInEnv;
+  const missingSystem = elevated && !systemPathInEnv;
+
+  const label =
+    missingUser && missingSystem ? "User and System PATH" :
+    missingUser ? "User PATH" :
+    "System PATH";
 
   return (
     <div className="flex items-center gap-3 px-5 py-2 bg-accent/10 border-b border-accent/30 text-sm shrink-0">
       <span className="text-fg/80 flex-1">
-        Envarly is not in your {scope} PATH — you can run it from the terminal by adding it.
+        Envarly is not in your {label} — add it to run{" "}
+        <span className="font-mono text-fg">envarly</span> from a terminal.
       </span>
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={() => onStageAddToPath(scope)}
-      >
-        Stage add to {scope} PATH
-      </Button>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {missingUser && (
+          <Button variant="secondary" size="sm" onClick={() => onStageAddToPath("User")}>
+            + User PATH
+          </Button>
+        )}
+        {missingSystem && (
+          <Button variant="secondary" size="sm" onClick={() => onStageAddToPath("System")}>
+            + System PATH
+          </Button>
+        )}
+      </div>
       <Button variant="ghost" size="sm" onClick={onDismiss}>
         Dismiss
       </Button>


### PR DESCRIPTION
## Summary

- **MSI installer UI**: Light banner image with Envarly branding; Envarly name shown on welcome dialog
- **PATH shortcut in DetailPanel**: Quick-access button to jump to PATH variable from the detail view
- **PATH validation fix**: Switch from \`Path::exists()\` to \`GetFileAttributesW\` to avoid false negatives under Windows security/filter drivers; trim null chars from entries
- **Whitespace lint**: Warn when PATH entries have leading/trailing spaces
- **CLI (\`--help\` / subcommands)**: Switch to console subsystem so the shell waits for the process; \`FreeConsole\` called on GUI launch to suppress console flash; restore foreground focus with \`SetForegroundWindow\`
- **\`path-cleanup\` subcommand**: Add \`--dry-run\` flag and verbose output; write log to \`%TEMP%\envarly-cleanup.log\` for diagnosing uninstall issues
- **Uninstall PATH cleanup (MSI)**: Work around Tauri bug #5970 (CustomActions in \`fragmentPaths\` are always stripped by the WiX linker) by switching to a custom \`wix/main.wxs\` template. CAs defined directly in the Product context are guaranteed reachable. Two-step pattern: immediate CA captures \`[INSTALLDIR]envarly.exe\` into a property; deferred Type-50 CA runs it before \`RemoveFiles\`.
- **Admin restart**: Replace PowerShell \`Start-Process -Verb RunAs\` with direct \`ShellExecuteW("runas")\` call — the PowerShell approach fails silently after \`FreeConsole()\` detaches the parent console
- **PATH UI**: Separate \`+ User PATH\` and \`+ System PATH\` buttons in the header (System PATH button only shown when elevated); PathBanner shows buttons for each missing scope independently
- **System variable UX**: When viewing a System variable without admin rights, a clickable "🛡 Restart as admin →" link replaces the static read-only badge

## Test plan

- [ ] Install MSI → verify banner and dialog images show correctly
- [ ] Launch Envarly from Start Menu → no console window flash or focus steal
- [ ] Run \`envarly --help\` from terminal → help displayed, shell returns (waits)
- [ ] Open PATH variable → verify all existing directories show OK, non-existent show NG
- [ ] Add PATH entry with leading/trailing space → whitespace warning banner appears
- [ ] Click "🛡 Run as admin" button → UAC prompt appears, elevated instance opens
- [ ] In elevated mode: "🛡 Administrator" indicator shown; both \`+ User PATH\` and \`+ System PATH\` buttons available
- [ ] In non-elevated mode: clicking a System variable shows "🛡 Restart as admin →" link
- [ ] Uninstall via MSI → \`%TEMP%\envarly-cleanup.log\` created; PATH entry removed
- [ ] Reinstall → PATH banner correctly shows entry is not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv