### PR TITLE
chore(deps): override uuid to >=11.1.1 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7161,10 +7161,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -7172,7 +7171,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1"
   },
+  "overrides": {
+    "uuid": ">=11.1.1"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@storybook/addon-a11y": "^8.6.18",


### PR DESCRIPTION
## Summary

- `uuid <11.1.1` has a missing buffer bounds check in v3/v5/v6 when the optional `buf` parameter is provided (GHSA-w5hq-g745-h8pq, moderate)
- Storybook's `@storybook/addon-actions` pulls in an older `uuid` as a transitive dependency
- Added `overrides.uuid` in `package.json` to force all transitive dependents to `>=11.1.1`
- `npm audit` now reports 0 vulnerabilities; all 150 tests pass

> Note: Only affects the dev toolchain (Storybook). The production Tauri bundle does not include `uuid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)