### PR TITLE
fix(security): validate scope parameter in export_custom and get_path_proposal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -171,7 +171,7 @@ pub async fn export_custom(
         match v.scope.as_str() {
             "User"   => { snapshot.user.insert(v.name.clone(), v.value.clone()); }
             "System" => { snapshot.system.insert(v.name.clone(), v.value.clone()); }
-            _ => {}
+            other => return Err(EnvarlyError::InvalidInput(format!("invalid scope: {other:?}"))),
         }
     }
 
@@ -288,7 +288,11 @@ pub fn get_path_status() -> path_manage::PathStatus {
 /// scope: "User" | "System"
 #[tauri::command]
 pub fn get_path_proposal(scope: String) -> Result<Option<String>, EnvarlyError> {
-    let user = scope != "System";
+    let user = match scope.as_str() {
+        "User"   => true,
+        "System" => false,
+        other    => return Err(EnvarlyError::InvalidInput(format!("invalid scope: {other:?}"))),
+    };
     path_manage::propose_add(user)
 }
 


### PR DESCRIPTION
## Summary

- `export_custom`: unknown scope values were silently dropped (`_ => {}`) — now returns `InvalidInput`
- `get_path_proposal`: non-"System" scope defaulted to User without validation — now explicitly matches "User" | "System" and returns `InvalidInput` for anything else

Closes the low-severity finding from the security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)