### PR TITLE
fix(security): remove restore_snapshot; warn on SYSTEMROOT/WINDIR/COMSPEC changes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -47,23 +47,6 @@ pub fn delete_snapshot(id: String) -> Result<(), EnvarlyError> {
     snapshot::delete_snapshot(&id)
 }
 
-#[tauri::command]
-pub fn restore_snapshot(id: String) -> Result<(), EnvarlyError> {
-    let snaps = snapshot::list_snapshots()?;
-    let target = snaps
-        .into_iter()
-        .find(|s| s.id == id)
-        .ok_or_else(|| EnvarlyError::Snapshot(format!("Snapshot '{id}' not found")))?;
-
-    for (name, value) in &target.snapshot.user {
-        env_store::write_var(name, value, &VarScope::User)?;
-    }
-    for (name, value) in &target.snapshot.system {
-        env_store::write_var(name, value, &VarScope::System)?;
-    }
-    Ok(())
-}
-
 /// Returns true when the process has write access to HKLM (admin / elevated).
 #[tauri::command]
 pub fn is_elevated() -> bool {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,7 +34,6 @@ pub fn run() {
             commands::create_snapshot,
             commands::list_snapshots,
             commands::delete_snapshot,
-            commands::restore_snapshot,
             commands::validate_paths,
             commands::export_vars,
             commands::export_custom,

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,9 +20,6 @@ export const api = {
   deleteSnapshot: (id: string) =>
     invoke<void>('delete_snapshot', { id }),
 
-  restoreSnapshot: (id: string) =>
-    invoke<void>('restore_snapshot', { id }),
-
   validatePaths: (paths: string[]) =>
     invoke<boolean[]>('validate_paths', { paths }),
 

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -3,6 +3,8 @@ import { cn } from "../../lib/cn";
 import type { DiffEntry } from "../../lib/diff";
 import { Button } from "../ui/Button";
 
+const CRITICAL_VARS = new Set(["SYSTEMROOT", "WINDIR", "COMSPEC"]);
+
 interface StagedModalProps {
   diff: DiffEntry[];
   busy: boolean;
@@ -13,6 +15,8 @@ interface StagedModalProps {
 export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) {
   const [takeSnapshot, setTakeSnapshot] = useState(true);
 
+  const criticalChanges = diff.filter((e) => CRITICAL_VARS.has(e.name.toUpperCase()));
+
   const byKind = {
     added:   diff.filter((e) => e.kind === "added"),
     removed: diff.filter((e) => e.kind === "removed"),
@@ -21,6 +25,18 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
+      {criticalChanges.length > 0 && (
+        <div className="px-6 py-3 bg-danger/10 border-b border-danger/30 shrink-0">
+          <p className="text-xs font-semibold text-danger mb-1">
+            ⚠ Critical system variable{criticalChanges.length > 1 ? "s" : ""} will be modified
+          </p>
+          <p className="text-xs text-danger/80">
+            {criticalChanges.map((e) => e.name).join(", ")} — changing {criticalChanges.length > 1 ? "these" : "this"} can break Windows or running applications.
+            A snapshot is strongly recommended.
+          </p>
+        </div>
+      )}
+
       <div className="px-6 py-4 border-b border-rim shrink-0">
         <p className="text-xs text-muted mb-3">
           These changes will be written to the Windows registry and broadcast to running applications.


### PR DESCRIPTION
## Summary

- **Remove `restore_snapshot` command**: Unused dead code that bypassed the staging system (UI has always used `stageSnapshot` instead). Removing it eliminates the risk of a direct full-registry overwrite without user review.
- **Critical variable warning in StagedModal**: If `SYSTEMROOT`, `WINDIR`, or `COMSPEC` appear in staged changes, a red warning banner is shown before the user confirms — since modifying these can break Windows or running applications.

## Test plan

- [x] Restore snapshot from Snapshot panel → still works (goes through staging as before)
- [x] Stage a change to a normal variable → no warning shown
- [x] Stage a change to COMSPEC/SYSTEMROOT/WINDIR → red warning banner appears in the Apply confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)