### PR TITLE
fix(ui): restore original PATH button UX; fix add/unstage state desync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { Modal } from "./components/ui/Modal";
 import { ThemeContext } from "./context/ThemeContext";
 import { useUndo } from "./contexts/UndoContext";
 import { useEnvVars } from "./hooks/useEnvVars";
-import { useStaged, type StagedChange } from "./hooks/useStaged";
+import { useStaged, stagedKey, type StagedChange } from "./hooks/useStaged";
 import { useStagingHandlers } from "./hooks/useStagingHandlers";
 import { useTheme } from "./hooks/useTheme";
 import { applyAccepted, computeDiff, snapshotsEqual } from "./lib/diff";
@@ -41,14 +41,20 @@ export default function App() {
   const [elevated, setElevated] = useState(false);
   const [dialog, setDialog] = useState<Dialog>(null);
   const [snapshotsOpen, setSnapshotsOpen] = useState(false);
-  const [userPathInEnv, setUserPathInEnv] = useState(true);
-  const [systemPathInEnv, setSystemPathInEnv] = useState(true);
+  const [actualUserPathInEnv, setActualUserPathInEnv] = useState(true);
+  const [actualSystemPathInEnv, setActualSystemPathInEnv] = useState(true);
   const [pathBannerDismissed, setPathBannerDismissed] = useState(
     () => localStorage.getItem("envarly.pathBannerDismissed") === "1",
   );
 
   const { staged, effectiveVars, stageSet, stageDelete, stageImport, stageSnapshot, unstage, clearStaged, restoreStaged } =
     useStaged(vars);
+
+  // Computed: Envarly is in PATH if the registry already has it OR it's currently staged.
+  // This means the "Add Envarly to PATH" button disappears when staged and reappears when unstaged,
+  // without any optimistic state that can get stuck.
+  const userPathInEnv = actualUserPathInEnv || staged.has(stagedKey("Path", "User"));
+  const systemPathInEnv = actualSystemPathInEnv || staged.has(stagedKey("Path", "System"));
 
   const { push, undo, redo } = useUndo();
 
@@ -77,8 +83,8 @@ export default function App() {
       try { isAdmin = await api.isElevated(); setElevated(isAdmin); } catch { }
       try {
         const ps = await api.getPathStatus();
-        setUserPathInEnv(ps.userHasEntry);
-        setSystemPathInEnv(ps.systemHasEntry);
+        setActualUserPathInEnv(ps.userHasEntry);
+        setActualSystemPathInEnv(ps.systemHasEntry);
       } catch { }
       refresh();
     })();
@@ -163,6 +169,11 @@ export default function App() {
       setDialog(null);
       await refresh();
       try { baselineRef.current = await api.getRegistrySnapshot(); } catch { }
+      try {
+        const ps = await api.getPathStatus();
+        setActualUserPathInEnv(ps.userHasEntry);
+        setActualSystemPathInEnv(ps.systemHasEntry);
+      } catch { }
     } catch (err) {
       console.error("Failed to apply staged changes", err);
     } finally {
@@ -177,8 +188,6 @@ export default function App() {
       const proposed = await api.getPathProposal(scope);
       if (proposed === null) return; // already in PATH
       stageSet("Path", scope, proposed);
-      if (scope === "User") setUserPathInEnv(true);
-      else setSystemPathInEnv(true);
     } catch (err) {
       console.error("Failed to get PATH proposal", err);
     }
@@ -197,8 +206,6 @@ export default function App() {
           stagedCount={staged.size}
           diffCount={diffEntries.length}
           elevated={elevated}
-          userPathInEnv={userPathInEnv}
-          systemPathInEnv={systemPathInEnv}
           snapshotsOpen={snapshotsOpen}
           theme={theme}
           onRefresh={handleRefresh}
@@ -209,15 +216,12 @@ export default function App() {
           onToggleSnapshots={() => setSnapshotsOpen((o) => !o)}
           onToggleTheme={toggleTheme}
           onLicenses={() => setDialog("licenses")}
-          onStageAddToPath={handleStageAddToPath}
         />
 
-        {(!userPathInEnv || (elevated && !systemPathInEnv)) && !pathBannerDismissed && (
+        {(elevated ? !systemPathInEnv : !userPathInEnv) && !pathBannerDismissed && (
           <PathBanner
-            elevated={elevated}
-            userPathInEnv={userPathInEnv}
-            systemPathInEnv={systemPathInEnv}
-            onStageAddToPath={handleStageAddToPath}
+            scope={elevated ? "System" : "User"}
+            onStageAddToPath={() => handleStageAddToPath(elevated ? "System" : "User")}
             onDismiss={handleDismissPathBanner}
           />
         )}

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -7,8 +7,6 @@ interface AppHeaderProps {
   stagedCount: number;
   diffCount: number;
   elevated: boolean;
-  userPathInEnv: boolean;
-  systemPathInEnv: boolean;
   snapshotsOpen: boolean;
   theme: "dark" | "light";
   onRefresh: () => void;
@@ -19,13 +17,12 @@ interface AppHeaderProps {
   onToggleSnapshots: () => void;
   onToggleTheme: () => void;
   onLicenses: () => void;
-  onStageAddToPath: (scope: "User" | "System") => void;
 }
 
 export function AppHeader({
-  loading, stagedCount, diffCount, elevated, userPathInEnv, systemPathInEnv, snapshotsOpen, theme,
+  loading, stagedCount, diffCount, elevated, snapshotsOpen, theme,
   onRefresh, onApplyStaged, onDiscard, onShowChanges, onImportExport,
-  onToggleSnapshots, onToggleTheme, onLicenses, onStageAddToPath,
+  onToggleSnapshots, onToggleTheme, onLicenses,
 }: AppHeaderProps) {
   return (
     <header
@@ -91,26 +88,6 @@ export function AppHeader({
         )}
         {elevated && (
           <span className="text-xs text-success opacity-60">🛡 Administrator</span>
-        )}
-        {!userPathInEnv && (
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => onStageAddToPath("User")}
-            title="Stage adding Envarly to User PATH so it can be run from a terminal"
-          >
-            + User PATH
-          </Button>
-        )}
-        {elevated && !systemPathInEnv && (
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => onStageAddToPath("System")}
-            title="Stage adding Envarly to System PATH"
-          >
-            + System PATH
-          </Button>
         )}
         <Button variant="ghost" size="xs" onClick={() => openUrl("https://github.com/iray-tno/envarly")} title="View on GitHub">
           ↗ GitHub

--- a/src/components/PathBanner/PathBanner.tsx
+++ b/src/components/PathBanner/PathBanner.tsx
@@ -1,40 +1,21 @@
 import { Button } from "../ui/Button";
 
 interface PathBannerProps {
-  elevated: boolean;
-  userPathInEnv: boolean;
-  systemPathInEnv: boolean;
-  onStageAddToPath: (scope: "User" | "System") => void;
+  scope: "User" | "System";
+  onStageAddToPath: () => void;
   onDismiss: () => void;
 }
 
-export function PathBanner({ elevated, userPathInEnv, systemPathInEnv, onStageAddToPath, onDismiss }: PathBannerProps) {
-  const missingUser = !userPathInEnv;
-  const missingSystem = elevated && !systemPathInEnv;
-
-  const label =
-    missingUser && missingSystem ? "User and System PATH" :
-    missingUser ? "User PATH" :
-    "System PATH";
-
+export function PathBanner({ scope, onStageAddToPath, onDismiss }: PathBannerProps) {
   return (
     <div className="flex items-center gap-3 px-5 py-2 bg-accent/10 border-b border-accent/30 text-sm shrink-0">
       <span className="text-fg/80 flex-1">
-        Envarly is not in your {label} — add it to run{" "}
+        Envarly is not in your {scope} PATH — add it to run{" "}
         <span className="font-mono text-fg">envarly</span> from a terminal.
       </span>
-      <div className="flex items-center gap-1.5 shrink-0">
-        {missingUser && (
-          <Button variant="secondary" size="sm" onClick={() => onStageAddToPath("User")}>
-            + User PATH
-          </Button>
-        )}
-        {missingSystem && (
-          <Button variant="secondary" size="sm" onClick={() => onStageAddToPath("System")}>
-            + System PATH
-          </Button>
-        )}
-      </div>
+      <Button variant="secondary" size="sm" onClick={onStageAddToPath}>
+        + {scope} PATH
+      </Button>
       <Button variant="ghost" size="sm" onClick={onDismiss}>
         Dismiss
       </Button>


### PR DESCRIPTION
## Summary

- **Remove + User PATH / + System PATH from the header** — these were added by mistake; PathBanner and the in-panel button are the right surfaces for this action
- **Simplify PathBanner** back to the original single-button style: shows the scope relevant to the current elevation (System when admin, User otherwise)
- **Fix stuck \"Add Envarly to PATH\" button**: staging PATH set `userPathInEnv = true` optimistically but unstaging never cleared it, so the button disappeared permanently. Now `userPathInEnv` / `systemPathInEnv` are computed as `actualRegistryValue || staged.has(stagedKey("Path", scope))` — the button reappears as soon as the staged change is removed
- After Apply completes, path status is refreshed from the registry so the button state stays accurate

## Test plan

- [x] Non-admin: PathBanner shows "+ User PATH", clicking it stages the change and button disappears; unstaging makes it reappear
- [x] Admin: PathBanner shows "+ System PATH"; in User PATH variable detail, "+ Add Envarly to PATH" button shows; in System PATH variable detail, same
- [x] After Apply, PATH buttons update correctly based on actual registry state
- [x] Header no longer shows separate User/System PATH buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)