### PR TITLE
fix(lp): fix sitemap.xml duplicate URL in Search Console

### DIFF
--- a/lp/astro.config.mjs
+++ b/lp/astro.config.mjs
@@ -5,8 +5,9 @@ import sitemap from '@astrojs/sitemap';
 import partytown from '@astrojs/partytown';
 
 export default defineConfig({
-  site: 'https://iray-tno.github.io/envarly',
+  site: 'https://iray-tno.github.io',
   base: '/envarly',
+  trailingSlash: 'always',
   integrations: [
     sitemap(),
     partytown({ config: { forward: ['dataLayer.push', 'clarity'] } }),

--- a/lp/src/pages/robots.txt.ts
+++ b/lp/src/pages/robots.txt.ts
@@ -1,7 +1,9 @@
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = ({ site }) => {
-  const sitemapUrl = new URL('sitemap-index.xml', site);
+  // BASE_URL is '/envarly/' — prepend it so the sitemap path is correct
+  // even when site is set to the root origin without the base path.
+  const sitemapUrl = new URL(`${import.meta.env.BASE_URL}sitemap-index.xml`, site);
   return new Response(
     `User-agent: *\nAllow: /\nSitemap: ${sitemapUrl}`,
     { headers: { 'Content-Type': 'text/plain; charset=utf-8' } },


### PR DESCRIPTION
## Problem

`site` was set to `'https://iray-tno.github.io/envarly'` (base path included), causing \`@astrojs/sitemap\` to emit two entries for the same page:

\`\`\`xml
<loc>https://iray-tno.github.io/envarly</loc>
<loc>https://iray-tno.github.io/envarly/</loc>
\`\`\`

Google Search Console reports this as a sitemap error.

## Fix

- Set `site` to the root origin `'https://iray-tno.github.io'` (Astro applies the `base` itself)
- Add `trailingSlash: 'always'` to normalize to one canonical form

Result: sitemap now contains exactly one entry — `https://iray-tno.github.io/envarly/`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)