### PR TITLE
chore: remove uuid override — resolved by Storybook v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1"
   },
-  "overrides": {
-    "uuid": ">=11.1.1"
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@storybook/addon-a11y": "^10.4.6",


### PR DESCRIPTION
The `uuid <11.1.1` vulnerability (GHSA-w5hq-g745-h8pq) was introduced via Storybook's transitive dependencies. Now that Storybook v10 no longer pulls in uuid, the `overrides` workaround in `package.json` is no longer needed.

`npm audit` confirms 0 vulnerabilities after removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)