### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/lp/src/pages/index.astro
+++ b/lp/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from '../layouts/Base.astro';
 const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 const STORYBOOK_URL = '/envarly/storybook/';
-const VERSION = '1.0.0';
+const VERSION = '1.1.0';
 
 const features = [
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.0.0"
+version = "1.1.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump from 1.0.0 → 1.1.0.

## Files changed

| File | Change |
|---|---|
| `package.json` | `1.0.0` → `1.1.0` |
| `src-tauri/tauri.conf.json` | `1.0.0` → `1.1.0` |
| `src-tauri/Cargo.toml` | `1.0.0` → `1.1.0` |
| `src-tauri/Cargo.lock` | version entry updated |
| `lp/src/pages/index.astro` | `const VERSION = '1.1.0'` |

## After merge

Tag with `v1.1.0` to trigger the release workflow:

```sh
git checkout main && git pull
git tag v1.1.0
git push origin v1.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)