### PR TITLE
fix(ci): split Pages workflow into build+deploy jobs to prevent duplicate artifact error

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -9,17 +9,10 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
-  deploy:
-    name: Build and deploy GitHub Pages
+  build:
+    name: Build site
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,5 +45,16 @@ jobs:
         with:
           path: site
 
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
       - id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

`deploy-pages` was failing with:
> Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.

**Root cause:** the workflow had `cancel-in-progress: true` at the workflow level. When a new push cancelled a running workflow that had already uploaded the `github-pages` artifact (but not yet deployed), the stale artifact persisted. The next run uploaded a second one, and `deploy-pages` found 2.

## Fix

Split into two jobs:

| Job | Concurrency |
|---|---|
| `build` | none — can be freely cancelled before artifact upload |
| `deploy` | `group: pages, cancel-in-progress: false` — serialised, never races |

If a build is cancelled before `upload-pages-artifact` completes, no artifact is left behind. The deploy job is guaranteed to see exactly one artifact per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)