### PR TITLE
fix(lp): hide secondary nav links on mobile

### DIFF
--- a/lp/src/pages/index.astro
+++ b/lp/src/pages/index.astro
@@ -56,9 +56,9 @@ const features = [
     <div class="mx-auto max-w-5xl px-6 h-14 flex items-center justify-between">
       <span class="font-semibold text-[var(--color-text)] tracking-tight">Envarly</span>
       <nav class="flex items-center gap-6">
-        <a href="#features" class="text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">Features</a>
-        <a href={STORYBOOK_URL} class="text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">Storybook</a>
-        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">GitHub</a>
+        <a href="#features" class="hidden sm:block text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">Features</a>
+        <a href={STORYBOOK_URL} class="hidden sm:block text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">Storybook</a>
+        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="hidden sm:block text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">GitHub</a>
         <a
           href={RELEASE_URL}
           target="_blank"


### PR DESCRIPTION
On narrow screens the header nav was cramped. This hides Features / Storybook / GitHub below the `sm` breakpoint (640 px) with `hidden sm:block`, leaving only the logo and the Download CTA visible on mobile.

Both links remain accessible via the footer on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)