### PR TITLE
chore: fix CI deprecation warnings (#35)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,8 +12,8 @@ jobs:
     name: npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -24,7 +24,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     name: Frontend (vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -23,7 +23,7 @@ jobs:
     name: Rust (cargo test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 mod cli;
 #[cfg(windows)]
 mod commands;
+#[cfg(windows)]
 mod crypto;
 mod env_store;
 mod error;


### PR DESCRIPTION
Fixes #35.

## Changes

### GitHub Actions — Node 20 → 24

Upgraded in all four workflows (`test.yml`, `release.yml`, `security.yml`, `storybook.yml`):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-node` | `@v4` | `@v5` |

### Rust — dead-code warnings in `crypto.rs`

Added `#[cfg(windows)]` to `mod crypto;` in `lib.rs`.

`crypto` is only referenced by `snapshot` and `commands`, both of which are already `#[cfg(windows)]`. On Linux CI the module compiled but had no callers, producing:
```
warning: function `protect` is never used
warning: function `unprotect` is never used
warning: unused import: `crate::error::EnvarlyError`
```

Gating the module declaration fixes all three warnings without changing any logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)