### PR TITLE
chore: fix unused import warning in path_manage.rs

### DIFF
--- a/src-tauri/src/path_manage.rs
+++ b/src-tauri/src/path_manage.rs
@@ -5,6 +5,7 @@ use winreg::enums::*;
 #[cfg(windows)]
 use winreg::RegKey;
 
+#[cfg(windows)]
 use crate::error::EnvarlyError;
 
 const USER_ENV_KEY: &str = "Environment";


### PR DESCRIPTION
`EnvarlyError` in `path_manage.rs` was imported without a `#[cfg(windows)]` guard, but every function that references it is `#[cfg(windows)]`-gated. On Linux CI this produced:

```
warning: unused import: `crate::error::EnvarlyError`
 --> src/path_manage.rs:8:5
```

Fix: add `#[cfg(windows)]` to the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)