### PR TITLE
fix(pages): create site/reports/ dir before xunit-viewer

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -72,7 +72,9 @@ jobs:
           mv storybook-static site/storybook
 
       - name: Build HTML reports
-        run: npx xunit-viewer --results junit-reports --output site/reports/index.html --title "Envarly — Reports"
+        run: |
+          mkdir -p site/reports
+          npx xunit-viewer --results junit-reports --output site/reports/index.html --title "Envarly — Reports"
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
xunit-viewer does not create the output directory automatically, causing an ENOENT error when writing to `site/reports/index.html`. Added `mkdir -p site/reports` before the xunit-viewer step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)