### PR TITLE
feat(reports): split nextest classnames by module for Allure grouping

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Copy nextest JUnit
         run: cp src-tauri/target/nextest/ci/nextest.xml junit-reports/nextest.xml || true
 
+      - name: Fix nextest classnames for Allure
+        run: node scripts/nextest-fix-junit.mjs junit-reports/nextest.xml || true
+
       - name: Report (Clippy)
         run: cargo clippy --message-format=json 2>/dev/null | node ../../scripts/clippy-to-junit.mjs > ../../junit-reports/clippy.xml || true
         working-directory: src-tauri

--- a/scripts/nextest-fix-junit.mjs
+++ b/scripts/nextest-fix-junit.mjs
@@ -1,0 +1,32 @@
+// Rewrites nextest JUnit XML to use module paths as classnames.
+// nextest outputs classname="envarly" (crate name) for all tests.
+// This splits "env_store::tests::my_test" into classname="env_store", name="my_test",
+// making Allure group tests by module instead of lumping them all under the crate name.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const filePath = process.argv[2];
+if (!filePath) {
+  process.stderr.write('Usage: node nextest-fix-junit.mjs <junit.xml>\n');
+  process.exit(1);
+}
+
+const xml = readFileSync(filePath, 'utf8');
+
+const fixed = xml.replace(/<testcase\b([^>]*?)(\s*\/>|>)/gs, (match, attrs, closing) => {
+  const nameMatch = attrs.match(/\bname="([^"]*)"/);
+  if (!nameMatch) return match;
+
+  const parts = nameMatch[1].split('::').filter(p => p !== 'tests');
+  if (parts.length <= 1) return match;
+
+  const testName = parts[parts.length - 1];
+  const classname = parts.slice(0, -1).join('::');
+
+  const newAttrs = attrs
+    .replace(/\bname="[^"]*"/, `name="${testName}"`)
+    .replace(/\bclassname="[^"]*"/, `classname="${classname}"`);
+
+  return `<testcase${newAttrs}${closing}`;
+});
+
+writeFileSync(filePath, fixed, 'utf8');


### PR DESCRIPTION
## Summary

nextest outputs `classname="envarly"` (crate name) for all tests, causing Allure to lump every Rust test under a single group.

Added `scripts/nextest-fix-junit.mjs` which rewrites the JUnit XML post-generation: it splits the test path on `::`, strips the conventional `tests` segment, and uses the module name as `classname`.

**Before:** all tests under `envarly`
**After:** grouped by module — `env_store`, `path_manage`, etc.

```
env_store::tests::path_name_always_semicolon
→ classname: env_store  |  name: path_name_always_semicolon
```

No changes to Rust source — idiomatic test structure is preserved.

## Test plan

- [ ] Pages build succeeds
- [ ] Allure report groups Rust tests by module

🤖 Generated with [Claude Code](https://claude.com/claude-code)