### PR TITLE
feat: add language switcher and useI18n wrapper hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "./hooks/useI18n";
 import { AppHeader } from "./components/AppHeader/AppHeader";
 import { AppModals } from "./components/AppModals/AppModals";
 import { PathBanner } from "./components/PathBanner/PathBanner";
@@ -25,7 +25,7 @@ import type { EnvVar } from "./types";
 type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | null;
 
 export default function App() {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const { theme, toggle: toggleTheme } = useTheme();
   const { vars, loading, error, refresh } = useEnvVars();
   const [selected, setSelected] = useState<EnvVar | null>(null);

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { Button } from "../ui/Button";
 
@@ -25,7 +25,7 @@ export function AppHeader({
   onRefresh, onApplyStaged, onDiscard, onShowChanges, onImportExport,
   onToggleSnapshots, onToggleTheme, onLicenses,
 }: AppHeaderProps) {
-  const { t } = useTranslation();
+  const { t, language, toggleLanguage } = useI18n();
 
   return (
     <header
@@ -94,6 +94,9 @@ export function AppHeader({
         )}
         <Button variant="ghost" size="xs" onClick={() => openUrl("https://github.com/iray-tno/envarly")} title="View on GitHub">
           ↗ GitHub
+        </Button>
+        <Button variant="ghost" size="xs" onClick={toggleLanguage} title={language === "ja" ? "Switch to English" : "日本語に切り替え"}>
+          {language === "ja" ? "EN" : "JA"}
         </Button>
         <Button variant="ghost" size="xs" onClick={onToggleTheme} title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}>
           {theme === "dark" ? "☀" : "🌙"}

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { DiffPanel } from "../DiffPanel/DiffPanel";
 import { ImportExportPanel } from "../ImportExportPanel/ImportExportPanel";
 import { LicensesPanel } from "../LicensesPanel/LicensesPanel";
@@ -34,7 +34,7 @@ export function AppModals({
   diffEntries, applyBusy, onDiffApply, onDiffDismiss,
   onStageImport, effectiveVars, elevated, onNewVarStage,
 }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
 
   return (
     <>

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { useLocalHistory } from "../../hooks/useLocalHistory";
 import type { StagedChange } from "../../hooks/useStaged";
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export function DetailPanel({ variable, allVars, elevated, userPathInEnv, systemPathInEnv, staged, onStage, onStageDelete, onUnstage, onStageAddToPath, onRegisterLocalUndo }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | null>(null);
   const prevVarRef = useRef<{ name: string; scope: string } | null>(null);
 

--- a/src/components/DiffPanel/DiffPanel.tsx
+++ b/src/components/DiffPanel/DiffPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import type { DiffEntry } from "../../lib/diff";
 import { Button } from "../ui/Button";
 import { IconButton } from "../ui/IconButton";
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [accepted, setAccepted] = useState<Record<string, boolean>>(
     () => Object.fromEntries(entries.map((e) => [`${e.scope}:${e.name}`, true])),
   );

--- a/src/components/ImportExportPanel/ExportTab.tsx
+++ b/src/components/ImportExportPanel/ExportTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { type SecretInfo, resolveSecret } from "../../lib/secrets";
 import type { EnvVar } from "../../types";
@@ -33,7 +33,7 @@ interface ExportConfirmProps {
 }
 
 function ExportConfirm({ secretServices, onConfirm, onCancel }: ExportConfirmProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   return (
     <div className="flex flex-col gap-3 p-3 rounded border border-warn/40 bg-warn/10">
       <p className="flex gap-2 text-warn text-xs">
@@ -55,7 +55,7 @@ interface ExportTabProps {
 }
 
 export function ExportTab({ onStatus }: ExportTabProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [scope, setScope] = useState<ExportScope>("All");
   const [format, setFormat] = useState<AnyFormat>("json");
   const [busy, setBusy] = useState(false);

--- a/src/components/ImportExportPanel/ImportExportPanel.tsx
+++ b/src/components/ImportExportPanel/ImportExportPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
 import type { VarScope } from "../../types";
 import { SegmentedControl } from "../ui/SegmentedControl";
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function ImportExportPanel({ onStage }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [mode, setMode] = useState<Mode>("export");
   const [status, setStatus] = useState<{ ok: boolean; msg: string } | null>(null);
 

--- a/src/components/ImportExportPanel/ImportTab.tsx
+++ b/src/components/ImportExportPanel/ImportTab.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { resolveSecret } from "../../lib/secrets";
 import type { VarScope } from "../../types";
@@ -18,7 +18,7 @@ interface ImportTabProps {
 }
 
 export function ImportTab({ onStage, onStatus }: ImportTabProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const fileRef = useRef<HTMLInputElement>(null);
   const [format, setFormat] = useState<ExportFormat>("json");
   const [text, setText] = useState("");

--- a/src/components/ImportExportPanel/VarTable.tsx
+++ b/src/components/ImportExportPanel/VarTable.tsx
@@ -1,11 +1,11 @@
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
 import { resolveSecret } from "../../lib/secrets";
 import { Button } from "../ui/Button";
 import { type FlatVar, varKey } from "./types";
 
 export function SecretBanner({ count }: { count: number }) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   if (count === 0) return null;
   return (
     <div className="flex gap-2 px-3 py-2 rounded border border-warn/40 bg-warn/10 text-warn text-xs">
@@ -23,7 +23,7 @@ interface VarTableProps {
 }
 
 export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const checkedCount = vars.filter((v) => checked[varKey(v)]).length;
   const allChecked = checkedCount === vars.length;
   const noneChecked = checkedCount === 0;

--- a/src/components/NewVarModal/NewVarModal.tsx
+++ b/src/components/NewVarModal/NewVarModal.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
 import type { EnvVar, VarScope } from "../../types";
 import { Button } from "../ui/Button";
@@ -13,7 +13,7 @@ interface NewVarModalProps {
 }
 
 export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [name, setName] = useState("");
   const [scope, setScope] = useState<VarScope>("User");
   const [value, setValue] = useState("");

--- a/src/components/PathBanner/PathBanner.tsx
+++ b/src/components/PathBanner/PathBanner.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { Button } from "../ui/Button";
 
 interface PathBannerProps {
@@ -8,7 +8,7 @@ interface PathBannerProps {
 }
 
 export function PathBanner({ scope, onStageAddToPath, onDismiss }: PathBannerProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
 
   return (
     <div className="flex items-center gap-3 px-5 py-2 bg-accent/10 border-b border-accent/30 text-sm shrink-0">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import type { StagedChange } from "../../hooks/useStaged";
 import { stagedKey } from "../../hooks/useStaged";
 import { cn } from "../../lib/cn";
@@ -21,7 +21,7 @@ const SCOPES = ["All", "User", "System"] as const;
 type ScopeFilter = (typeof SCOPES)[number];
 
 export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>("All");
   const [secretsOnly, setSecretsOnly] = useState(false);

--- a/src/components/SnapshotPanel/SnapshotCompare.tsx
+++ b/src/components/SnapshotPanel/SnapshotCompare.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import type { DiffEntry } from "../../lib/diff";
 import type { SnapshotMeta } from "../../types";
 import { Button } from "../ui/Button";
@@ -12,7 +12,7 @@ interface SnapshotCompareProps {
 }
 
 export function SnapshotCompare({ from, to, diff, onBack }: SnapshotCompareProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-start gap-2">

--- a/src/components/SnapshotPanel/SnapshotPanel.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { cn } from "../../lib/cn";
 import { computeDiff } from "../../lib/diff";
@@ -22,7 +22,7 @@ interface CompareResult {
 }
 
 export function SnapshotPanel({ onStageSnapshot }: Props) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [snapshots, setSnapshots] = useState<SnapshotMeta[]>([]);
   const [label, setLabel] = useState("");
   const [busy, setBusy] = useState(false);

--- a/src/components/SnapshotPanel/SnapshotPreview.tsx
+++ b/src/components/SnapshotPanel/SnapshotPreview.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import type { DiffEntry } from "../../lib/diff";
 import type { SnapshotMeta } from "../../types";
 import { Button } from "../ui/Button";
@@ -12,7 +12,7 @@ interface SnapshotPreviewProps {
 }
 
 export function SnapshotPreview({ snap, diff, onRestore, onCancel }: SnapshotPreviewProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-start gap-2">

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
 import type { DiffEntry } from "../../lib/diff";
 import { Button } from "../ui/Button";
@@ -24,7 +24,7 @@ function isList(value: string): boolean {
 }
 
 function ListDiffDelta({ oldValue, newValue }: { oldValue: string; newValue: string }) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const oldEntries = splitList(oldValue);
   const newEntries = splitList(newValue);
   const removed = oldEntries.filter((e) => !newEntries.includes(e));
@@ -98,7 +98,7 @@ function ListEntries({ value, className }: { value: string; className?: string }
 }
 
 export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) {
-  const { t } = useTranslation();
+  const { t } = useI18n();
   const [takeSnapshot, setTakeSnapshot] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("delta");
 

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -1,0 +1,20 @@
+import i18n from "../i18n";
+import { useTranslation } from "react-i18next";
+
+export type Language = "en" | "ja";
+
+const STORAGE_KEY = "envarly-language";
+
+export function useI18n() {
+  const { t, i18n: i18next } = useTranslation();
+  const language = i18next.language as Language;
+
+  const setLanguage = (lang: Language) => {
+    localStorage.setItem(STORAGE_KEY, lang);
+    i18n.changeLanguage(lang);
+  };
+
+  const toggleLanguage = () => setLanguage(language === "ja" ? "en" : "ja");
+
+  return { t, language, setLanguage, toggleLanguage };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,8 +3,10 @@ import { initReactI18next } from "react-i18next";
 import en from "./locales/en.json";
 import ja from "./locales/ja.json";
 
+const STORAGE_KEY = "envarly-language";
+const stored = localStorage.getItem(STORAGE_KEY);
 const detected = navigator.language;
-const lng = detected.startsWith("ja") ? "ja" : "en";
+const lng = stored === "ja" || stored === "en" ? stored : detected.startsWith("ja") ? "ja" : "en";
 
 i18n
   .use(initReactI18next)


### PR DESCRIPTION
## Summary

- Add `useI18n` hook (`src/hooks/useI18n.ts`) that wraps `useTranslation` and exposes `language` + `toggleLanguage`
- Replace all direct `useTranslation()` calls across 16 components with `useI18n()`
- Add **EN / JA** toggle button to `AppHeader` (right of the theme toggle)
- Persist the chosen language to `localStorage` (`envarly-language`) so it survives app restarts
- Initial locale still falls back to `navigator.language` when no stored preference exists

## Test plan

- [ ] Click EN/JA button — UI switches language immediately
- [ ] Restart app — chosen language is remembered
- [ ] Fresh install (no localStorage) — detects OS locale correctly
- [ ] All 199 tests pass (`npx vitest run`)

Closes #53
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)