### PR TITLE
chore(storybook): reorganise into Design System / Primitives / Components

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from "@storybook/react-vite";
 import "../src/index.css";
+import "../src/i18n";
 
 // Mock Tauri invoke for all stories
 // @ts-ignore

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppHeader } from "./AppHeader";
+
+const meta: Meta<typeof AppHeader> = {
+  title: "Components/AppHeader",
+  component: AppHeader,
+  tags: ["autodocs"],
+  args: {
+    loading: false,
+    stagedCount: 0,
+    diffCount: 0,
+    elevated: false,
+    snapshotsOpen: false,
+    theme: "dark",
+  },
+  argTypes: {
+    loading: { control: "boolean" },
+    stagedCount: { control: "number" },
+    diffCount: { control: "number" },
+    elevated: { control: "boolean" },
+    snapshotsOpen: { control: "boolean" },
+    theme: { control: "radio", options: ["dark", "light"] },
+  },
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof AppHeader>;
+
+export const Default: Story = {};
+
+export const WithStagedChanges: Story = {
+  args: { stagedCount: 5 },
+};
+
+export const WithExternalChanges: Story = {
+  args: { diffCount: 3 },
+};
+
+export const Elevated: Story = {
+  args: { elevated: true },
+};
+
+export const SnapshotsOpen: Story = {
+  args: { snapshotsOpen: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+};

--- a/src/components/ListEditor/ListEditor.stories.tsx
+++ b/src/components/ListEditor/ListEditor.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { ListEditor } from "./ListEditor";
+
+const meta: Meta<typeof ListEditor> = {
+  title: "Components/ListEditor",
+  component: ListEditor,
+  tags: ["autodocs"],
+  argTypes: {
+    separator: { control: "radio", options: [";", ","] },
+    readOnly: { control: "boolean" },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ListEditor>;
+
+const PATH_VALUE = "C:\\Windows\\System32;C:\\Program Files\\Git\\bin;C:\\Users\\dev\\.cargo\\bin;C:\\Users\\dev\\.local\\bin";
+
+export const PathSemicolon: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(PATH_VALUE);
+    return <ListEditor {...args} rawValue={value} onChange={setValue} />;
+  },
+  args: { separator: ";" },
+};
+
+export const CommaSeparated: Story = {
+  render: (args) => {
+    const [value, setValue] = useState("production,staging,development");
+    return <ListEditor {...args} rawValue={value} onChange={setValue} />;
+  },
+  args: { separator: "," },
+};
+
+export const ReadOnly: Story = {
+  render: (args) => (
+    <ListEditor {...args} rawValue={PATH_VALUE} onChange={() => {}} />
+  ),
+  args: { separator: ";", readOnly: true },
+};
+
+export const Empty: Story = {
+  render: (args) => {
+    const [value, setValue] = useState("");
+    return <ListEditor {...args} rawValue={value} onChange={setValue} />;
+  },
+  args: { separator: ";" },
+};

--- a/src/components/NewVarModal/NewVarModal.stories.tsx
+++ b/src/components/NewVarModal/NewVarModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { NewVarModal } from "./NewVarModal";
+
+const meta: Meta<typeof NewVarModal> = {
+  title: "Components/NewVarModal",
+  component: NewVarModal,
+  tags: ["autodocs"],
+  args: {
+    vars: [],
+    elevated: false,
+  },
+  argTypes: {
+    elevated: { control: "boolean" },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof NewVarModal>;
+
+export const Default: Story = {};
+
+export const Elevated: Story = {
+  args: { elevated: true },
+};
+
+export const WithExistingVar: Story = {
+  args: {
+    vars: [{ name: "MY_VAR", value: "hello", scope: "User" }],
+  },
+};

--- a/src/components/PathBanner/PathBanner.stories.tsx
+++ b/src/components/PathBanner/PathBanner.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PathBanner } from "./PathBanner";
+
+const meta: Meta<typeof PathBanner> = {
+  title: "Components/PathBanner",
+  component: PathBanner,
+  tags: ["autodocs"],
+  args: { scope: "User" },
+  argTypes: {
+    scope: { control: "radio", options: ["User", "System"] },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PathBanner>;
+
+export const UserScope: Story = { args: { scope: "User" } };
+export const SystemScope: Story = { args: { scope: "System" } };

--- a/src/components/StagedModal/StagedModal.stories.tsx
+++ b/src/components/StagedModal/StagedModal.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { DiffEntry } from "../../lib/diff";
+import { StagedModal } from "./StagedModal";
+
+const added: DiffEntry   = { kind: "added",   name: "NEW_VAR",     scope: "User",   value: "hello" };
+const removed: DiffEntry = { kind: "removed",  name: "OLD_VAR",     scope: "User",   value: "bye" };
+const changed: DiffEntry = { kind: "changed",  name: "PATH",        scope: "User",   oldValue: "C:\\old", newValue: "C:\\old;C:\\new" };
+const critical: DiffEntry = { kind: "changed", name: "SYSTEMROOT",  scope: "System", oldValue: "C:\\Windows", newValue: "D:\\Windows" };
+const pathChange: DiffEntry = {
+  kind: "changed", name: "PATH", scope: "System",
+  oldValue: "C:\\Windows\\System32;C:\\Program Files\\Git\\bin",
+  newValue: "C:\\Windows\\System32;C:\\Program Files\\Git\\bin;C:\\Users\\dev\\.cargo\\bin",
+};
+
+const meta: Meta<typeof StagedModal> = {
+  title: "Components/StagedModal",
+  component: StagedModal,
+  tags: ["autodocs"],
+  args: { busy: false },
+  argTypes: { busy: { control: "boolean" } },
+};
+export default meta;
+type Story = StoryObj<typeof StagedModal>;
+
+export const MixedChanges: Story = {
+  args: { diff: [added, removed, changed] },
+};
+
+export const PathListChange: Story = {
+  args: { diff: [pathChange] },
+};
+
+export const CriticalVar: Story = {
+  args: { diff: [critical, added] },
+};
+
+export const Busy: Story = {
+  args: { diff: [added, changed], busy: true },
+};

--- a/src/components/ui/Badge.stories.tsx
+++ b/src/components/ui/Badge.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Badge } from "./Badge";
 
 const meta: Meta<typeof Badge> = {
-  title: "ui/Badge",
+  title: "Primitives/Badge",
   component: Badge,
   tags: ["autodocs"],
   args: { children: "User" },

--- a/src/components/ui/Button.stories.tsx
+++ b/src/components/ui/Button.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button } from "./Button";
 
 const meta: Meta<typeof Button> = {
-  title: "ui/Button",
+  title: "Primitives/Button",
   component: Button,
   tags: ["autodocs"],
   args: { children: "Click me" },

--- a/src/components/ui/IconButton.stories.tsx
+++ b/src/components/ui/IconButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { IconButton } from "./IconButton";
 
 const meta: Meta<typeof IconButton> = {
-  title: "ui/IconButton",
+  title: "Primitives/IconButton",
   component: IconButton,
   tags: ["autodocs"],
   argTypes: {

--- a/src/components/ui/Modal.stories.tsx
+++ b/src/components/ui/Modal.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { Button } from "./Button";
+import { Modal } from "./Modal";
+
+const meta: Meta<typeof Modal> = {
+  title: "Primitives/Modal",
+  component: Modal,
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "radio", options: ["md", "lg", "xl", "2xl"] },
+    open: { control: "boolean" },
+    flex: { control: "boolean" },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+        <Modal {...args} open={open} onClose={() => setOpen(false)}>
+          <div className="px-6 py-5 text-sm text-muted">Modal content goes here.</div>
+        </Modal>
+      </>
+    );
+  },
+  args: { title: "Dialog title", size: "lg" },
+};
+
+export const NoTitle: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open modal</Button>
+        <Modal {...args} open={open} onClose={() => setOpen(false)}>
+          <div className="px-6 py-5 text-sm text-muted">No title bar — close via backdrop or Escape.</div>
+        </Modal>
+      </>
+    );
+  },
+  args: { size: "md" },
+};
+
+export const Sizes: Story = {
+  render: () => {
+    const [size, setSize] = useState<"md" | "lg" | "xl" | "2xl" | null>(null);
+    return (
+      <div className="flex gap-2 flex-wrap">
+        {(["md", "lg", "xl", "2xl"] as const).map((s) => (
+          <Button key={s} variant="secondary" onClick={() => setSize(s)}>{s}</Button>
+        ))}
+        {size && (
+          <Modal open title={`Size: ${size}`} size={size} onClose={() => setSize(null)}>
+            <div className="px-6 py-5 text-sm text-muted">Content at size <code>{size}</code>.</div>
+          </Modal>
+        )}
+      </div>
+    );
+  },
+};

--- a/src/components/ui/SegmentedControl.stories.tsx
+++ b/src/components/ui/SegmentedControl.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { SegmentedControl } from "./SegmentedControl";
 
 const meta: Meta<typeof SegmentedControl> = {
-  title: "ui/SegmentedControl",
+  title: "Primitives/SegmentedControl",
   component: SegmentedControl,
   tags: ["autodocs"],
 };

--- a/src/components/ui/TextInput.stories.tsx
+++ b/src/components/ui/TextInput.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TextInput } from "./TextInput";
 
 const meta: Meta<typeof TextInput> = {
-  title: "ui/TextInput",
+  title: "Primitives/TextInput",
   component: TextInput,
   tags: ["autodocs"],
   args: { label: "Variable name", placeholder: "e.g. MY_VAR" },

--- a/src/components/ui/Textarea.stories.tsx
+++ b/src/components/ui/Textarea.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Textarea } from "./Textarea";
 
 const meta: Meta<typeof Textarea> = {
-  title: "ui/Textarea",
+  title: "Primitives/Textarea",
   component: Textarea,
   tags: ["autodocs"],
   args: { label: "Value", rows: 4 },

--- a/src/stories/Colors.stories.tsx
+++ b/src/stories/Colors.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta = {
+  title: "Design System/Colors",
+  tags: ["autodocs"],
+};
+export default meta;
+
+const semanticColors = [
+  { name: "canvas",      cls: "bg-canvas",      label: "Canvas",      desc: "App background" },
+  { name: "panel",       cls: "bg-panel",        label: "Panel",       desc: "Sidebar, header, overlays" },
+  { name: "surface",     cls: "bg-surface",      label: "Surface",     desc: "Input fields, cards" },
+  { name: "hover",       cls: "bg-hover",        label: "Hover",       desc: "Hover / selected states" },
+  { name: "rim",         cls: "bg-rim",          label: "Rim",         desc: "Primary borders" },
+  { name: "rim-subtle",  cls: "bg-rim-subtle",   label: "Rim subtle",  desc: "Faint dividers" },
+];
+
+const textColors = [
+  { name: "fg",     cls: "bg-fg",     label: "Foreground", desc: "Primary text" },
+  { name: "muted",  cls: "bg-muted",  label: "Muted",      desc: "Secondary text, labels" },
+  { name: "dim",    cls: "bg-dim",    label: "Dim",        desc: "Placeholder, disabled" },
+];
+
+const accentColors = [
+  { name: "accent",   cls: "bg-accent",   label: "Accent",   desc: "Primary action, links" },
+  { name: "accent-hi",cls: "bg-accent-hi",label: "Accent hi",desc: "Accent hover / focus ring" },
+  { name: "success",  cls: "bg-success",  label: "Success",  desc: "Added, ok states" },
+  { name: "danger",   cls: "bg-danger",   label: "Danger",   desc: "Errors, destructive actions" },
+  { name: "warn",     cls: "bg-warn",     label: "Warn",     desc: "Warnings, external changes" },
+  { name: "violet",   cls: "bg-violet",   label: "Violet",   desc: "System scope badge" },
+];
+
+function SwatchRow({ colors }: { colors: typeof semanticColors }) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {colors.map((c) => (
+        <div key={c.name} className="flex flex-col gap-1.5 w-32">
+          <div className={`${c.cls} h-14 rounded border border-rim`} />
+          <p className="text-xs font-semibold text-fg">{c.label}</p>
+          <p className="text-[10px] text-dim">{c.desc}</p>
+          <p className="text-[9px] font-mono text-muted">{c.name}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export const Palette: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-10 p-8 bg-canvas min-h-screen">
+      <Section title="Surface">
+        <SwatchRow colors={semanticColors} />
+      </Section>
+      <Section title="Text">
+        <SwatchRow colors={textColors} />
+      </Section>
+      <Section title="Semantic">
+        <SwatchRow colors={accentColors} />
+      </Section>
+    </div>
+  ),
+};

--- a/src/stories/Spacing.stories.tsx
+++ b/src/stories/Spacing.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta = {
+  title: "Design System/Spacing",
+  tags: ["autodocs"],
+};
+export default meta;
+
+const steps = [
+  { token: "0.5", px: "2px" },
+  { token: "1",   px: "4px" },
+  { token: "1.5", px: "6px" },
+  { token: "2",   px: "8px" },
+  { token: "2.5", px: "10px" },
+  { token: "3",   px: "12px" },
+  { token: "4",   px: "16px" },
+  { token: "5",   px: "20px" },
+  { token: "6",   px: "24px" },
+  { token: "8",   px: "32px" },
+  { token: "10",  px: "40px" },
+  { token: "12",  px: "48px" },
+  { token: "16",  px: "64px" },
+];
+
+const patterns = [
+  { label: "Button padding",    cls: "px-3 py-1.5", desc: "px-3 py-1.5" },
+  { label: "Panel padding",     cls: "px-5 py-4",   desc: "px-5 py-4" },
+  { label: "Section gap",       cls: "gap-4",        desc: "gap-4 (between fields)" },
+  { label: "Inline chip gap",   cls: "gap-1.5",      desc: "gap-1.5 (badge + text)" },
+];
+
+export const Scale: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-10 p-8 bg-canvas min-h-screen">
+      <section className="flex flex-col gap-4">
+        <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">Spacing scale</h2>
+        <div className="flex flex-col gap-2">
+          {steps.map((s) => (
+            <div key={s.token} className="flex items-center gap-4">
+              <span className="text-[10px] font-mono text-dim w-16 shrink-0">{s.token} / {s.px}</span>
+              <div
+                className="bg-accent/60 h-4 rounded shrink-0"
+                style={{ width: s.px }}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">Common patterns</h2>
+        <div className="flex flex-col gap-3">
+          {patterns.map((p) => (
+            <div key={p.label} className="flex items-center gap-6">
+              <span className="text-xs text-muted w-36 shrink-0">{p.label}</span>
+              <div className={`${p.cls} bg-surface border border-rim rounded text-xs text-fg inline-flex items-center`}>
+                <span className="bg-accent/20 rounded">&nbsp;</span>
+              </div>
+              <code className="text-[10px] font-mono text-dim">{p.desc}</code>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">Border radius</h2>
+        <div className="flex gap-6 flex-wrap">
+          {(["rounded-sm", "rounded", "rounded-md", "rounded-lg", "rounded-full"] as const).map((r) => (
+            <div key={r} className="flex flex-col items-center gap-2">
+              <div className={`${r} w-12 h-12 bg-accent/30 border border-accent/50`} />
+              <span className="text-[10px] font-mono text-dim">{r}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  ),
+};

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta = {
+  title: "Design System/Typography",
+  tags: ["autodocs"],
+};
+export default meta;
+
+const scale = [
+  { label: "text-xs",   cls: "text-xs",   size: "12px" },
+  { label: "text-sm",   cls: "text-sm",   size: "14px" },
+  { label: "text-base", cls: "text-base", size: "16px" },
+  { label: "text-lg",   cls: "text-lg",   size: "18px" },
+  { label: "text-xl",   cls: "text-xl",   size: "20px" },
+];
+
+const weights = [
+  { label: "normal",    cls: "font-normal" },
+  { label: "medium",    cls: "font-medium" },
+  { label: "semibold",  cls: "font-semibold" },
+  { label: "bold",      cls: "font-bold" },
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export const Scale: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-10 p-8 bg-canvas min-h-screen">
+      <Section title="Font scale (sans)">
+        <div className="flex flex-col gap-4">
+          {scale.map((s) => (
+            <div key={s.label} className="flex items-baseline gap-6">
+              <span className="text-[10px] font-mono text-dim w-20 shrink-0">{s.label} / {s.size}</span>
+              <span className={`${s.cls} text-fg`}>The quick brown fox jumps over the lazy dog</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Font scale (mono)">
+        <div className="flex flex-col gap-4">
+          {scale.map((s) => (
+            <div key={s.label} className="flex items-baseline gap-6">
+              <span className="text-[10px] font-mono text-dim w-20 shrink-0">{s.label} / {s.size}</span>
+              <span className={`${s.cls} font-mono text-fg`}>PATH=C:\Windows\System32;C:\Program Files</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Font weight">
+        <div className="flex gap-8 flex-wrap">
+          {weights.map((w) => (
+            <div key={w.label} className="flex flex-col gap-1">
+              <span className={`${w.cls} text-base text-fg`}>Aa</span>
+              <span className="text-[10px] font-mono text-dim">{w.label}</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Patterns in use">
+        <div className="flex flex-col gap-3 p-4 bg-panel rounded border border-rim">
+          <p className="text-xs font-semibold text-muted uppercase tracking-wide">Section label</p>
+          <h2 className="text-sm font-semibold text-fg">Panel heading</h2>
+          <p className="text-xs text-muted">Descriptive body text that provides context for the user.</p>
+          <p className="text-[10px] text-dim">Metadata / timestamp</p>
+          <code className="font-mono text-sm text-fg">MY_VARIABLE=some_value</code>
+        </div>
+      </Section>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- **Rename** all `ui/` story titles → `Primitives/` (Badge, Button, IconButton, SegmentedControl, TextInput, Textarea)
- **Add** missing `Primitives/Modal` story
- **Add** missing `Components/` stories: AppHeader, PathBanner, NewVarModal, StagedModal, ListEditor
- **Add** `Design System/` documentation stories: Colors (palette swatches), Typography (font scale, weight, patterns), Spacing (scale, common patterns, border radius)
- **Fix** Storybook preview to initialise i18n so components using `useI18n` render correctly

## Storybook structure after this PR

```
Design System/
  Colors
  Typography
  Spacing

Primitives/
  Badge · Button · IconButton · Modal · SegmentedControl · TextInput · Textarea

Components/
  AppHeader · DetailPanel · DiffPanel · ImportExportPanel · ListEditor
  NewVarModal · PathBanner · PathEditor · Sidebar · SnapshotPanel · StagedModal
```

## Test plan

- [ ] `npx storybook dev` — all stories appear under the correct category
- [ ] Design System pages render colour swatches / type scale / spacing without errors
- [ ] Components that use `useI18n` (AppHeader, PathBanner, NewVarModal, StagedModal) render English text
- [ ] All 199 unit tests still pass

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)