### PR TITLE
feat: language select dropdown and expanded env descriptions

### DIFF
--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -25,7 +25,7 @@ export function AppHeader({
   onRefresh, onApplyStaged, onDiscard, onShowChanges, onImportExport,
   onToggleSnapshots, onToggleTheme, onLicenses,
 }: AppHeaderProps) {
-  const { t, language, toggleLanguage } = useI18n();
+  const { t, language, setLanguage } = useI18n();
 
   return (
     <header
@@ -95,9 +95,17 @@ export function AppHeader({
         <Button variant="ghost" size="xs" onClick={() => openUrl("https://github.com/iray-tno/envarly")} title="View on GitHub">
           ↗ GitHub
         </Button>
-        <Button variant="ghost" size="xs" onClick={toggleLanguage} title={language === "ja" ? "Switch to English" : "日本語に切り替え"}>
-          {language === "ja" ? "EN" : "JA"}
-        </Button>
+        <label className="flex items-center gap-1 text-xs text-dim cursor-pointer">
+          <span title="Language">🌐</span>
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value as "en" | "ja")}
+            className="bg-transparent text-xs text-dim cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded"
+          >
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+          </select>
+        </label>
         <Button variant="ghost" size="xs" onClick={onToggleTheme} title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}>
           {theme === "dark" ? "☀" : "🌙"}
         </Button>

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -172,10 +172,12 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
       {description && (
         <div className="flex items-start gap-2.5 px-6 py-2 border-b border-rim-subtle bg-hover/40 shrink-0">
           <span className="text-dim text-xs mt-px select-none">ℹ</span>
-          <p className="text-xs text-muted leading-relaxed">
-            <span className="font-semibold text-dim mr-1.5">{t(description.categoryKey)}</span>
-            {t(description.summaryKey)}
-          </p>
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-surface border border-rim text-dim shrink-0 select-none">
+              {t(description.categoryKey)}
+            </span>
+            <p className="text-xs text-muted leading-relaxed">{t(description.summaryKey)}</p>
+          </div>
         </div>
       )}
 

--- a/src/lib/envDescriptions.ts
+++ b/src/lib/envDescriptions.ts
@@ -11,8 +11,11 @@ const vars: Record<string, string> = {
   PROGRAMFILES: "windows", "PROGRAMFILES(X86)": "windows", PROGRAMDATA: "windows",
   COMPUTERNAME: "windows", USERNAME: "windows", USERDOMAIN: "windows", OS: "windows",
   PROCESSOR_ARCHITECTURE: "windows", NUMBER_OF_PROCESSORS: "windows", SYSTEMDRIVE: "windows",
-  PUBLIC: "windows", ALLUSERSPROFILE: "windows", ONEDRIVE: "windows",
+  PUBLIC: "windows", ALLUSERSPROFILE: "windows",
+  ONEDRIVE: "windows", ONEDRIVECONSUMER: "windows", ONEDRIVECOMMERCIAL: "windows",
   PSMODULEPATH: "windows", DRIVERDATA: "windows",
+  PROCESSOR_IDENTIFIER: "windows", PROCESSOR_LEVEL: "windows", PROCESSOR_REVISION: "windows",
+  POWERSHELL_DISTRIBUTION_CHANNEL: "windows",
 
   // Network
   HTTP_PROXY: "network", HTTPS_PROXY: "network", NO_PROXY: "network", ALL_PROXY: "network",
@@ -69,6 +72,12 @@ const vars: Record<string, string> = {
   // Azure
   AZURE_SUBSCRIPTION_ID: "azure", AZURE_TENANT_ID: "azure",
   AZURE_CLIENT_ID: "azure", AZURE_CLIENT_SECRET: "azure",
+
+  // GPU / CUDA
+  CUDA_PATH: "gpu", CUDA_HOME: "gpu", CUDA_VISIBLE_DEVICES: "gpu",
+  NVIDIA_VISIBLE_DEVICES: "gpu", NVIDIA_DRIVER_CAPABILITIES: "gpu",
+  ROCM_PATH: "gpu", HIP_PATH: "gpu", HIP_VISIBLE_DEVICES: "gpu",
+  OPENCL_VENDOR_PATH: "gpu",
 
   // Dev tools
   EDITOR: "devtools", VISUAL: "devtools", DATABASE_URL: "devtools", DEBUG: "devtools",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,8 +51,8 @@
   },
   "sidebar": {
     "search_placeholder": "Search variables...",
-    "secret_one": "⚠ {{count}} secret",
-    "secret_other": "⚠ {{count}} secrets",
+    "secret_one": "{{count}} secret",
+    "secret_other": "{{count}} secrets",
     "sort_name_asc": "Name A→Z",
     "sort_name_desc": "Name Z→A",
     "sort_scope": "Scope",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,7 +212,8 @@
       "aws": "AWS",
       "gcp": "GCP",
       "azure": "Azure",
-      "devtools": "Dev tools"
+      "devtools": "Dev tools",
+      "gpu": "GPU / CUDA"
     },
     "PATH": "Directories searched for executable files. Programs like Node, Python, and Git are found here.",
     "PATHEXT": "File extensions treated as executables by the shell (e.g. .COM;.EXE;.BAT).",
@@ -239,8 +240,14 @@
     "PUBLIC": "Shared public profile directory accessible to all users (e.g. C:\\Users\\Public).",
     "ALLUSERSPROFILE": "Legacy alias for C:\\ProgramData. Points to the per-machine shared data directory.",
     "ONEDRIVE": "Path to the user's OneDrive sync folder. Set by the OneDrive client.",
+    "ONEDRIVECONSUMER": "Path to the personal OneDrive sync folder. Variant set by the OneDrive consumer client.",
+    "ONEDRIVECOMMERCIAL": "Path to the OneDrive for Business sync folder. Set by the OneDrive commercial client.",
     "PSMODULEPATH": "Semicolon-separated list of directories where PowerShell looks for modules.",
     "DRIVERDATA": "Directory for driver data files shared between kernel and user mode.",
+    "PROCESSOR_IDENTIFIER": "Full description string of the CPU model (e.g. Intel64 Family 6 Model 186 Stepping 2).",
+    "PROCESSOR_LEVEL": "Processor family level number. Used by legacy applications to determine CPU generation.",
+    "PROCESSOR_REVISION": "Processor model and stepping packed into a hex word. Complements PROCESSOR_LEVEL.",
+    "POWERSHELL_DISTRIBUTION_CHANNEL": "Identifies the PowerShell distribution channel (e.g. MSI, Store, dotnet-global-tool). Used by telemetry.",
     "HTTP_PROXY": "HTTP proxy URL used by curl, wget, Python requests, and many CLI tools.",
     "HTTPS_PROXY": "HTTPS proxy URL. Takes precedence over HTTP_PROXY for HTTPS requests.",
     "NO_PROXY": "Comma-separated list of hostnames/domains that bypass the proxy.",
@@ -335,6 +342,15 @@
     "PORT": "TCP port the server process should listen on. Used by many web frameworks by convention.",
     "HOST": "Hostname or IP address the server should bind to (e.g. 0.0.0.0 or localhost).",
     "TZ": "IANA timezone name (e.g. America/New_York). Overrides the system timezone for the process.",
-    "LANG": "Default locale for the process (e.g. en_US.UTF-8). Affects character encoding and sorting."
+    "LANG": "Default locale for the process (e.g. en_US.UTF-8). Affects character encoding and sorting.",
+    "CUDA_PATH": "CUDA toolkit installation directory. Used by compilers and libraries to locate CUDA headers and libs.",
+    "CUDA_HOME": "Alias for CUDA_PATH used by some frameworks (PyTorch, TensorFlow). Points to the CUDA toolkit root.",
+    "CUDA_VISIBLE_DEVICES": "Comma-separated list of GPU indices visible to CUDA applications. Use to restrict GPU usage.",
+    "NVIDIA_VISIBLE_DEVICES": "GPUs exposed inside Docker containers with NVIDIA Container Toolkit. Similar to CUDA_VISIBLE_DEVICES.",
+    "NVIDIA_DRIVER_CAPABILITIES": "Docker GPU capabilities to expose (e.g. compute,utility). Requires NVIDIA Container Toolkit.",
+    "ROCM_PATH": "AMD ROCm installation root. Used by HIP compilers and ROCm-aware frameworks.",
+    "HIP_PATH": "HIP toolkit installation directory. Points to AMD's CUDA-compatible GPU programming layer.",
+    "HIP_VISIBLE_DEVICES": "GPU indices visible to HIP/ROCm applications. Analogous to CUDA_VISIBLE_DEVICES.",
+    "OPENCL_VENDOR_PATH": "Directory containing OpenCL ICD (Installable Client Driver) vendor files."
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -51,8 +51,8 @@
   },
   "sidebar": {
     "search_placeholder": "変数を検索...",
-    "secret_one": "⚠ {{count}} 件の機密情報",
-    "secret_other": "⚠ {{count}} 件の機密情報",
+    "secret_one": "{{count}} 件の機密情報",
+    "secret_other": "{{count}} 件の機密情報",
     "sort_name_asc": "名前 A→Z",
     "sort_name_desc": "名前 Z→A",
     "sort_scope": "スコープ",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -212,7 +212,8 @@
       "aws": "AWS",
       "gcp": "GCP",
       "azure": "Azure",
-      "devtools": "開発ツール"
+      "devtools": "開発ツール",
+      "gpu": "GPU / CUDA"
     },
     "PATH": "実行ファイルを検索するディレクトリのリスト。Node、Python、Git などのプログラムはここで見つかります。",
     "PATHEXT": "シェルが実行可能として扱うファイル拡張子（例: .COM;.EXE;.BAT）。",
@@ -239,8 +240,14 @@
     "PUBLIC": "全ユーザーがアクセスできる共有パブリックプロファイルディレクトリ（例: C:\\Users\\Public）。",
     "ALLUSERSPROFILE": "C:\\ProgramData の旧エイリアス。マシンごとの共有データディレクトリを指す。",
     "ONEDRIVE": "ユーザーの OneDrive 同期フォルダーへのパス。OneDrive クライアントによって設定。",
+    "ONEDRIVECONSUMER": "個人用 OneDrive 同期フォルダーへのパス。OneDrive コンシューマークライアントが設定するバリアント。",
+    "ONEDRIVECOMMERCIAL": "OneDrive for Business 同期フォルダーへのパス。OneDrive 商用クライアントが設定。",
     "PSMODULEPATH": "PowerShell がモジュールを検索するディレクトリのセミコロン区切りリスト。",
     "DRIVERDATA": "カーネルモードとユーザーモード間で共有されるドライバーデータファイルのディレクトリ。",
+    "PROCESSOR_IDENTIFIER": "CPU モデルの完全な説明文字列（例: Intel64 Family 6 Model 186 Stepping 2）。",
+    "PROCESSOR_LEVEL": "プロセッサーファミリーレベル番号。レガシーアプリが CPU 世代を判定するために使用。",
+    "PROCESSOR_REVISION": "プロセッサーのモデルとステッピングを16進数にパック。PROCESSOR_LEVEL を補完。",
+    "POWERSHELL_DISTRIBUTION_CHANNEL": "PowerShell の配布チャンネルを識別（例: MSI、Store、dotnet-global-tool）。テレメトリで使用。",
     "HTTP_PROXY": "curl、wget、Python requests など多くの CLI ツールが使用する HTTP プロキシ URL。",
     "HTTPS_PROXY": "HTTPS プロキシ URL。HTTPS リクエストでは HTTP_PROXY より優先される。",
     "NO_PROXY": "プロキシをバイパスするホスト名/ドメインのカンマ区切りリスト。",
@@ -335,6 +342,15 @@
     "PORT": "サーバープロセスがリッスンする TCP ポート。多くの Web フレームワークが慣習として使用。",
     "HOST": "サーバーがバインドするホスト名または IP アドレス（例: 0.0.0.0 または localhost）。",
     "TZ": "IANA タイムゾーン名（例: America/New_York）。プロセスのシステムタイムゾーンを上書き。",
-    "LANG": "プロセスのデフォルトロケール（例: en_US.UTF-8）。文字エンコーディングとソートに影響。"
+    "LANG": "プロセスのデフォルトロケール（例: en_US.UTF-8）。文字エンコーディングとソートに影響。",
+    "CUDA_PATH": "CUDA ツールキットのインストールディレクトリ。コンパイラやライブラリが CUDA ヘッダーとライブラリを見つけるために使用。",
+    "CUDA_HOME": "一部のフレームワーク（PyTorch、TensorFlow）が使用する CUDA_PATH の別名。CUDA ツールキットルートを指す。",
+    "CUDA_VISIBLE_DEVICES": "CUDA アプリケーションに見えるGPUインデックスのカンマ区切りリスト。GPU 使用を制限するために使用。",
+    "NVIDIA_VISIBLE_DEVICES": "NVIDIA Container Toolkit を使用した Docker コンテナ内で公開する GPU。CUDA_VISIBLE_DEVICES に相当。",
+    "NVIDIA_DRIVER_CAPABILITIES": "公開する Docker GPU 機能（例: compute,utility）。NVIDIA Container Toolkit が必要。",
+    "ROCM_PATH": "AMD ROCm インストールルート。HIP コンパイラと ROCm 対応フレームワークが使用。",
+    "HIP_PATH": "HIP ツールキットのインストールディレクトリ。AMD の CUDA 互換 GPU プログラミング層を指す。",
+    "HIP_VISIBLE_DEVICES": "HIP/ROCm アプリケーションに見える GPU インデックス。CUDA_VISIBLE_DEVICES に相当。",
+    "OPENCL_VENDOR_PATH": "OpenCL ICD（インストール可能クライアントドライバー）ベンダーファイルを含むディレクトリ。"
   }
 }


### PR DESCRIPTION
## Summary

### Language switcher UI
- Replace the `EN` / `JA` toggle button with a 🌐 globe icon + `<select>` dropdown — easier to discover and more scalable when more locales are added

### Env descriptions expanded
- **New category — GPU / CUDA**: `CUDA_PATH`, `CUDA_HOME`, `CUDA_VISIBLE_DEVICES`, `NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`, `ROCM_PATH`, `HIP_PATH`, `HIP_VISIBLE_DEVICES`, `OPENCL_VENDOR_PATH`
- **Missing Windows vars**: `PROCESSOR_IDENTIFIER`, `PROCESSOR_LEVEL`, `PROCESSOR_REVISION`, `POWERSHELL_DISTRIBUTION_CHANNEL`
- **OneDrive variants**: `ONEDRIVECONSUMER`, `ONEDRIVECOMMERCIAL`

All new entries have both English and Japanese translations.

## Test plan
- [x] Language dropdown shows 🌐 English / 日本語, switching works and persists across restarts
- [x] `CUDA_PATH`, `PROCESSOR_IDENTIFIER`, `ONEDRIVECONSUMER` show descriptions in DetailPanel
- [x] All 199 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)