### PR TITLE
fix(lp): remove Partytown — use standard script tags for GA and Clarity

### DIFF
--- a/lp/astro.config.mjs
+++ b/lp/astro.config.mjs
@@ -2,7 +2,6 @@
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
-import partytown from '@astrojs/partytown';
 
 export default defineConfig({
   site: 'https://iray-tno.github.io',
@@ -10,7 +9,6 @@ export default defineConfig({
   trailingSlash: 'always',
   integrations: [
     sitemap(),
-    partytown({ config: { forward: ['dataLayer.push', 'clarity'] } }),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/lp/package-lock.json
+++ b/lp/package-lock.json
@@ -8,7 +8,6 @@
       "name": "lp",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/partytown": "^2.1.7",
         "@astrojs/sitemap": "^3.7.3",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.3.1",
@@ -219,16 +218,6 @@
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "satteri": "^0.9.1"
-      }
-    },
-    "node_modules/@astrojs/partytown": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
-      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@qwik.dev/partytown": "^0.13.2",
-        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1458,21 +1447,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@qwik.dev/partytown": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
-      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.4.7"
-      },
-      "bin": {
-        "partytown": "bin/partytown.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -2972,18 +2946,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {

--- a/lp/package.json
+++ b/lp/package.json
@@ -12,7 +12,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/partytown": "^2.1.7",
     "@astrojs/sitemap": "^3.7.3",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.3.1",

--- a/lp/src/layouts/Base.astro
+++ b/lp/src/layouts/Base.astro
@@ -70,17 +70,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="apple-touch-icon" sizes="128x128" href="/envarly/icon-128.png" />
     <link rel="icon" type="image/x-icon" href="/envarly/favicon.ico" />
 
-    <!-- Google Analytics (via Partytown) -->
-    <script type="text/partytown" src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
-    <script type="text/partytown" define:vars={{ GA_ID }}>
+    <!-- Google Analytics -->
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
+    <script define:vars={{ GA_ID }}>
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
       gtag('config', GA_ID);
     </script>
 
-    <!-- Microsoft Clarity (via Partytown) -->
-    <script type="text/partytown" define:vars={{ CLARITY_ID }}>
+    <!-- Microsoft Clarity -->
+    <script define:vars={{ CLARITY_ID }}>
       (function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
       t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
       y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);


### PR DESCRIPTION
## Summary

Partytown's Web Worker isolation was silently preventing both Google Analytics and Microsoft Clarity from recording any data.

Replaced `type="text/partytown"` with standard `<script async>` tags and removed the `@astrojs/partytown` integration and package entirely.

## Test plan
- [ ] After deploy, confirm GA receives page view events
- [ ] After deploy, confirm Clarity session recording starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)