### PR TITLE
feat(detail): add folder picker for path values

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:default",
     "opener:default"
   ]
 }

--- a/src/components/DetailPanel/DetailPanel.test.tsx
+++ b/src/components/DetailPanel/DetailPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../api";
 import type { StagedChange } from "../../hooks/useStaged";
@@ -8,6 +9,10 @@ import { DetailPanel } from "./DetailPanel";
 
 vi.mock("../../api", () => ({
   api: { validatePaths: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
 }));
 
 const noStaged = new Map<string, StagedChange>();
@@ -34,6 +39,7 @@ describe("DetailPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.validatePaths).mockResolvedValue([true]);
+    vi.mocked(open).mockResolvedValue(null);
   });
 
   const render_ = (
@@ -88,9 +94,36 @@ describe("DetailPanel", () => {
     expect(onStage).toHaveBeenCalledWith("JAVA_HOME", "User", "NewValue");
   });
 
+  it("shows a folder picker button for path-like single values", () => {
+    render_(simpleVar);
+    expect(screen.getByRole("button", { name: /browse for folder/i })).toBeInTheDocument();
+  });
+
+  it("updates the value with the selected folder path", async () => {
+    const user = userEvent.setup();
+    vi.mocked(open).mockResolvedValue("C:\\Program Files\\Java\\jdk-22");
+    render_(simpleVar);
+
+    await user.click(screen.getByRole("button", { name: /browse for folder/i }));
+    await user.click(screen.getByRole("button", { name: /^stage$/i }));
+
+    expect(open).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      defaultPath: simpleVar.value,
+    });
+    expect(onStage).toHaveBeenCalledWith("JAVA_HOME", "User", "C:\\Program Files\\Java\\jdk-22");
+  });
+
+  it("does not show a folder picker button for non-path single values", () => {
+    render_({ ...simpleVar, name: "NODE_ENV", value: "development" });
+    expect(screen.queryByRole("button", { name: /browse for folder/i })).not.toBeInTheDocument();
+  });
+
   it("shows PATH editor for path-like variable", () => {
     render_(pathVar);
     expect(screen.getByText(/drag to reorder/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse for folder/i })).not.toBeInTheDocument();
   });
 
   it("shows Delete button when not dirty and not staged", () => {
@@ -111,6 +144,7 @@ describe("DetailPanel", () => {
     render_(sysVar, false);
     expect(screen.getByText(/restart as admin/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse for folder/i })).not.toBeInTheDocument();
   });
 
   it("shows staged badge and Unstage button when var is staged for set", () => {

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
 import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { useLocalHistory } from "../../hooks/useLocalHistory";
@@ -10,6 +11,7 @@ import { ListEditor } from "../ListEditor/ListEditor";
 import { PathEditor } from "../PathEditor/PathEditor";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
+import { IconButton } from "../ui/IconButton";
 import { Textarea } from "../ui/Textarea";
 
 interface Props {
@@ -25,6 +27,46 @@ interface Props {
   onStageAddToPath: (scope: "User" | "System") => void;
   /** Called with a discard fn when dirty, null when clean. Lets App wire Ctrl+Z. */
   onRegisterLocalUndo?: (fn: (() => void) | null) => void;
+}
+
+const PATH_NAME_SUFFIXES = ["_HOME", "_ROOT", "_PATH", "_DIR", "_DIRECTORY"];
+const PATH_NAME_EXACT = new Set([
+  "APPDATA",
+  "CUDA_PATH",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "PUBLIC",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+  "WINDIR",
+]);
+
+function looksLikeSinglePath(name: string, value: string) {
+  const normalizedName = name.toUpperCase();
+  const trimmedValue = value.trim();
+
+  if (
+    PATH_NAME_EXACT.has(normalizedName) ||
+    PATH_NAME_SUFFIXES.some((suffix) => normalizedName.endsWith(suffix))
+  ) {
+    return true;
+  }
+
+  return /^[a-z]:[\\/]/i.test(trimmedValue) || trimmedValue.startsWith("/") || trimmedValue.startsWith("\\\\");
+}
+
+function FolderIcon() {
+  return (
+    <svg aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" viewBox="0 0 24 24">
+      <path d="M3.5 6.5a2 2 0 0 1 2-2h4l2 2h7a2 2 0 0 1 2 2v1.25" />
+      <path d="M4.5 9.5h15.8a1.5 1.5 0 0 1 1.45 1.88l-1.65 6.25a2.5 2.5 0 0 1-2.42 1.87H5.35a2 2 0 0 1-1.94-2.49l1.1-4.4" />
+    </svg>
+  );
 }
 
 export function DetailPanel({ variable, allVars, elevated, userPathInEnv, systemPathInEnv, staged, onStage, onStageDelete, onUnstage, onStageAddToPath, onRegisterLocalUndo }: Props) {
@@ -94,6 +136,17 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
     reset(stagedChange?.originalValue ?? variable.value);
   };
 
+  const handleBrowseFolder = async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath: value.trim() || undefined,
+    });
+    if (typeof selected === "string") {
+      handleValueChange(selected);
+    }
+  };
+
   /** Auto-detect list separator from pasted text. */
   const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const text = e.clipboardData.getData("text");
@@ -106,6 +159,7 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
 
   const effectiveSeparator = overrideSeparator ?? variable.listSeparator;
   const readOnly = variable.scope === "System" && !elevated;
+  const showFolderPicker = !readOnly && effectiveSeparator === null && looksLikeSinglePath(variable.name, value);
   const description = lookupEnvDescription(variable.name);
   const isPathVar = variable.name.toUpperCase() === "PATH";
   const pathInEnvForScope = variable.scope === "System" ? systemPathInEnv : userPathInEnv;
@@ -252,16 +306,28 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
           ) : effectiveSeparator === "," ? (
             <ListEditor separator="," rawValue={value} onChange={handleValueChange} readOnly={readOnly} />
           ) : (
-            <Textarea
-              label="Value"
-              labelHidden
-              value={value}
-              onChange={(e) => handleValueChange(e.target.value)}
-              onPaste={handlePaste}
-              rows={Math.max(3, value.split("\n").length + 1)}
-              spellCheck={false}
-              disabled={readOnly}
-            />
+            <div className="group relative">
+              <Textarea
+                label="Value"
+                labelHidden
+                value={value}
+                onChange={(e) => handleValueChange(e.target.value)}
+                onPaste={handlePaste}
+                rows={Math.max(3, value.split("\n").length + 1)}
+                spellCheck={false}
+                disabled={readOnly}
+                className={showFolderPicker ? "pr-11" : undefined}
+              />
+              {showFolderPicker && (
+                <IconButton
+                  aria-label={t("detail.browse_folder")}
+                  title={t("detail.browse_folder")}
+                  icon={<FolderIcon />}
+                  onClick={handleBrowseFolder}
+                  className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                />
+              )}
+            </div>
           )}
 
           {/* Metadata */}

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -10,7 +10,13 @@ export function useI18n() {
   const language = i18next.language as Language;
 
   const setLanguage = (lang: Language) => {
-    localStorage.setItem(STORAGE_KEY, lang);
+    try {
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem(STORAGE_KEY, lang);
+      }
+    } catch {
+      // Language switching should still work in test/private-storage contexts.
+    }
     i18n.changeLanguage(lang);
   };
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,7 +4,18 @@ import en from "./locales/en.json";
 import ja from "./locales/ja.json";
 
 const STORAGE_KEY = "envarly-language";
-const stored = localStorage.getItem(STORAGE_KEY);
+
+function getStoredLanguage() {
+  try {
+    return typeof localStorage !== "undefined" && typeof localStorage.getItem === "function"
+      ? localStorage.getItem(STORAGE_KEY)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+const stored = getStoredLanguage();
 const detected = navigator.language;
 const lng = stored === "ja" || stored === "en" ? stored : detected.startsWith("ja") ? "ja" : "en";
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
     "label_path": "Path entries (drag to reorder)",
     "label_list": "List entries (drag to reorder)",
     "label_value": "Value",
+    "browse_folder": "Browse for folder",
     "plain_text": "Plain text",
     "list_semicolon": "List (;)",
     "list_comma": "List (,)",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -38,6 +38,7 @@
     "label_path": "パスエントリ (ドラッグで並べ替え)",
     "label_list": "リストエントリ (ドラッグで並べ替え)",
     "label_value": "値",
+    "browse_folder": "フォルダーを選択",
     "plain_text": "プレーンテキスト",
     "list_semicolon": "リスト (;)",
     "list_comma": "リスト (,)",


### PR DESCRIPTION
## Summary
- Add a focus/hover-revealed folder picker button for path-like single-value environment variables
- Populate the value editor from the native Tauri folder dialog and keep typed editing unchanged
- Allow dialog access in Tauri capabilities and harden i18n localStorage access for test/private-storage contexts

Closes #58

## Tests
- npm test -- DetailPanel
- npm run build
- cargo check (with TEMP/TMP set to LOCALAPPDATA\\Temp because the shell environment currently points them at a literal %USERP~1 path)
