### PR TITLE
fix(ui): improve color contrast

### DIFF
--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -190,7 +190,7 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
               <button
                 type="button"
                 onClick={() => api.restartAsAdmin()}
-                className="text-[10px] text-accent/70 hover:text-accent px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors shrink-0"
+                className="text-[10px] text-accent hover:text-accent-hi px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors shrink-0"
                 title="Restart as administrator to edit system variables"
               >
                 {t("detail.restart_admin")}
@@ -257,7 +257,7 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
                 <button
                   type="button"
                   onClick={() => onStageAddToPath(variable.scope as "User" | "System")}
-                  className="text-[10px] text-accent/70 hover:text-accent px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors"
+                  className="text-[10px] text-accent hover:text-accent-hi px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors"
                   title="Stage adding Envarly install directory to this PATH variable"
                 >
                   {t("detail.add_to_path")}

--- a/src/components/PathBanner/PathBanner.tsx
+++ b/src/components/PathBanner/PathBanner.tsx
@@ -12,7 +12,7 @@ export function PathBanner({ scope, onStageAddToPath, onDismiss }: PathBannerPro
 
   return (
     <div className="flex items-center gap-3 px-5 py-2 bg-accent/10 border-b border-accent/30 text-sm shrink-0">
-      <span className="text-fg/80 flex-1">
+      <span className="text-fg flex-1">
         {t("path_banner.prefix", { scope })}{" "}
         <span className="font-mono text-fg">envarly</span>{" "}
         {t("path_banner.suffix")}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -137,7 +137,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
               secretsOnly
                 ? "bg-warn/20 text-warn border border-warn/40"
-                : "bg-warn/10 text-warn/70 border border-warn/20 hover:bg-warn/15 hover:text-warn",
+                : "bg-warn/10 text-warn border border-warn/40 hover:bg-warn/15 hover:text-warn",
             )}
           >
             <span>⚠</span>
@@ -209,7 +209,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
               {secret && !isDelete && (
                 <span
                   title={secret.label}
-                  className="text-[9px] font-medium text-warn/80 shrink-0 max-w-[44px] truncate"
+                  className="text-[9px] font-medium text-warn shrink-0 max-w-[44px] truncate"
                 >
                   {secret.service}
                 </span>

--- a/src/components/SnapshotPanel/SnapshotDiffRow.tsx
+++ b/src/components/SnapshotPanel/SnapshotDiffRow.tsx
@@ -18,15 +18,15 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
       <td className="px-2 py-1.5 font-mono font-semibold text-fg whitespace-nowrap">
         <span className="flex items-center gap-1.5">
           {entry.name}
-          {secret && <span className="text-[9px] font-medium text-warn/80">{secret.service}</span>}
+          {secret && <span className="text-[9px] font-medium text-warn">{secret.service}</span>}
         </span>
       </td>
       <td className="px-2 py-1.5 text-muted w-12">{entry.scope[0]}</td>
       <td className="px-2 py-1.5 font-mono text-muted max-w-xs truncate">
         {entry.kind === "changed" ? (
           <span className="flex flex-col gap-0.5">
-            <span className="line-through text-danger/70">{mask(entry.oldValue!)}</span>
-            <span className="text-success/90">{mask(entry.newValue!)}</span>
+            <span className="line-through text-danger">{mask(entry.oldValue!)}</span>
+            <span className="text-success">{mask(entry.newValue!)}</span>
           </span>
         ) : (
           <span>{mask(entry.value!)}</span>

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -41,7 +41,7 @@ function ListDiffDelta({ oldValue, newValue }: { oldValue: string; newValue: str
   return (
     <div className="flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto">
       {removed.map((e, i) => (
-        <p key={`r${i}`} className="font-mono text-[11px] text-danger/80 break-all">
+        <p key={`r${i}`} className="font-mono text-[11px] text-danger break-all">
           <span className="select-none mr-1 opacity-70">−</span>{e}
         </p>
       ))}
@@ -72,7 +72,7 @@ function ListDiffFull({ oldValue, newValue }: { oldValue: string; newValue: stri
           key={i}
           className={cn(
             "font-mono text-[11px] break-all",
-            r.status === "removed"   && "text-danger/80 line-through",
+            r.status === "removed"   && "text-danger line-through",
             r.status === "added"     && "text-success",
             r.status === "unchanged" && "text-muted",
           )}
@@ -120,7 +120,7 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
           <p className="text-xs font-semibold text-danger mb-1">
             {t("staged.critical", { count: criticalChanges.length })}
           </p>
-          <p className="text-xs text-danger/80">
+          <p className="text-xs text-danger">
             {t("staged.critical_detail", { count: criticalChanges.length, vars: criticalChanges.map((e) => e.name).join(", ") })}
           </p>
         </div>
@@ -202,7 +202,7 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
                   )
                 ) : (
                   <div className="flex flex-col gap-0.5">
-                    <p className="font-mono text-[11px] text-danger/70 line-through break-all">{entry.oldValue}</p>
+                    <p className="font-mono text-[11px] text-danger line-through break-all">{entry.oldValue}</p>
                     <p className="font-mono text-[11px] text-success break-all">{entry.newValue}</p>
                   </div>
                 )

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -13,8 +13,8 @@ const variantCls: Record<Variant, string> = {
   primary:   "bg-accent text-canvas hover:bg-accent-hi",
   secondary: "border border-rim text-muted hover:bg-hover hover:text-fg",
   ghost:     "text-muted hover:bg-hover hover:text-fg",
-  danger:    "bg-danger/15 text-danger border border-danger/30 hover:bg-danger/25",
-  warn:      "border border-warn/40 text-warn hover:bg-warn/10",
+  danger:    "bg-danger/15 text-danger border border-danger hover:bg-danger/25",
+  warn:      "border border-warn text-warn hover:bg-warn/10",
   link:      "text-muted hover:text-fg hover:underline",
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,15 +5,15 @@
   --color-panel: #161b22;
   --color-surface: #1c2333;
   --color-hover: #21283b;
-  --color-rim: #30363d;
-  --color-rim-subtle: #21262d;
+  --color-rim: #69788c;
+  --color-rim-subtle: #30363d;
   --color-fg: #e6edf3;
-  --color-muted: #7d8590;
-  --color-dim: #7a848f;
+  --color-muted: #99a3ad;
+  --color-dim: #a6b0ba;
   --color-accent: #58a6ff;
   --color-accent-hi: #79bbff;
   --color-success: #3fb950;
-  --color-danger: #f85149;
+  --color-danger: #ff6b65;
   --color-warn: #d29922;
   --color-violet: #bc8cff;
 
@@ -26,17 +26,17 @@
   --color-panel: #f6f8fa;
   --color-surface: #eaeef2;
   --color-hover:  #dde3ea;
-  --color-rim: #d0d7de;
-  --color-rim-subtle: #e7ecf0;
+  --color-rim: #737d88;
+  --color-rim-subtle: #d0d7de;
   --color-fg: #1f2328;
-  --color-muted: #636c76;
-  --color-dim: #697076;
-  --color-accent: #0969da;
-  --color-accent-hi: #0550ae;
-  --color-success: #1a7f37;
-  --color-danger: #cf222e;
-  --color-warn: #9a6700;
-  --color-violet: #8250df;
+  --color-muted: #57606a;
+  --color-dim: #4c5661;
+  --color-accent: #0550ae;
+  --color-accent-hi: #033d8b;
+  --color-success: #116329;
+  --color-danger: #a40e26;
+  --color-warn: #744500;
+  --color-violet: #6639ba;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Adjust dark and light theme tokens to meet WCAG AA contrast targets
- Remove low-contrast alpha text usage in detail, staged, snapshot, sidebar, banner, and button UI
- Strengthen warning/danger borders where they communicate state

## Verification
- `npm run build`
- Contrast token check: text pairs >= 4.5:1, rim borders >= 3:1
- `git diff --check`

## Notes
- `npm run lint` and `npm test -- --run` currently expose existing tooling issues unrelated to this contrast change. Tracked separately in #66.

Fixes #61