### PR TITLE
feat: add demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ envarly export --format ansible  --output backup.yml      # Ansible environment 
 envarly export --format json | jq '.user.PATH'
 ```
 
+## Demo mode
+
+Demo mode opens the GUI with fixture data and keeps every change in memory, so it is safe for screenshots, walkthroughs, and release media.
+
+```sh
+envarly --demo
+envarly --demo --demo-fixture path\to\fixture.json
+envarly --demo-fixture=path\to\fixture.json
+```
+
+The bundled fixture lives at `src/demo/envarly-demo.json`. Custom fixtures use the same shape and can include User/System variables, snapshots, PATH validation results, and an initial baseline for external-change demos.
+
 ## Import / Export (GUI)
 
 Open the **Import / Export** tab.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,13 +2,49 @@ use crate::env_store::{self, EnvSnapshot, EnvVar, VarScope};
 use crate::error::EnvarlyError;
 use crate::path_manage;
 use crate::snapshot::{self, SnapshotMeta};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 pub struct CustomExportVar {
     pub name: String,
     pub value: String,
     pub scope: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchOptions {
+    pub demo: bool,
+    pub demo_fixture: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_launch_options() -> LaunchOptions {
+    let mut args = std::env::args().skip(1);
+    let mut demo = false;
+    let mut demo_fixture = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--demo" => demo = true,
+            "--demo-fixture" => {
+                demo = true;
+                demo_fixture = args.next();
+            }
+            _ if arg.starts_with("--demo-fixture=") => {
+                demo = true;
+                demo_fixture = Some(arg["--demo-fixture=".len()..].to_string());
+            }
+            _ => {}
+        }
+    }
+
+    LaunchOptions { demo, demo_fixture }
+}
+
+#[tauri::command]
+pub fn read_demo_fixture(path: String) -> Result<String, EnvarlyError> {
+    std::fs::read_to_string(path).map_err(EnvarlyError::Registry)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,12 @@ mod snapshot;
 /// Returns normally (unit) when there are no subcommand args, so the caller can launch the GUI.
 #[cfg(windows)]
 pub fn try_run_cli() {
-    if std::env::args().len() <= 1 {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty()
+        || args
+            .iter()
+            .any(|arg| arg == "--demo" || arg.starts_with("--demo-fixture"))
+    {
         return;
     }
     cli::run() // -> !  (either exits 0 on success or exits 1 on error)
@@ -43,6 +48,8 @@ pub fn run() {
             commands::restart_as_admin,
             commands::get_path_status,
             commands::get_path_proposal,
+            commands::get_launch_options,
+            commands::read_demo_fixture,
         ])
         .run(tauri::generate_context!())
         .expect("error while running envarly");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,13 @@ export default function App() {
   const { diffEntries, baselineRef, checkForExternalChanges, handleDiffApply, handleDiffDismiss, applyBusy } =
     useDiff(refresh, setDialog);
 
-  const { handleRefresh } = useAppInit({ baselineRef, setElevated, refreshPathStatus, refresh, checkForExternalChanges });
+  const { handleRefresh } = useAppInit({
+    baselineRef,
+    setElevated,
+    refreshPathStatus,
+    refresh,
+    checkForExternalChanges,
+  });
 
   useKeyboardShortcuts(undo, redo, localUndoRef);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,54 +1,84 @@
-import { invoke } from '@tauri-apps/api/core';
-import type { EnvVar, VarScope, SnapshotMeta } from './types';
+import { invoke } from "@tauri-apps/api/core";
+import { createDemoApi, loadDemoFixture } from "./demo/createDemoApi";
+import type { EnvSnapshot, EnvVar, SnapshotMeta, VarScope } from "./types";
 
-export const api = {
-  getEnvVars: () =>
-    invoke<EnvVar[]>('get_env_vars'),
+export interface LaunchOptions {
+  demo: boolean;
+  demoFixture: string | null;
+}
 
-  setEnvVar: (name: string, value: string, scope: VarScope) =>
-    invoke<void>('set_env_var', { name, value, scope }),
+export interface EnvarlyApi {
+  getLaunchOptions: () => Promise<LaunchOptions>;
+  getEnvVars: () => Promise<EnvVar[]>;
+  setEnvVar: (name: string, value: string, scope: VarScope) => Promise<void>;
+  deleteEnvVar: (name: string, scope: VarScope) => Promise<void>;
+  createSnapshot: (label: string) => Promise<SnapshotMeta>;
+  listSnapshots: () => Promise<SnapshotMeta[]>;
+  deleteSnapshot: (id: string) => Promise<void>;
+  validatePaths: (paths: string[]) => Promise<boolean[]>;
+  getRegistrySnapshot: () => Promise<EnvSnapshot>;
+  isElevated: () => Promise<boolean>;
+  restartAsAdmin: () => Promise<void>;
+  exportVars: (scope: "All" | "User" | "System", format: string) => Promise<string | null>;
+  exportCustomVars: (
+    vars: { name: string; value: string; scope: string }[],
+    format: string,
+  ) => Promise<string | null>;
+  parseImport: (content: string, format: "json" | "reg") => Promise<EnvSnapshot>;
+  getPathStatus: () => Promise<{ installDir: string; userHasEntry: boolean; systemHasEntry: boolean }>;
+  getPathProposal: (scope: "User" | "System") => Promise<string | null>;
+}
 
-  deleteEnvVar: (name: string, scope: VarScope) =>
-    invoke<void>('delete_env_var', { name, scope }),
-
-  createSnapshot: (label: string) =>
-    invoke<SnapshotMeta>('create_snapshot', { label }),
-
-  listSnapshots: () =>
-    invoke<SnapshotMeta[]>('list_snapshots'),
-
-  deleteSnapshot: (id: string) =>
-    invoke<void>('delete_snapshot', { id }),
-
-  validatePaths: (paths: string[]) =>
-    invoke<boolean[]>('validate_paths', { paths }),
-
-  getRegistrySnapshot: () =>
-    invoke<import('./types').EnvSnapshot>('get_registry_snapshot'),
-
-  /** True when the process has write access to HKLM (elevated / admin). */
-  isElevated: () => invoke<boolean>('is_elevated'),
-
-  /** Spawn a new elevated instance via UAC and exit this process. */
-  restartAsAdmin: () => invoke<void>('restart_as_admin'),
-
-  /** Opens a native save dialog, writes the file, and returns the saved path (null = cancelled). */
-  exportVars: (scope: 'All' | 'User' | 'System', format: string) =>
-    invoke<string | null>('export_vars', { scope, format }),
-
-  /** Export a hand-picked list of variables. Values come from the frontend. */
-  exportCustomVars: (vars: { name: string; value: string; scope: string }[], format: string) =>
-    invoke<string | null>('export_custom', { vars, format }),
-
-  /** Parses file content and returns a snapshot. Does NOT write to the registry. */
-  parseImport: (content: string, format: 'json' | 'reg') =>
-    invoke<import('./types').EnvSnapshot>('parse_import', { content, format }),
-
-  /** Returns whether the Envarly install directory is currently in User/System PATH. */
+const normalApi: EnvarlyApi = {
+  getLaunchOptions: () => invoke<LaunchOptions>("get_launch_options"),
+  getEnvVars: () => invoke<EnvVar[]>("get_env_vars"),
+  setEnvVar: (name, value, scope) => invoke<void>("set_env_var", { name, value, scope }),
+  deleteEnvVar: (name, scope) => invoke<void>("delete_env_var", { name, scope }),
+  createSnapshot: (label) => invoke<SnapshotMeta>("create_snapshot", { label }),
+  listSnapshots: () => invoke<SnapshotMeta[]>("list_snapshots"),
+  deleteSnapshot: (id) => invoke<void>("delete_snapshot", { id }),
+  validatePaths: (paths) => invoke<boolean[]>("validate_paths", { paths }),
+  getRegistrySnapshot: () => invoke<EnvSnapshot>("get_registry_snapshot"),
+  isElevated: () => invoke<boolean>("is_elevated"),
+  restartAsAdmin: () => invoke<void>("restart_as_admin"),
+  exportVars: (scope, format) => invoke<string | null>("export_vars", { scope, format }),
+  exportCustomVars: (vars, format) => invoke<string | null>("export_custom", { vars, format }),
+  parseImport: (content, format) => invoke<EnvSnapshot>("parse_import", { content, format }),
   getPathStatus: () =>
-    invoke<{ installDir: string; userHasEntry: boolean; systemHasEntry: boolean }>('get_path_status'),
+    invoke<{ installDir: string; userHasEntry: boolean; systemHasEntry: boolean }>("get_path_status"),
+  getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
+};
 
-  /** Returns proposed new PATH value with Envarly added, or null if already present. */
-  getPathProposal: (scope: 'User' | 'System') =>
-    invoke<string | null>('get_path_proposal', { scope }),
+let apiPromise: Promise<EnvarlyApi> | null = null;
+
+async function getApi(): Promise<EnvarlyApi> {
+  if (!apiPromise) {
+    apiPromise = normalApi
+      .getLaunchOptions()
+      .catch(() => ({ demo: false, demoFixture: null }))
+      .then(async (options) => {
+        if (!options.demo) return normalApi;
+        return createDemoApi(options, await loadDemoFixture(options), normalApi);
+      });
+  }
+  return apiPromise;
+}
+
+export const api: EnvarlyApi = {
+  getLaunchOptions: async () => (await getApi()).getLaunchOptions(),
+  getEnvVars: async () => (await getApi()).getEnvVars(),
+  setEnvVar: async (name, value, scope) => (await getApi()).setEnvVar(name, value, scope),
+  deleteEnvVar: async (name, scope) => (await getApi()).deleteEnvVar(name, scope),
+  createSnapshot: async (label) => (await getApi()).createSnapshot(label),
+  listSnapshots: async () => (await getApi()).listSnapshots(),
+  deleteSnapshot: async (id) => (await getApi()).deleteSnapshot(id),
+  validatePaths: async (paths) => (await getApi()).validatePaths(paths),
+  getRegistrySnapshot: async () => (await getApi()).getRegistrySnapshot(),
+  isElevated: async () => (await getApi()).isElevated(),
+  restartAsAdmin: async () => (await getApi()).restartAsAdmin(),
+  exportVars: async (scope, format) => (await getApi()).exportVars(scope, format),
+  exportCustomVars: async (vars, format) => (await getApi()).exportCustomVars(vars, format),
+  parseImport: async (content, format) => (await getApi()).parseImport(content, format),
+  getPathStatus: async () => (await getApi()).getPathStatus(),
+  getPathProposal: async (scope) => (await getApi()).getPathProposal(scope),
 };

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -1,0 +1,134 @@
+import { invoke } from "@tauri-apps/api/core";
+import bundledFixture from "./envarly-demo.json";
+import type { EnvarlyApi, LaunchOptions } from "../api";
+import type { EnvSnapshot, EnvVar, SnapshotMeta, VarScope } from "../types";
+
+interface DemoFixture {
+  elevated: boolean;
+  installDir: string;
+  pathStatus: {
+    userHasEntry: boolean;
+    systemHasEntry: boolean;
+  };
+  pathExists: Record<string, boolean>;
+  baseline?: EnvSnapshot;
+  current: EnvSnapshot;
+  snapshots: SnapshotMeta[];
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function inferListSeparator(name: string, value: string): ";" | "," | null {
+  const upper = name.toUpperCase();
+  if (upper === "PATH" || upper === "PATHEXT") return ";";
+  if (upper === "NO_PROXY" || upper === "NOPROXY") return ",";
+  if (value.includes(";") && value.split(";").some((part) => part.includes("\\"))) return ";";
+  return null;
+}
+
+function snapshotToVars(snapshot: EnvSnapshot): EnvVar[] {
+  return (["User", "System"] as const).flatMap((scope) => {
+    const entries = scope === "User" ? snapshot.user : snapshot.system;
+    return Object.entries(entries).map(([name, value]) => ({
+      name,
+      value,
+      scope,
+      listSeparator: inferListSeparator(name, value),
+    }));
+  });
+}
+
+function scopedRecord(snapshot: EnvSnapshot, scope: VarScope) {
+  return scope === "User" ? snapshot.user : snapshot.system;
+}
+
+function parseJsonSnapshot(content: string): EnvSnapshot {
+  const parsed = JSON.parse(content) as Partial<EnvSnapshot>;
+  return {
+    user: parsed.user ?? {},
+    system: parsed.system ?? {},
+  };
+}
+
+export async function loadDemoFixture(options: LaunchOptions): Promise<DemoFixture> {
+  if (!options.demoFixture) return clone(bundledFixture as unknown as DemoFixture);
+  const content = await invoke<string>("read_demo_fixture", { path: options.demoFixture });
+  return JSON.parse(content) as DemoFixture;
+}
+
+export function createDemoApi(
+  options: LaunchOptions,
+  fixture: DemoFixture,
+  fallbackApi: EnvarlyApi,
+): EnvarlyApi {
+  let current = clone(fixture.current);
+  let snapshots = clone(fixture.snapshots);
+  let pendingBaseline = fixture.baseline ? clone(fixture.baseline) : null;
+
+  const snapshot = () => clone(current);
+
+  return {
+    getLaunchOptions: async () => options,
+    getEnvVars: async () => snapshotToVars(current),
+    setEnvVar: async (name, value, scope) => {
+      scopedRecord(current, scope)[name] = value;
+    },
+    deleteEnvVar: async (name, scope) => {
+      delete scopedRecord(current, scope)[name];
+    },
+    createSnapshot: async (label) => {
+      const created: SnapshotMeta = {
+        id: `demo-${Date.now()}`,
+        createdAt: new Date().toISOString(),
+        label,
+        snapshot: snapshot(),
+      };
+      snapshots = [created, ...snapshots];
+      return clone(created);
+    },
+    listSnapshots: async () => clone(snapshots),
+    deleteSnapshot: async (id) => {
+      snapshots = snapshots.filter((snap) => snap.id !== id);
+    },
+    validatePaths: async (paths) =>
+      paths.map((path) => {
+        const normalized = path.trim();
+        if (normalized in fixture.pathExists) return fixture.pathExists[normalized];
+        return !normalized.toLowerCase().includes("missing") && !normalized.toLowerCase().includes("oldtools");
+      }),
+    getRegistrySnapshot: async () => {
+      if (pendingBaseline) {
+        const baseline = pendingBaseline;
+        pendingBaseline = null;
+        return baseline;
+      }
+      return snapshot();
+    },
+    isElevated: async () => fixture.elevated,
+    restartAsAdmin: async () => undefined,
+    exportVars: async (_scope, format) => `C:\\Users\\Demo\\Downloads\\envarly-demo.${format === "reg" ? "reg" : "json"}`,
+    exportCustomVars: async (_vars, format) =>
+      `C:\\Users\\Demo\\Downloads\\envarly-demo-custom.${format === "reg" ? "reg" : "json"}`,
+    parseImport: async (content, format) => {
+      if (format !== "json") {
+        return fallbackApi.parseImport(content, format);
+      }
+      return parseJsonSnapshot(content);
+    },
+    getPathStatus: async () => ({
+      installDir: fixture.installDir,
+      userHasEntry: fixture.pathStatus.userHasEntry,
+      systemHasEntry: fixture.pathStatus.systemHasEntry,
+    }),
+    getPathProposal: async (scope) => {
+      const path = scopedRecord(current, scope).Path ?? "";
+      const entries = path.split(";").filter(Boolean);
+      if (entries.some((entry) => entry.toLowerCase() === fixture.installDir.toLowerCase())) {
+        return null;
+      }
+      return [fixture.installDir, ...entries].join(";");
+    },
+  };
+}

--- a/src/demo/envarly-demo.json
+++ b/src/demo/envarly-demo.json
@@ -1,0 +1,111 @@
+{
+  "elevated": false,
+  "installDir": "C:\\Program Files\\Envarly",
+  "pathStatus": {
+    "userHasEntry": false,
+    "systemHasEntry": true
+  },
+  "pathExists": {
+    "C:\\Program Files\\Envarly": true,
+    "C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312\\Scripts": true,
+    "C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312": true,
+    "C:\\Program Files\\nodejs": true,
+    "C:\\Program Files\\Git\\cmd": true,
+    "C:\\Users\\demo\\.cargo\\bin": true,
+    "C:\\Users\\demo\\Tools\\missing-bin": false,
+    "C:\\Windows\\System32": true,
+    "C:\\Windows": true,
+    "C:\\Program Files\\PowerShell\\7": true,
+    "C:\\OldTools\\Java\\bin": false
+  },
+  "baseline": {
+    "user": {
+      "Path": "C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312\\Scripts;C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312;C:\\Program Files\\nodejs;C:\\Program Files\\Git\\cmd;C:\\Users\\demo\\Tools\\missing-bin",
+      "JAVA_HOME": "C:\\Program Files\\Java\\jdk-17",
+      "NO_PROXY": "localhost,127.0.0.1,.local",
+      "OPENAI_API_KEY": "sk-proj-demoDemoDemoDemoDemoDemoDemoDemoDemoDemoDemo",
+      "DATABASE_URL": "postgres://demo_user:demo_password@localhost:5432/envarly_demo"
+    },
+    "system": {
+      "Path": "C:\\Windows\\System32;C:\\Windows;C:\\Program Files\\PowerShell\\7;C:\\OldTools\\Java\\bin",
+      "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+      "TEMP": "C:\\Windows\\Temp",
+      "TMP": "C:\\Windows\\Temp"
+    }
+  },
+  "current": {
+    "user": {
+      "Path": "C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312\\Scripts;C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312;C:\\Program Files\\nodejs;C:\\Program Files\\Git\\cmd;C:\\Users\\demo\\.cargo\\bin;C:\\Users\\demo\\Tools\\missing-bin",
+      "JAVA_HOME": "C:\\Program Files\\Java\\jdk-21",
+      "NO_PROXY": "localhost,127.0.0.1,.local,*.internal",
+      "OPENAI_API_KEY": "sk-proj-demoDemoDemoDemoDemoDemoDemoDemoDemoDemoDemo",
+      "DATABASE_URL": "postgres://demo_user:demo_password@localhost:5432/envarly_demo",
+      "GITHUB_TOKEN": "ghp_demoDemoDemoDemoDemoDemoDemoDemo"
+    },
+    "system": {
+      "Path": "C:\\Windows\\System32;C:\\Windows;C:\\Program Files\\PowerShell\\7;C:\\OldTools\\Java\\bin",
+      "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+      "TEMP": "C:\\Windows\\Temp",
+      "TMP": "C:\\Windows\\Temp"
+    }
+  },
+  "snapshots": [
+    {
+      "id": "demo-clean-dev",
+      "createdAt": "2026-07-01T09:00:00.000Z",
+      "label": "Clean developer setup",
+      "snapshot": {
+        "user": {
+          "Path": "C:\\Program Files\\Envarly;C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312\\Scripts;C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312;C:\\Program Files\\nodejs;C:\\Program Files\\Git\\cmd;C:\\Users\\demo\\.cargo\\bin",
+          "JAVA_HOME": "C:\\Program Files\\Java\\jdk-21",
+          "NO_PROXY": "localhost,127.0.0.1,.local,*.internal",
+          "OPENAI_API_KEY": "sk-proj-demoDemoDemoDemoDemoDemoDemoDemoDemoDemoDemo"
+        },
+        "system": {
+          "Path": "C:\\Windows\\System32;C:\\Windows;C:\\Program Files\\PowerShell\\7",
+          "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+          "TEMP": "C:\\Windows\\Temp",
+          "TMP": "C:\\Windows\\Temp"
+        }
+      }
+    },
+    {
+      "id": "demo-before-node-upgrade",
+      "createdAt": "2026-06-21T15:30:00.000Z",
+      "label": "Before Node upgrade",
+      "snapshot": {
+        "user": {
+          "Path": "C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312\\Scripts;C:\\Users\\demo\\AppData\\Local\\Programs\\Python\\Python312;C:\\Program Files\\nodejs;C:\\Program Files\\Git\\cmd",
+          "JAVA_HOME": "C:\\Program Files\\Java\\jdk-17",
+          "NO_PROXY": "localhost,127.0.0.1,.local",
+          "DATABASE_URL": "postgres://demo_user:demo_password@localhost:5432/envarly_demo"
+        },
+        "system": {
+          "Path": "C:\\Windows\\System32;C:\\Windows;C:\\Program Files\\PowerShell\\7;C:\\OldTools\\Java\\bin",
+          "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+          "TEMP": "C:\\Windows\\Temp",
+          "TMP": "C:\\Windows\\Temp"
+        }
+      }
+    },
+    {
+      "id": "demo-broken-path",
+      "createdAt": "2026-06-15T08:15:00.000Z",
+      "label": "Broken PATH example",
+      "snapshot": {
+        "user": {
+          "Path": "C:\\Users\\demo\\Tools\\missing-bin;C:\\OldTools\\Java\\bin;C:\\Program Files\\Git\\cmd",
+          "JAVA_HOME": "C:\\OldTools\\Java",
+          "NO_PROXY": "localhost,127.0.0.1",
+          "GITHUB_TOKEN": "ghp_demoDemoDemoDemoDemoDemoDemoDemo"
+        },
+        "system": {
+          "Path": "C:\\Windows\\System32;C:\\Windows;C:\\OldTools\\Java\\bin",
+          "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+          "TEMP": "C:\\Windows\\Temp",
+          "TMP": "C:\\Windows\\Temp"
+        }
+      }
+    }
+  ]
+}

--- a/src/hooks/useAppInit.ts
+++ b/src/hooks/useAppInit.ts
@@ -11,11 +11,21 @@ interface Params {
   checkForExternalChanges: () => Promise<void>;
 }
 
-export function useAppInit({ baselineRef, setElevated, refreshPathStatus, refresh, checkForExternalChanges }: Params) {
+export function useAppInit({
+  baselineRef,
+  setElevated,
+  refreshPathStatus,
+  refresh,
+  checkForExternalChanges,
+}: Params) {
   useEffect(() => {
     (async () => {
-      try { baselineRef.current = await api.getRegistrySnapshot(); } catch { }
-      try { setElevated(await api.isElevated()); } catch { }
+      try {
+        baselineRef.current = await api.getRegistrySnapshot();
+      } catch {}
+      try {
+        setElevated(await api.isElevated());
+      } catch {}
       await refreshPathStatus();
       refresh();
     })();


### PR DESCRIPTION
## Summary
- add GUI demo mode behind `--demo`
- support external fixture JSON via `--demo-fixture <path>` / `--demo-fixture=path`
- keep demo writes in memory through a demo API adapter, with a bundled scenario fixture and README usage notes

## Verification
- `npm run build`
- `npm test -- --run src/hooks/useAppInit.test.ts`
- `cargo check`
- `cargo test`
- `git diff --check`

## Notes
- `npm run lint` still stops on the existing Biome config error: `files.ignore` is no longer a known key.
- Full `npm test -- --run` still fails only in the existing `useTheme.test.ts` localStorage setup; 19 files / 197 tests passed.