### PR TITLE
chore: reduce biome warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,11 +21,7 @@
       "preset": "recommended",
       "correctness": {
         "noUnusedVariables": "warn",
-        "noUnusedImports": "warn",
-        "useExhaustiveDependencies": "warn"
-      },
-      "style": {
-        "noNonNullAssertion": "warn"
+        "noUnusedImports": "warn"
       }
     }
   },

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { useI18n } from "../../hooks/useI18n";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../api";
+import { useI18n } from "../../hooks/useI18n";
 import { useLocalHistory } from "../../hooks/useLocalHistory";
 import type { StagedChange } from "../../hooks/useStaged";
 import { stagedKey } from "../../hooks/useStaged";
@@ -58,13 +58,31 @@ function looksLikeSinglePath(name: string, value: string) {
     return true;
   }
 
-  return /^[a-z]:[\\/]/i.test(trimmedValue) || trimmedValue.startsWith("/") || trimmedValue.startsWith("\\\\");
+  return (
+    /^[a-z]:[\\/]/i.test(trimmedValue) ||
+    trimmedValue.startsWith("/") ||
+    trimmedValue.startsWith("\\\\")
+  );
 }
 
-export function DetailPanel({ variable, allVars, elevated, userPathInEnv, systemPathInEnv, staged, onStage, onStageDelete, onUnstage, onStageAddToPath, onRegisterLocalUndo }: Props) {
+export function DetailPanel({
+  variable,
+  allVars,
+  elevated,
+  userPathInEnv,
+  systemPathInEnv,
+  staged,
+  onStage,
+  onStageDelete,
+  onUnstage,
+  onStageAddToPath,
+  onRegisterLocalUndo,
+}: Props) {
   const { t } = useI18n();
   const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | null>(null);
   const prevVarRef = useRef<{ name: string; scope: string } | null>(null);
+  const variableName = variable?.name;
+  const variableScope = variable?.scope;
 
   const {
     value,
@@ -77,30 +95,38 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
 
   // Reset overrideSeparator only when the variable identity changes (not on value-only updates).
   useEffect(() => {
-    if (!variable) return;
+    if (!variableName || !variableScope) return;
     const isSameVar =
-      prevVarRef.current?.name === variable.name &&
-      prevVarRef.current?.scope === variable.scope;
+      prevVarRef.current?.name === variableName && prevVarRef.current?.scope === variableScope;
     if (!isSameVar) setOverrideSeparator(null);
-    prevVarRef.current = { name: variable.name, scope: variable.scope };
-  }, [variable?.name, variable?.scope]);
+    prevVarRef.current = { name: variableName, scope: variableScope };
+  }, [variableName, variableScope]);
 
   useEffect(() => {
     if (!onRegisterLocalUndo) return;
     onRegisterLocalUndo(dirty ? handleDiscard : null);
-    return () => { onRegisterLocalUndo(null); };
+    return () => {
+      onRegisterLocalUndo(null);
+    };
   }, [dirty, handleDiscard, onRegisterLocalUndo]);
 
   const expandedValue = useMemo(() => {
     if (!value.includes("%")) return null;
     const lookup = new Map<string, string>();
-    allVars.filter((v) => v.scope === "System").forEach((v) => {
-      lookup.set(v.name.toUpperCase(), v.value);
-    });
-    allVars.filter((v) => v.scope === "User").forEach((v) => {
-      lookup.set(v.name.toUpperCase(), v.value);
-    });
-    const expanded = value.replace(/%([^%]+)%/g, (match, name: string) => lookup.get(name.toUpperCase()) ?? match);
+    allVars
+      .filter((v) => v.scope === "System")
+      .forEach((v) => {
+        lookup.set(v.name.toUpperCase(), v.value);
+      });
+    allVars
+      .filter((v) => v.scope === "User")
+      .forEach((v) => {
+        lookup.set(v.name.toUpperCase(), v.value);
+      });
+    const expanded = value.replace(
+      /%([^%]+)%/g,
+      (match, name: string) => lookup.get(name.toUpperCase()) ?? match,
+    );
     return expanded !== value ? expanded : null;
   }, [value, allVars]);
 
@@ -123,7 +149,8 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
   };
 
   const handleDelete = () => {
-    if (!confirm(t("detail.confirm_delete", { name: variable.name, scope: variable.scope }))) return;
+    if (!confirm(t("detail.confirm_delete", { name: variable.name, scope: variable.scope })))
+      return;
     onStageDelete(variable.name, variable.scope);
   };
 
@@ -155,17 +182,20 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
 
   const effectiveSeparator = overrideSeparator ?? variable.listSeparator;
   const readOnly = variable.scope === "System" && !elevated;
-  const showFolderPicker = !readOnly && effectiveSeparator === null && looksLikeSinglePath(variable.name, value);
+  const showFolderPicker =
+    !readOnly && effectiveSeparator === null && looksLikeSinglePath(variable.name, value);
   const description = lookupEnvDescription(variable.name);
   const isPathVar = variable.name.toUpperCase() === "PATH";
   const pathInEnvForScope = variable.scope === "System" ? systemPathInEnv : userPathInEnv;
-  const showAddToPathHint = isPathVar && !pathInEnvForScope && !isStagedDelete
-    && (variable.scope === "User" || elevated);
+  const showAddToPathHint =
+    isPathVar && !pathInEnvForScope && !isStagedDelete && (variable.scope === "User" || elevated);
 
   const editorLabel =
-    effectiveSeparator === ";" ? t("detail.label_path") :
-    effectiveSeparator === "," ? t("detail.label_list") :
-    t("detail.label_value");
+    effectiveSeparator === ";"
+      ? t("detail.label_path")
+      : effectiveSeparator === ","
+        ? t("detail.label_list")
+        : t("detail.label_value");
 
   const entriesCount = effectiveSeparator
     ? value.split(effectiveSeparator).filter((p) => p.trim()).length
@@ -177,9 +207,7 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
       <div className="flex items-center gap-3 px-6 h-[60px] border-b border-rim-subtle shrink-0">
         <div className="flex items-center gap-2.5 flex-1 min-w-0">
           <h2 className="font-mono font-semibold text-base text-fg truncate">{variable.name}</h2>
-          <Badge variant={variable.scope === "User" ? "user" : "system"}>
-            {variable.scope}
-          </Badge>
+          <Badge variant={variable.scope === "User" ? "user" : "system"}>{variable.scope}</Badge>
           {readOnly && (
             <>
               <Badge variant="readonly">{t("detail.readonly_badge")}</Badge>
@@ -208,13 +236,21 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
         <div className="flex gap-2 shrink-0">
           {dirty ? (
             <>
-              <Button variant="primary" size="sm" onClick={handleApply}>{t("detail.stage")}</Button>
-              <Button variant="ghost" size="sm" onClick={handleDiscard}>{t("detail.discard")}</Button>
+              <Button variant="primary" size="sm" onClick={handleApply}>
+                {t("detail.stage")}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleDiscard}>
+                {t("detail.discard")}
+              </Button>
             </>
           ) : isStagedSet ? (
-            <Button variant="ghost" size="sm" onClick={handleUnstage}>{t("detail.unstage")}</Button>
+            <Button variant="ghost" size="sm" onClick={handleUnstage}>
+              {t("detail.unstage")}
+            </Button>
           ) : !isStagedDelete && !readOnly ? (
-            <Button variant="danger" size="sm" onClick={handleDelete}>{t("detail.delete")}</Button>
+            <Button variant="danger" size="sm" onClick={handleDelete}>
+              {t("detail.delete")}
+            </Button>
           ) : null}
         </div>
       </div>
@@ -239,16 +275,21 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
             {t("detail.staged_delete_title", { name: variable.name })}
           </p>
           <p className="text-xs text-center">
-            {t("detail.original_value_label")} <span className="font-mono text-muted">{stagedChange.originalValue}</span>
+            {t("detail.original_value_label")}{" "}
+            <span className="font-mono text-muted">{stagedChange.originalValue}</span>
           </p>
-          <Button variant="secondary" size="md" onClick={handleUnstage}>{t("detail.unstage")}</Button>
+          <Button variant="secondary" size="md" onClick={handleUnstage}>
+            {t("detail.unstage")}
+          </Button>
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-4">
           {/* Editor label + mode toggle */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <p className="text-sm font-semibold text-muted uppercase tracking-wide">{editorLabel}</p>
+              <p className="text-sm font-semibold text-muted uppercase tracking-wide">
+                {editorLabel}
+              </p>
               {showAddToPathHint && (
                 <button
                   type="button"
@@ -300,7 +341,12 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
               onBeforeReorder={onBeforeStructuralChange}
             />
           ) : effectiveSeparator === "," ? (
-            <ListEditor separator="," rawValue={value} onChange={handleValueChange} readOnly={readOnly} />
+            <ListEditor
+              separator=","
+              rawValue={value}
+              onChange={handleValueChange}
+              readOnly={readOnly}
+            />
           ) : (
             <div className="group relative">
               <Textarea
@@ -333,12 +379,22 @@ export function DetailPanel({ variable, allVars, elevated, userPathInEnv, system
               [t("detail.meta_length_label"), t("detail.meta_length", { count: value.length })],
               ...(entriesCount !== null ? [[t("detail.meta_entries"), String(entriesCount)]] : []),
               ...(expandedValue !== null
-                ? [[t("detail.meta_expanded"), expandedValue.length > 60 ? `${expandedValue.slice(0, 60)}…` : expandedValue]]
+                ? [
+                    [
+                      t("detail.meta_expanded"),
+                      expandedValue.length > 60 ? `${expandedValue.slice(0, 60)}…` : expandedValue,
+                    ],
+                  ]
                 : []),
               ...(isStagedSet && stagedChange.originalValue !== null
-                ? [[t("detail.meta_original"), stagedChange.originalValue.length > 40
-                    ? `${stagedChange.originalValue.slice(0, 40)}…`
-                    : stagedChange.originalValue]]
+                ? [
+                    [
+                      t("detail.meta_original"),
+                      stagedChange.originalValue.length > 40
+                        ? `${stagedChange.originalValue.slice(0, 40)}…`
+                        : stagedChange.originalValue,
+                    ],
+                  ]
                 : []),
             ].map(([label, val]) => (
               <div key={label} className="flex gap-3 text-sm">

--- a/src/components/DiffPanel/EntryRow.tsx
+++ b/src/components/DiffPanel/EntryRow.tsx
@@ -1,5 +1,5 @@
-import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import { useState } from "react";
+import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import { cn } from "../../lib/cn";
 import type { DiffEntry } from "../../lib/diff";
 import { Icon } from "../ui/Icon";
@@ -27,7 +27,7 @@ function pathLines(value: string) {
 }
 
 function isLongOrPath(entry: DiffEntry): boolean {
-  const val = entry.kind === "changed" ? entry.oldValue! : entry.value ?? "";
+  const val = entry.kind === "changed" ? entry.oldValue : entry.value;
   return val.includes(";") || val.length > 80;
 }
 
@@ -43,9 +43,9 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
   const showExpand = isLongOrPath(entry);
 
   const displayOld =
-    entry.kind === "changed" ? entry.oldValue! : entry.kind === "removed" ? entry.value! : "";
+    entry.kind === "changed" ? entry.oldValue : entry.kind === "removed" ? entry.value : "";
   const displayNew =
-    entry.kind === "changed" ? entry.newValue! : entry.kind === "added" ? entry.value! : "";
+    entry.kind === "changed" ? entry.newValue : entry.kind === "added" ? entry.value : "";
 
   return (
     <div
@@ -64,9 +64,18 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
           aria-label={`${entry.kind} ${entry.name}`}
         />
         <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", KIND_DOT[entry.kind])} />
-        <span className="font-mono text-xs font-semibold text-fg truncate flex-1">{entry.name}</span>
-        <span className="text-[10px] uppercase tracking-wide font-semibold shrink-0 opacity-70">{entry.scope}</span>
-        <span className={cn("text-[10px] uppercase tracking-wide font-semibold shrink-0 px-1.5 py-0.5 rounded", KIND_COLORS[entry.kind])}>
+        <span className="font-mono text-xs font-semibold text-fg truncate flex-1">
+          {entry.name}
+        </span>
+        <span className="text-[10px] uppercase tracking-wide font-semibold shrink-0 opacity-70">
+          {entry.scope}
+        </span>
+        <span
+          className={cn(
+            "text-[10px] uppercase tracking-wide font-semibold shrink-0 px-1.5 py-0.5 rounded",
+            KIND_COLORS[entry.kind],
+          )}
+        >
           {KIND_LABEL[entry.kind]}
         </span>
         {showExpand && (
@@ -83,7 +92,9 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
       {!showExpand && (
         <div className="px-3 pb-2 flex flex-col gap-1">
           {(entry.kind === "removed" || entry.kind === "changed") && (
-            <p className="font-mono text-[11px] text-danger line-through opacity-70 truncate">{displayOld}</p>
+            <p className="font-mono text-[11px] text-danger line-through opacity-70 truncate">
+              {displayOld}
+            </p>
           )}
           {(entry.kind === "added" || entry.kind === "changed") && (
             <p className="font-mono text-[11px] text-success truncate">{displayNew}</p>
@@ -119,8 +130,14 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
             </div>
           ) : (
             <div className="flex flex-col gap-1">
-              {displayOld && <p className="font-mono text-[11px] text-danger line-through break-all">{displayOld}</p>}
-              {displayNew && <p className="font-mono text-[11px] text-success break-all">{displayNew}</p>}
+              {displayOld && (
+                <p className="font-mono text-[11px] text-danger line-through break-all">
+                  {displayOld}
+                </p>
+              )}
+              {displayNew && (
+                <p className="font-mono text-[11px] text-success break-all">{displayNew}</p>
+              )}
             </div>
           )}
         </div>

--- a/src/components/ImportExportPanel/ExportTab.tsx
+++ b/src/components/ImportExportPanel/ExportTab.tsx
@@ -1,29 +1,36 @@
 import { useEffect, useState } from "react";
-import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
-import { type SecretInfo, resolveSecret } from "../../lib/secrets";
+import { useI18n } from "../../hooks/useI18n";
+import { resolveSecret, type SecretInfo } from "../../lib/secrets";
 import type { EnvVar } from "../../types";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { SegmentedControl } from "../ui/SegmentedControl";
+import {
+  type AnyFormat,
+  type ExportScope,
+  type FlatVar,
+  formatOptions,
+  scopeOptions,
+  varKey,
+} from "./types";
 import { SecretBanner, VarTable } from "./VarTable";
-import { type AnyFormat, type ExportScope, type FlatVar, formatOptions, scopeOptions, varKey } from "./types";
 
 const FORMAT_EXT: Record<AnyFormat, string> = {
-  json:    ".json",
-  reg:     ".reg",
-  ps1:     ".ps1",
-  dsc_v2:  ".ps1",
-  dsc_v3:  ".dsc.yaml",
+  json: ".json",
+  reg: ".reg",
+  ps1: ".ps1",
+  dsc_v2: ".ps1",
+  dsc_v3: ".dsc.yaml",
   ansible: ".yml",
 };
 
 const FORMAT_DESC: Record<AnyFormat, string> = {
-  json:    "Envarly JSON — can be re-imported into Envarly.",
-  reg:     "Windows Registry Editor format — double-click to merge into the registry directly.",
-  ps1:     "PowerShell script — SetEnvironmentVariable calls.",
-  dsc_v2:  "PowerShell DSC v2 — Configuration block using PSDscResources.",
-  dsc_v3:  "DSC v3 YAML — Microsoft's cross-platform DSC format.",
+  json: "Envarly JSON — can be re-imported into Envarly.",
+  reg: "Windows Registry Editor format — double-click to merge into the registry directly.",
+  ps1: "PowerShell script — SetEnvironmentVariable calls.",
+  dsc_v2: "PowerShell DSC v2 — Configuration block using PSDscResources.",
+  dsc_v3: "DSC v3 YAML — Microsoft's cross-platform DSC format.",
   ansible: "Ansible playbook — win_environment tasks.",
 };
 
@@ -39,13 +46,15 @@ function ExportConfirm({ secretServices, onConfirm, onCancel }: ExportConfirmPro
     <div className="flex flex-col gap-3 p-3 rounded border border-warn/40 bg-warn/10">
       <p className="flex gap-2 text-warn text-xs">
         <Icon name="warning" size={14} className="mt-px" />
-        <span>
-          {t("export.secret_warning", { services: secretServices.join(", ") })}
-        </span>
+        <span>{t("export.secret_warning", { services: secretServices.join(", ") })}</span>
       </p>
       <div className="flex gap-2">
-        <Button variant="primary" size="sm" onClick={onConfirm}>{t("export.export_anyway")}</Button>
-        <Button variant="ghost" size="sm" onClick={onCancel}>{t("export.cancel")}</Button>
+        <Button variant="primary" size="sm" onClick={onConfirm}>
+          {t("export.export_anyway")}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          {t("export.cancel")}
+        </Button>
       </div>
     </div>
   );
@@ -71,7 +80,8 @@ export function ExportTab({ onStatus }: ExportTabProps) {
     if (scope !== "Custom") return;
     if (allVars !== null) return;
     setLoadingVars(true);
-    api.getEnvVars()
+    api
+      .getEnvVars()
       .then((vars: EnvVar[]) => {
         const flat: FlatVar[] = vars.map((v) => ({ name: v.name, value: v.value, scope: v.scope }));
         setAllVars(flat);
@@ -79,7 +89,7 @@ export function ExportTab({ onStatus }: ExportTabProps) {
       })
       .catch(() => onStatus(t("export.failed_load")))
       .finally(() => setLoadingVars(false));
-  }, [scope]);
+  }, [scope, allVars, onStatus, t]);
 
   const handleScopeChange = (s: ExportScope) => {
     setScope(s);
@@ -164,13 +174,28 @@ export function ExportTab({ onStatus }: ExportTabProps) {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
-        <span className="text-xs font-medium text-muted uppercase tracking-wide">{t("export.scope_label")}</span>
-        <SegmentedControl aria-label="Export scope" options={scopeOptions} value={scope} onChange={handleScopeChange} />
+        <span className="text-xs font-medium text-muted uppercase tracking-wide">
+          {t("export.scope_label")}
+        </span>
+        <SegmentedControl
+          aria-label="Export scope"
+          options={scopeOptions}
+          value={scope}
+          onChange={handleScopeChange}
+        />
       </div>
 
       <div className="flex flex-col gap-2">
-        <span className="text-xs font-medium text-muted uppercase tracking-wide">{t("export.format_label")}</span>
-        <SegmentedControl aria-label="Export format" options={formatOptions} value={format} onChange={setFormat} className="flex-wrap" />
+        <span className="text-xs font-medium text-muted uppercase tracking-wide">
+          {t("export.format_label")}
+        </span>
+        <SegmentedControl
+          aria-label="Export format"
+          options={formatOptions}
+          value={format}
+          onChange={setFormat}
+          className="flex-wrap"
+        />
         <p className="text-xs text-dim">{FORMAT_DESC[format]}</p>
       </div>
 
@@ -184,7 +209,9 @@ export function ExportTab({ onStatus }: ExportTabProps) {
                 vars={allVars}
                 checked={checked}
                 onToggle={(key) => setChecked((prev) => ({ ...prev, [key]: !prev[key] }))}
-                onToggleAll={(val) => setChecked(Object.fromEntries((allVars ?? []).map((v) => [varKey(v), val])))}
+                onToggleAll={(val) =>
+                  setChecked(Object.fromEntries((allVars ?? []).map((v) => [varKey(v), val])))
+                }
               />
             </>
           )}
@@ -195,7 +222,10 @@ export function ExportTab({ onStatus }: ExportTabProps) {
         <ExportConfirm
           secretServices={pendingSecretServices}
           onConfirm={() => void doExport()}
-          onCancel={() => { setPendingExport(false); setPendingSecretServices([]); }}
+          onCancel={() => {
+            setPendingExport(false);
+            setPendingSecretServices([]);
+          }}
         />
       ) : (
         <Button
@@ -205,9 +235,13 @@ export function ExportTab({ onStatus }: ExportTabProps) {
           disabled={busy || !canExport || checkingSecrets}
           className="self-start"
         >
-          {checkingSecrets ? t("export.checking") : busy ? t("export.exporting") : scope === "Custom"
-            ? t("export.custom_btn", { count: selectedCustomVars.length, ext })
-            : t("export.scope_btn", { scope, ext })}
+          {checkingSecrets
+            ? t("export.checking")
+            : busy
+              ? t("export.exporting")
+              : scope === "Custom"
+                ? t("export.custom_btn", { count: selectedCustomVars.length, ext })
+                : t("export.scope_btn", { scope, ext })}
         </Button>
       )}
     </div>

--- a/src/components/ListEditor/ListEditor.tsx
+++ b/src/components/ListEditor/ListEditor.tsx
@@ -13,11 +13,12 @@ export function ListEditor({ separator, rawValue, onChange, readOnly = false }: 
   const [entries, setEntries] = useState<ListEntry[]>([]);
 
   useEffect(() => {
-    const current = entries.map((e) => e.value).join(separator);
-    if (current === rawValue) return;
-    const parts = rawValue.split(separator).filter((p) => p.trim().length > 0);
-    setEntries(parts.map((value, i) => ({ id: `${i}-${value}`, value })));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    setEntries((prev) => {
+      const current = prev.map((e) => e.value).join(separator);
+      if (current === rawValue) return prev;
+      const parts = rawValue.split(separator).filter((p) => p.trim().length > 0);
+      return parts.map((value, i) => ({ id: `${i}-${value}`, value }));
+    });
   }, [rawValue, separator]);
 
   const handleEntriesChange = (next: ListEntry[]) => {

--- a/src/components/PathEditor/PathEditor.tsx
+++ b/src/components/PathEditor/PathEditor.tsx
@@ -19,7 +19,14 @@ interface Props {
   onBeforeReorder?: () => void;
 }
 
-export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skipPathValidation = false, onBeforeReorder }: Props) {
+export function PathEditor({
+  rawValue,
+  onChange,
+  readOnly = false,
+  allVars,
+  skipPathValidation = false,
+  onBeforeReorder,
+}: Props) {
   const [entries, setEntries] = useState<ListEntry[]>([]);
   // Lint runs against lintedValue, which only updates on blur or when rawValue changes while not focused.
   const [lintedValue, setLintedValue] = useState(rawValue);
@@ -32,21 +39,28 @@ export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skip
 
   // Parse rawValue → entries. Guard prevents reset when the change originated here.
   useEffect(() => {
-    const current = entries.map((e) => e.value).join(";");
-    if (current === rawValue) return;
-    const parts = rawValue.split(";").filter((p) => p.trim().length > 0);
-    // Reuse existing entry IDs to preserve DOM nodes and focus across undo operations.
-    // 1. Value match  — handles drag undo (same values, reordered).
-    // 2. Index match  — handles text-edit undo (same position, different value).
-    const pool = entries.map((e, i) => ({ e, i, used: false }));
-    setEntries(parts.map((value, i) => {
-      const byVal = pool.find((p) => !p.used && p.e.value === value);
-      if (byVal) { byVal.used = true; return byVal.e; }
-      const byIdx = pool.find((p) => !p.used && p.i === i);
-      if (byIdx) { byIdx.used = true; return { ...byIdx.e, value, exists: null }; }
-      return { id: `${i}-${value}-${Date.now()}`, value, exists: null };
-    }));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    setEntries((prev) => {
+      const current = prev.map((e) => e.value).join(";");
+      if (current === rawValue) return prev;
+      const parts = rawValue.split(";").filter((p) => p.trim().length > 0);
+      // Reuse existing entry IDs to preserve DOM nodes and focus across undo operations.
+      // 1. Value match  — handles drag undo (same values, reordered).
+      // 2. Index match  — handles text-edit undo (same position, different value).
+      const pool = prev.map((e, i) => ({ e, i, used: false }));
+      return parts.map((value, i) => {
+        const byVal = pool.find((p) => !p.used && p.e.value === value);
+        if (byVal) {
+          byVal.used = true;
+          return byVal.e;
+        }
+        const byIdx = pool.find((p) => !p.used && p.i === i);
+        if (byIdx) {
+          byIdx.used = true;
+          return { ...byIdx.e, value, exists: null };
+        }
+        return { id: `${i}-${value}-${Date.now()}`, value, exists: null };
+      });
+    });
   }, [rawValue]);
 
   // Validate paths when new entries appear with exists === null.
@@ -62,7 +76,9 @@ export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skip
         }
       })
       .catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [skipPathValidation, entries]);
 
   const handleEntriesChange = (next: ListEntry[]) => {
@@ -76,7 +92,9 @@ export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skip
     if (!allVars) return { unresolvedRefs: [], hasWhitespace: false };
     const diags = lintPathValue(lintedValue, allVars);
     return {
-      unresolvedRefs: [...new Set(diags.filter((d) => d.kind === "unresolved-ref").map((d) => d.varName))],
+      unresolvedRefs: [
+        ...new Set(diags.filter((d) => d.kind === "unresolved-ref").map((d) => d.varName)),
+      ],
       hasWhitespace: diags.some((d) => d.kind === "whitespace"),
     };
   }, [lintedValue, allVars]);
@@ -84,7 +102,9 @@ export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skip
   return (
     <fieldset
       className="flex flex-col gap-2 min-w-0 border-0 p-0 m-0"
-      onFocus={() => { hasFocusRef.current = true; }}
+      onFocus={() => {
+        hasFocusRef.current = true;
+      }}
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
           hasFocusRef.current = false;
@@ -93,18 +113,28 @@ export function PathEditor({ rawValue, onChange, readOnly = false, allVars, skip
       }}
     >
       {hasWhitespace && (
-        <div className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs" role="alert">
+        <div
+          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          role="alert"
+        >
           Some entries have leading or trailing spaces — remove them to avoid lookup failures
         </div>
       )}
       {unresolvedRefs.length > 0 && (
-        <div className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs" role="alert">
-          {unresolvedRefs.length} unresolvable {unresolvedRefs.length === 1 ? "reference" : "references"}:{" "}
+        <div
+          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          role="alert"
+        >
+          {unresolvedRefs.length} unresolvable{" "}
+          {unresolvedRefs.length === 1 ? "reference" : "references"}:{" "}
           {unresolvedRefs.map((v) => `%${v}%`).join(", ")}
         </div>
       )}
       {invalidCount > 0 && (
-        <div className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs" role="alert">
+        <div
+          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          role="alert"
+        >
           {invalidCount} path{invalidCount > 1 ? "s" : ""} not found on disk
         </div>
       )}

--- a/src/components/SnapshotPanel/SnapshotDiffRow.tsx
+++ b/src/components/SnapshotPanel/SnapshotDiffRow.tsx
@@ -4,15 +4,15 @@ import { resolveSecret } from "../../lib/secrets";
 import { Icon } from "../ui/Icon";
 
 export function DiffRow({ entry }: { entry: DiffEntry }) {
-  const secret = resolveSecret(entry.name, entry.value ?? entry.newValue ?? "");
+  const secret = resolveSecret(entry.name, entry.kind === "changed" ? entry.newValue : entry.value);
   const [revealed, setRevealed] = useState(false);
 
-  const mask = (v: string) => secret && !revealed ? "••••••••" : v;
+  const mask = (v: string) => (secret && !revealed ? "••••••••" : v);
 
   return (
     <tr className="border-b border-rim-subtle last:border-0 text-xs">
       <td className="px-2 py-1.5 w-5 text-center font-mono font-bold shrink-0">
-        {entry.kind === "added"   && <span className="text-success">+</span>}
+        {entry.kind === "added" && <span className="text-success">+</span>}
         {entry.kind === "removed" && <span className="text-danger">−</span>}
         {entry.kind === "changed" && <span className="text-warn">~</span>}
       </td>
@@ -31,11 +31,11 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
       <td className="px-2 py-1.5 font-mono text-muted max-w-xs truncate">
         {entry.kind === "changed" ? (
           <span className="flex flex-col gap-0.5">
-            <span className="line-through text-danger">{mask(entry.oldValue!)}</span>
-            <span className="text-success">{mask(entry.newValue!)}</span>
+            <span className="line-through text-danger">{mask(entry.oldValue)}</span>
+            <span className="text-success">{mask(entry.newValue)}</span>
           </span>
         ) : (
-          <span>{mask(entry.value!)}</span>
+          <span>{mask(entry.value)}</span>
         )}
       </td>
       {secret && (
@@ -54,14 +54,14 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
 }
 
 export function DiffTable({ diff }: { diff: DiffEntry[] }) {
-  const added   = diff.filter((e) => e.kind === "added").length;
+  const added = diff.filter((e) => e.kind === "added").length;
   const removed = diff.filter((e) => e.kind === "removed").length;
   const changed = diff.filter((e) => e.kind === "changed").length;
 
   return (
     <>
       <div className="flex gap-3 text-xs">
-        {added   > 0 && <span className="text-success">+{added} added</span>}
+        {added > 0 && <span className="text-success">+{added} added</span>}
         {removed > 0 && <span className="text-danger">−{removed} removed</span>}
         {changed > 0 && <span className="text-warn">~{changed} changed</span>}
       </div>

--- a/src/components/SnapshotPanel/SnapshotPanel.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-import { useI18n } from "../../hooks/useI18n";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "../../api";
+import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
-import { computeDiff } from "../../lib/diff";
 import type { DiffEntry } from "../../lib/diff";
+import { computeDiff } from "../../lib/diff";
 import type { EnvSnapshot, SnapshotMeta } from "../../types";
 import { Button } from "../ui/Button";
 import { IconButton } from "../ui/IconButton";
@@ -34,15 +34,17 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
   const [comparingFrom, setComparingFrom] = useState<SnapshotMeta | null>(null);
   const [compareResult, setCompareResult] = useState<CompareResult | null>(null);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       setSnapshots(await api.listSnapshots());
     } catch (e) {
       console.error(e);
     }
-  };
+  }, []);
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const handleCreate = async () => {
     const snapshotLabel = label.trim() || new Date().toLocaleString();
@@ -90,7 +92,10 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
   const handleDelete = async (id: string) => {
     try {
       await api.deleteSnapshot(id);
-      if (previewing?.id === id) { setPreviewing(null); setPreviewDiff([]); }
+      if (previewing?.id === id) {
+        setPreviewing(null);
+        setPreviewDiff([]);
+      }
       if (comparingFrom?.id === id) setComparingFrom(null);
       if (compareResult?.from.id === id || compareResult?.to.id === id) setCompareResult(null);
       setConfirmDeleteId(null);
@@ -120,7 +125,11 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
   };
 
   const formatDate = (iso: string) => {
-    try { return new Date(iso).toLocaleString(); } catch { return iso; }
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
   };
 
   return (
@@ -163,14 +172,19 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
           snap={previewing}
           diff={previewDiff}
           onRestore={handleRestore}
-          onCancel={() => { setPreviewing(null); setPreviewDiff([]); }}
+          onCancel={() => {
+            setPreviewing(null);
+            setPreviewDiff([]);
+          }}
         />
       ) : (
         <div className="flex flex-col gap-2">
           {comparingFrom && (
             <div className="flex items-center justify-between px-2.5 py-1.5 rounded border border-accent/30 bg-accent/10 text-accent text-xs">
               <span>{t("snapshot.comparing_hint", { label: comparingFrom.label })}</span>
-              <Button variant="link" size="xs" onClick={handleCancelCompare}>{t("snapshot.cancel")}</Button>
+              <Button variant="link" size="xs" onClick={handleCancelCompare}>
+                {t("snapshot.cancel")}
+              </Button>
             </div>
           )}
           {snapshots.length === 0 && (
@@ -193,7 +207,11 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                 <div className="flex gap-1.5 shrink-0 items-center">
                   {comparingFrom ? (
                     !isComparingSource && (
-                      <Button variant="secondary" size="sm" onClick={() => handlePickCompareTarget(s)}>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => handlePickCompareTarget(s)}
+                      >
                         {t("snapshot.compare_with")}
                       </Button>
                     )
@@ -218,11 +236,15 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                       </Button>
                     </>
                   )}
-                  {!comparingFrom && (
-                    confirmDeleteId === s.id ? (
+                  {!comparingFrom &&
+                    (confirmDeleteId === s.id ? (
                       <>
-                        <Button variant="danger" size="sm" onClick={() => handleDelete(s.id)}>{t("snapshot.delete")}</Button>
-                        <Button variant="ghost" size="sm" onClick={() => setConfirmDeleteId(null)}>{t("snapshot.cancel")}</Button>
+                        <Button variant="danger" size="sm" onClick={() => handleDelete(s.id)}>
+                          {t("snapshot.delete")}
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => setConfirmDeleteId(null)}>
+                          {t("snapshot.cancel")}
+                        </Button>
                       </>
                     ) : (
                       <IconButton
@@ -232,8 +254,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                         onClick={() => setConfirmDeleteId(s.id)}
                         title="Delete snapshot"
                       />
-                    )
-                  )}
+                    ))}
                 </div>
               </div>
             );

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -17,11 +17,20 @@ interface StagedModalProps {
 }
 
 function splitList(value: string): string[] {
-  return value.split(";").map((e) => e.trim()).filter(Boolean);
+  return value
+    .split(";")
+    .map((e) => e.trim())
+    .filter(Boolean);
 }
 
 function isList(value: string): boolean {
   return value.includes(";") && splitList(value).length > 1;
+}
+
+function entryHasListValue(entry: DiffEntry): boolean {
+  return entry.kind === "changed"
+    ? isList(entry.oldValue) || isList(entry.newValue)
+    : isList(entry.value);
 }
 
 function keyedEntries(entries: string[], prefix: string) {
@@ -38,7 +47,7 @@ function ListDiffDelta({ oldValue, newValue }: { oldValue: string; newValue: str
   const oldEntries = splitList(oldValue);
   const newEntries = splitList(newValue);
   const removed = oldEntries.filter((e) => !newEntries.includes(e));
-  const added   = newEntries.filter((e) => !oldEntries.includes(e));
+  const added = newEntries.filter((e) => !oldEntries.includes(e));
 
   if (removed.length === 0 && added.length === 0) {
     return (
@@ -52,12 +61,14 @@ function ListDiffDelta({ oldValue, newValue }: { oldValue: string; newValue: str
     <div className="flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto">
       {keyedEntries(removed, "removed").map(({ entry, key }) => (
         <p key={key} className="font-mono text-[11px] text-danger break-all">
-          <span className="select-none mr-1 opacity-70">−</span>{entry}
+          <span className="select-none mr-1 opacity-70">−</span>
+          {entry}
         </p>
       ))}
       {keyedEntries(added, "added").map(({ entry, key }) => (
         <p key={key} className="font-mono text-[11px] text-success break-all">
-          <span className="select-none mr-1 opacity-70">+</span>{entry}
+          <span className="select-none mr-1 opacity-70">+</span>
+          {entry}
         </p>
       ))}
     </div>
@@ -68,11 +79,14 @@ function ListDiffFull({ oldValue, newValue }: { oldValue: string; newValue: stri
   const oldEntries = splitList(oldValue);
   const newEntries = splitList(newValue);
   const removedSet = new Set(oldEntries.filter((e) => !newEntries.includes(e)));
-  const addedSet   = new Set(newEntries.filter((e) => !oldEntries.includes(e)));
+  const addedSet = new Set(newEntries.filter((e) => !oldEntries.includes(e)));
 
   const rows: { entry: string; status: "added" | "removed" | "unchanged" }[] = [
     ...Array.from(removedSet).map((e) => ({ entry: e, status: "removed" as const })),
-    ...newEntries.map((e) => ({ entry: e, status: addedSet.has(e) ? "added" as const : "unchanged" as const })),
+    ...newEntries.map((e) => ({
+      entry: e,
+      status: addedSet.has(e) ? ("added" as const) : ("unchanged" as const),
+    })),
   ];
   const seen = new Map<string, number>();
 
@@ -87,8 +101,8 @@ function ListDiffFull({ oldValue, newValue }: { oldValue: string; newValue: stri
             key={`${keyBase}:${count}`}
             className={cn(
               "font-mono text-[11px] break-all",
-              r.status === "removed"   && "text-danger line-through",
-              r.status === "added"     && "text-success",
+              r.status === "removed" && "text-danger line-through",
+              r.status === "added" && "text-success",
               r.status === "unchanged" && "text-muted",
             )}
           >
@@ -107,7 +121,9 @@ function ListEntries({ value, className }: { value: string; className?: string }
   return (
     <div className={cn("flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto", className)}>
       {keyedEntries(splitList(value), "entry").map(({ entry, key }) => (
-        <p key={key} className="font-mono text-[11px] break-all">{entry}</p>
+        <p key={key} className="font-mono text-[11px] break-all">
+          {entry}
+        </p>
       ))}
     </div>
   );
@@ -119,12 +135,10 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
   const [viewMode, setViewMode] = useState<ViewMode>("delta");
 
   const criticalChanges = diff.filter((e) => CRITICAL_VARS.has(e.name.toUpperCase()));
-  const hasListValues = diff.some(
-    (e) => isList(e.value ?? "") || isList(e.oldValue ?? "") || isList(e.newValue ?? ""),
-  );
+  const hasListValues = diff.some(entryHasListValue);
 
   const byKind = {
-    added:   diff.filter((e) => e.kind === "added"),
+    added: diff.filter((e) => e.kind === "added"),
     removed: diff.filter((e) => e.kind === "removed"),
     changed: diff.filter((e) => e.kind === "changed"),
   };
@@ -139,21 +153,34 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
               {t("staged.critical", { count: criticalChanges.length })}
             </p>
             <p className="text-xs">
-              {t("staged.critical_detail", { count: criticalChanges.length, vars: criticalChanges.map((e) => e.name).join(", ") })}
+              {t("staged.critical_detail", {
+                count: criticalChanges.length,
+                vars: criticalChanges.map((e) => e.name).join(", "),
+              })}
             </p>
           </div>
         </div>
       )}
 
       <div className="px-6 py-4 border-b border-rim shrink-0">
-        <p className="text-xs text-muted mb-3">
-          {t("staged.broadcast")}
-        </p>
+        <p className="text-xs text-muted mb-3">{t("staged.broadcast")}</p>
         <div className="flex items-center justify-between">
           <div className="flex gap-3 text-xs">
-            {byKind.added.length > 0   && <span className="text-success">{t("staged.added", { count: byKind.added.length })}</span>}
-            {byKind.removed.length > 0 && <span className="text-danger">{t("staged.removed", { count: byKind.removed.length })}</span>}
-            {byKind.changed.length > 0 && <span className="text-warn">{t("staged.changed", { count: byKind.changed.length })}</span>}
+            {byKind.added.length > 0 && (
+              <span className="text-success">
+                {t("staged.added", { count: byKind.added.length })}
+              </span>
+            )}
+            {byKind.removed.length > 0 && (
+              <span className="text-danger">
+                {t("staged.removed", { count: byKind.removed.length })}
+              </span>
+            )}
+            {byKind.changed.length > 0 && (
+              <span className="text-warn">
+                {t("staged.changed", { count: byKind.changed.length })}
+              </span>
+            )}
           </div>
           {hasListValues && (
             <div className="flex rounded border border-rim overflow-hidden text-[10px]">
@@ -185,7 +212,7 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
               key={key}
               className={cn(
                 "rounded border px-3 py-2 text-xs",
-                entry.kind === "added"   && "border-success/30 bg-success/5 text-success",
+                entry.kind === "added" && "border-success/30 bg-success/5 text-success",
                 entry.kind === "removed" && "border-danger/30 bg-danger/5 text-danger",
                 entry.kind === "changed" && "border-warn/30 bg-warn/5 text-warn",
               )}
@@ -193,39 +220,45 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
               <div className="flex items-center gap-2 mb-1">
                 <span className="font-mono font-semibold text-fg">{entry.name}</span>
                 <span className="opacity-60 text-[10px]">{entry.scope}</span>
-                <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide">{t(`staged.kind_${entry.kind}`)}</span>
+                <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide">
+                  {t(`staged.kind_${entry.kind}`)}
+                </span>
               </div>
 
-              {entry.kind === "removed" && (
-                isList(entry.value!) ? (
-                  <ListEntries value={entry.value!} className="opacity-70 line-through" />
+              {entry.kind === "removed" &&
+                (isList(entry.value) ? (
+                  <ListEntries value={entry.value} className="opacity-70 line-through" />
                 ) : (
-                  <p className="font-mono text-[11px] opacity-70 line-through break-all">{entry.value}</p>
-                )
-              )}
+                  <p className="font-mono text-[11px] opacity-70 line-through break-all">
+                    {entry.value}
+                  </p>
+                ))}
 
-              {entry.kind === "added" && (
-                isList(entry.value!) ? (
-                  <ListEntries value={entry.value!} />
+              {entry.kind === "added" &&
+                (isList(entry.value) ? (
+                  <ListEntries value={entry.value} />
                 ) : (
                   <p className="font-mono text-[11px] break-all">{entry.value}</p>
-                )
-              )}
+                ))}
 
-              {entry.kind === "changed" && (
-                isList(entry.oldValue ?? "") || isList(entry.newValue ?? "") ? (
+              {entry.kind === "changed" &&
+                (isList(entry.oldValue ?? "") || isList(entry.newValue ?? "") ? (
                   viewMode === "delta" ? (
-                    <ListDiffDelta oldValue={entry.oldValue ?? ""} newValue={entry.newValue ?? ""} />
+                    <ListDiffDelta
+                      oldValue={entry.oldValue ?? ""}
+                      newValue={entry.newValue ?? ""}
+                    />
                   ) : (
                     <ListDiffFull oldValue={entry.oldValue ?? ""} newValue={entry.newValue ?? ""} />
                   )
                 ) : (
                   <div className="flex flex-col gap-0.5">
-                    <p className="font-mono text-[11px] text-danger line-through break-all">{entry.oldValue}</p>
+                    <p className="font-mono text-[11px] text-danger line-through break-all">
+                      {entry.oldValue}
+                    </p>
                     <p className="font-mono text-[11px] text-success break-all">{entry.newValue}</p>
                   </div>
-                )
-              )}
+                ))}
             </div>
           );
         })}
@@ -243,7 +276,9 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
           {t("staged.take_snapshot")}
         </label>
         <div className="flex gap-2 justify-end">
-          <Button variant="ghost" size="md" onClick={onClose} disabled={busy}>{t("staged.cancel")}</Button>
+          <Button variant="ghost" size="md" onClick={onClose} disabled={busy}>
+            {t("staged.cancel")}
+          </Button>
           <Button variant="primary" size="md" onClick={() => onApply(takeSnapshot)} disabled={busy}>
             {busy ? t("staged.applying") : t("staged.apply", { count: diff.length })}
           </Button>

--- a/src/hooks/useAppInit.ts
+++ b/src/hooks/useAppInit.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect } from "react";
 import type { RefObject } from "react";
+import { useCallback, useEffect } from "react";
 import { api } from "../api";
 import type { EnvSnapshot } from "../types";
 
@@ -29,7 +29,7 @@ export function useAppInit({
       await refreshPathStatus();
       refresh();
     })();
-  }, []);
+  }, [baselineRef, setElevated, refreshPathStatus, refresh]);
 
   const handleRefresh = useCallback(async () => {
     await refresh();

--- a/src/hooks/useApplyStaged.ts
+++ b/src/hooks/useApplyStaged.ts
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react";
 import type { RefObject } from "react";
+import { useCallback, useState } from "react";
 import { api } from "../api";
 import type { EnvSnapshot } from "../types";
 import type { StagedChange } from "./useStaged";
@@ -15,28 +15,40 @@ interface Params {
   setDialog: SetDialog;
 }
 
-export function useApplyStaged({ staged, clearStaged, refresh, refreshPathStatus, baselineRef, setDialog }: Params) {
+export function useApplyStaged({
+  staged,
+  clearStaged,
+  refresh,
+  refreshPathStatus,
+  baselineRef,
+  setDialog,
+}: Params) {
   const [busy, setBusy] = useState(false);
 
-  const handleApplyStaged = useCallback(async (takeSnapshot: boolean) => {
-    setBusy(true);
-    try {
-      if (takeSnapshot) await api.createSnapshot("auto: before apply");
-      for (const change of staged.values()) {
-        if (change.kind === "delete") await api.deleteEnvVar(change.name, change.scope);
-        else await api.setEnvVar(change.name, change.newValue!, change.scope);
+  const handleApplyStaged = useCallback(
+    async (takeSnapshot: boolean) => {
+      setBusy(true);
+      try {
+        if (takeSnapshot) await api.createSnapshot("auto: before apply");
+        for (const change of staged.values()) {
+          if (change.kind === "delete") await api.deleteEnvVar(change.name, change.scope);
+          else await api.setEnvVar(change.name, change.newValue, change.scope);
+        }
+        clearStaged();
+        setDialog(null);
+        await refresh();
+        try {
+          baselineRef.current = await api.getRegistrySnapshot();
+        } catch {}
+        await refreshPathStatus();
+      } catch (err) {
+        console.error("Failed to apply staged changes", err);
+      } finally {
+        setBusy(false);
       }
-      clearStaged();
-      setDialog(null);
-      await refresh();
-      try { baselineRef.current = await api.getRegistrySnapshot(); } catch { }
-      await refreshPathStatus();
-    } catch (err) {
-      console.error("Failed to apply staged changes", err);
-    } finally {
-      setBusy(false);
-    }
-  }, [staged, clearStaged, refresh, refreshPathStatus, baselineRef, setDialog]);
+    },
+    [staged, clearStaged, refresh, refreshPathStatus, baselineRef, setDialog],
+  );
 
   return { handleApplyStaged, busy };
 }

--- a/src/hooks/useDiff.ts
+++ b/src/hooks/useDiff.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api";
-import { applyAccepted, computeDiff, snapshotsEqual } from "../lib/diff";
 import type { DiffEntry } from "../lib/diff";
+import { applyAccepted, computeDiff, snapshotsEqual } from "../lib/diff";
 import type { EnvSnapshot, VarScope } from "../types";
 
 type SetDialog = (d: "importexport" | "changes" | "staged" | "licenses" | "newvar" | null) => void;
@@ -24,7 +24,11 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
     if (!baselineRef.current) return;
     try {
       const current = await api.getRegistrySnapshot();
-      setDiffEntries(snapshotsEqual(baselineRef.current, current) ? [] : computeDiff(baselineRef.current, current));
+      setDiffEntries(
+        snapshotsEqual(baselineRef.current, current)
+          ? []
+          : computeDiff(baselineRef.current, current),
+      );
     } catch {}
   }, []);
 
@@ -32,25 +36,28 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
     if (diffEntries.length > 0) setDialog("changes");
   }, [diffEntries.length, setDialog]);
 
-  const handleDiffApply = useCallback(async (accepted: DiffEntry[], reverted: DiffEntry[]) => {
-    setApplyBusy(true);
-    try {
-      for (const entry of reverted) {
-        const scope = entry.scope as VarScope;
-        if (entry.kind === "added") await api.deleteEnvVar(entry.name, scope);
-        else if (entry.kind === "removed") await api.setEnvVar(entry.name, entry.value!, scope);
-        else await api.setEnvVar(entry.name, entry.oldValue!, scope);
+  const handleDiffApply = useCallback(
+    async (accepted: DiffEntry[], reverted: DiffEntry[]) => {
+      setApplyBusy(true);
+      try {
+        for (const entry of reverted) {
+          const scope = entry.scope as VarScope;
+          if (entry.kind === "added") await api.deleteEnvVar(entry.name, scope);
+          else if (entry.kind === "removed") await api.setEnvVar(entry.name, entry.value, scope);
+          else await api.setEnvVar(entry.name, entry.oldValue, scope);
+        }
+        if (baselineRef.current) baselineRef.current = applyAccepted(baselineRef.current, accepted);
+        setDiffEntries([]);
+        setDialog(null);
+        await refresh();
+      } catch (err) {
+        console.error("Failed to apply diff", err);
+      } finally {
+        setApplyBusy(false);
       }
-      if (baselineRef.current) baselineRef.current = applyAccepted(baselineRef.current, accepted);
-      setDiffEntries([]);
-      setDialog(null);
-      await refresh();
-    } catch (err) {
-      console.error("Failed to apply diff", err);
-    } finally {
-      setApplyBusy(false);
-    }
-  }, [refresh, setDialog]);
+    },
+    [refresh, setDialog],
+  );
 
   const handleDiffDismiss = useCallback(() => {
     if (baselineRef.current) baselineRef.current = applyAccepted(baselineRef.current, diffEntries);
@@ -58,5 +65,12 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
     setDialog(null);
   }, [diffEntries, setDialog]);
 
-  return { diffEntries, baselineRef, checkForExternalChanges, handleDiffApply, handleDiffDismiss, applyBusy };
+  return {
+    diffEntries,
+    baselineRef,
+    checkForExternalChanges,
+    handleDiffApply,
+    handleDiffDismiss,
+    applyBusy,
+  };
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import type { RefObject } from "react";
+import { useEffect } from "react";
 
 export function useKeyboardShortcuts(
   undo: () => void,
@@ -16,10 +16,16 @@ export function useKeyboardShortcuts(
       }
       const active = document.activeElement;
       if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return;
-      if (e.key === "z" && !e.shiftKey) { e.preventDefault(); undo(); }
-      if (e.key === "y" || (e.key === "z" && e.shiftKey)) { e.preventDefault(); redo(); }
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      }
+      if (e.key === "y" || (e.key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        redo();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [undo, redo]);
+  }, [undo, redo, localUndoRef]);
 }

--- a/src/hooks/useStaged.ts
+++ b/src/hooks/useStaged.ts
@@ -3,15 +3,15 @@ import type { EnvSnapshot, EnvVar, VarScope } from "../types";
 
 export type StagedKind = "set" | "delete";
 
-export interface StagedChange {
-  kind: StagedKind;
+interface StagedChangeBase {
   name: string;
   scope: VarScope;
-  /** Value currently in the registry; null if this is a brand-new variable. */
-  originalValue: string | null;
-  /** New value; null when kind is "delete". */
-  newValue: string | null;
 }
+
+export type StagedChange =
+  /** Value currently in the registry; null if this is a brand-new variable. */
+  | (StagedChangeBase & { kind: "set"; originalValue: string | null; newValue: string })
+  | (StagedChangeBase & { kind: "delete"; originalValue: string; newValue: null });
 
 type StagedKey = string; // `${VarScope}:${name}`
 
@@ -82,14 +82,26 @@ export function useStaged(registryVars: EnvVar[]) {
           if (original === v.value) {
             next.delete(k);
           } else {
-            next.set(k, { kind: "set", name: v.name, scope: v.scope, originalValue: original, newValue: v.value });
+            next.set(k, {
+              kind: "set",
+              name: v.name,
+              scope: v.scope,
+              originalValue: original,
+              newValue: v.value,
+            });
           }
         }
         for (const d of deletes) {
           const k = stagedKey(d.name, d.scope);
           const original = registryByKey.get(k)?.value ?? null;
           if (original !== null) {
-            next.set(k, { kind: "delete", name: d.name, scope: d.scope, originalValue: original, newValue: null });
+            next.set(k, {
+              kind: "delete",
+              name: d.name,
+              scope: d.scope,
+              originalValue: original,
+              newValue: null,
+            });
           }
         }
         return next;
@@ -107,14 +119,32 @@ export function useStaged(registryVars: EnvVar[]) {
         for (const [name, value] of Object.entries(snap.user)) {
           const k = stagedKey(name, "User");
           const original = registryByKey.get(k)?.value ?? null;
-          if (original === value) { next.delete(k); }
-          else { next.set(k, { kind: "set", name, scope: "User", originalValue: original, newValue: value }); }
+          if (original === value) {
+            next.delete(k);
+          } else {
+            next.set(k, {
+              kind: "set",
+              name,
+              scope: "User",
+              originalValue: original,
+              newValue: value,
+            });
+          }
         }
         for (const [name, value] of Object.entries(snap.system)) {
           const k = stagedKey(name, "System");
           const original = registryByKey.get(k)?.value ?? null;
-          if (original === value) { next.delete(k); }
-          else { next.set(k, { kind: "set", name, scope: "System", originalValue: original, newValue: value }); }
+          if (original === value) {
+            next.delete(k);
+          } else {
+            next.set(k, {
+              kind: "set",
+              name,
+              scope: "System",
+              originalValue: original,
+              newValue: value,
+            });
+          }
         }
 
         // Stage deletes for registry vars not present in the snapshot
@@ -122,7 +152,13 @@ export function useStaged(registryVars: EnvVar[]) {
           const inSnap = v.scope === "User" ? snap.user : snap.system;
           if (!(v.name in inSnap)) {
             const k = stagedKey(v.name, v.scope);
-            next.set(k, { kind: "delete", name: v.name, scope: v.scope, originalValue: v.value, newValue: null });
+            next.set(k, {
+              kind: "delete",
+              name: v.name,
+              scope: v.scope,
+              originalValue: v.value,
+              newValue: null,
+            });
           }
         }
         return next;
@@ -164,8 +200,9 @@ export function useStaged(registryVars: EnvVar[]) {
         result.set(k, {
           name: change.name,
           scope: change.scope,
-          value: change.newValue!,
-          listSeparator: existing?.listSeparator ?? inferListSeparator(change.name, change.newValue ?? ""),
+          value: change.newValue,
+          listSeparator:
+            existing?.listSeparator ?? inferListSeparator(change.name, change.newValue),
         });
       }
       // "delete": var stays in result with original value; sidebar renders D marker

--- a/src/hooks/useStagingHandlers.ts
+++ b/src/hooks/useStagingHandlers.ts
@@ -24,49 +24,67 @@ interface Params {
 }
 
 export function useStagingHandlers({
-  staged, stageSet, stageDelete, stageImport, stageSnapshot,
-  unstage, clearStaged, restoreStaged, push,
-  setDialog, setSelected, setSnapshotsOpen,
+  staged,
+  stageSet,
+  stageDelete,
+  stageImport,
+  stageSnapshot,
+  unstage,
+  clearStaged,
+  restoreStaged,
+  push,
+  setDialog,
+  setSelected,
+  setSnapshotsOpen,
 }: Params) {
-  const handleStage = useCallback((name: string, scope: VarScope, value: string) => {
-    const prev = staged.get(`${scope}:${name}`);
-    stageSet(name, scope, value);
-    push({
-      label: `Stage ${name}`,
-      undo: () => {
-        if (prev?.kind === "set") stageSet(name, scope, prev.newValue!);
-        else if (prev?.kind === "delete") stageDelete(name, scope);
-        else unstage(name, scope);
-      },
-      redo: () => stageSet(name, scope, value),
-    });
-  }, [staged, stageSet, stageDelete, unstage, push]);
+  const handleStage = useCallback(
+    (name: string, scope: VarScope, value: string) => {
+      const prev = staged.get(`${scope}:${name}`);
+      stageSet(name, scope, value);
+      push({
+        label: `Stage ${name}`,
+        undo: () => {
+          if (prev?.kind === "set") stageSet(name, scope, prev.newValue);
+          else if (prev?.kind === "delete") stageDelete(name, scope);
+          else unstage(name, scope);
+        },
+        redo: () => stageSet(name, scope, value),
+      });
+    },
+    [staged, stageSet, stageDelete, unstage, push],
+  );
 
-  const handleStageDelete = useCallback((name: string, scope: VarScope) => {
-    const prev = staged.get(`${scope}:${name}`);
-    stageDelete(name, scope);
-    push({
-      label: `Delete ${name}`,
-      undo: () => {
-        if (prev?.kind === "set") stageSet(name, scope, prev.newValue!);
-        else unstage(name, scope);
-      },
-      redo: () => stageDelete(name, scope),
-    });
-  }, [staged, stageDelete, stageSet, unstage, push]);
+  const handleStageDelete = useCallback(
+    (name: string, scope: VarScope) => {
+      const prev = staged.get(`${scope}:${name}`);
+      stageDelete(name, scope);
+      push({
+        label: `Delete ${name}`,
+        undo: () => {
+          if (prev?.kind === "set") stageSet(name, scope, prev.newValue);
+          else unstage(name, scope);
+        },
+        redo: () => stageDelete(name, scope),
+      });
+    },
+    [staged, stageDelete, stageSet, unstage, push],
+  );
 
-  const handleUnstage = useCallback((name: string, scope: VarScope) => {
-    const prev = staged.get(`${scope}:${name}`);
-    unstage(name, scope);
-    push({
-      label: `Unstage ${name}`,
-      undo: () => {
-        if (prev?.kind === "set") stageSet(name, scope, prev.newValue!);
-        else if (prev?.kind === "delete") stageDelete(name, scope);
-      },
-      redo: () => unstage(name, scope),
-    });
-  }, [staged, unstage, stageSet, stageDelete, push]);
+  const handleUnstage = useCallback(
+    (name: string, scope: VarScope) => {
+      const prev = staged.get(`${scope}:${name}`);
+      unstage(name, scope);
+      push({
+        label: `Unstage ${name}`,
+        undo: () => {
+          if (prev?.kind === "set") stageSet(name, scope, prev.newValue);
+          else if (prev?.kind === "delete") stageDelete(name, scope);
+        },
+        redo: () => unstage(name, scope),
+      });
+    },
+    [staged, unstage, stageSet, stageDelete, push],
+  );
 
   const handleClearStaged = useCallback(() => {
     const snapshot = new Map(staged);
@@ -78,41 +96,50 @@ export function useStagingHandlers({
     });
   }, [staged, clearStaged, restoreStaged, push]);
 
-  const handleStageImport = useCallback((
-    sets: Array<{ name: string; scope: VarScope; value: string }>,
-    deletes: Array<{ name: string; scope: VarScope }> = [],
-  ) => {
-    const snapshot = new Map(staged);
-    stageImport(sets, deletes);
-    setDialog(null);
-    push({
-      label: "Import",
-      undo: () => restoreStaged(snapshot),
-      redo: () => stageImport(sets, deletes),
-    });
-  }, [staged, stageImport, restoreStaged, push, setDialog]);
+  const handleStageImport = useCallback(
+    (
+      sets: Array<{ name: string; scope: VarScope; value: string }>,
+      deletes: Array<{ name: string; scope: VarScope }> = [],
+    ) => {
+      const snapshot = new Map(staged);
+      stageImport(sets, deletes);
+      setDialog(null);
+      push({
+        label: "Import",
+        undo: () => restoreStaged(snapshot),
+        redo: () => stageImport(sets, deletes),
+      });
+    },
+    [staged, stageImport, restoreStaged, push, setDialog],
+  );
 
-  const handleStageSnapshot = useCallback((snap: EnvSnapshot) => {
-    const snapshot = new Map(staged);
-    stageSnapshot(snap);
-    setSnapshotsOpen(false);
-    push({
-      label: "Stage snapshot restore",
-      undo: () => restoreStaged(snapshot),
-      redo: () => stageSnapshot(snap),
-    });
-  }, [staged, stageSnapshot, restoreStaged, push, setSnapshotsOpen]);
+  const handleStageSnapshot = useCallback(
+    (snap: EnvSnapshot) => {
+      const snapshot = new Map(staged);
+      stageSnapshot(snap);
+      setSnapshotsOpen(false);
+      push({
+        label: "Stage snapshot restore",
+        undo: () => restoreStaged(snapshot),
+        redo: () => stageSnapshot(snap),
+      });
+    },
+    [staged, stageSnapshot, restoreStaged, push, setSnapshotsOpen],
+  );
 
-  const handleNewVarStage = useCallback((name: string, scope: VarScope, value: string) => {
-    stageSet(name, scope, value);
-    setSelected({ name, scope, value, listSeparator: null });
-    setDialog(null);
-    push({
-      label: `New variable ${name}`,
-      undo: () => unstage(name, scope),
-      redo: () => stageSet(name, scope, value),
-    });
-  }, [stageSet, unstage, push, setSelected, setDialog]);
+  const handleNewVarStage = useCallback(
+    (name: string, scope: VarScope, value: string) => {
+      stageSet(name, scope, value);
+      setSelected({ name, scope, value, listSeparator: null });
+      setDialog(null);
+      push({
+        label: `New variable ${name}`,
+        undo: () => unstage(name, scope),
+        redo: () => stageSet(name, scope, value),
+      });
+    },
+    [stageSet, unstage, push, setSelected, setDialog],
+  );
 
   return {
     handleStage,

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -2,17 +2,15 @@ import type { EnvSnapshot, VarScope } from "../types";
 
 export type DiffKind = "added" | "removed" | "changed";
 
-export interface DiffEntry {
-  kind: DiffKind;
+interface DiffEntryBase {
   name: string;
   scope: VarScope;
-  /** present for added and removed */
-  value?: string;
-  /** present for changed */
-  oldValue?: string;
-  /** present for changed */
-  newValue?: string;
 }
+
+export type DiffEntry =
+  | (DiffEntryBase & { kind: "added"; value: string })
+  | (DiffEntryBase & { kind: "removed"; value: string })
+  | (DiffEntryBase & { kind: "changed"; oldValue: string; newValue: string });
 
 /** Compare two snapshots and return a sorted list of differences. */
 export function computeDiff(baseline: EnvSnapshot, current: EnvSnapshot): DiffEntry[] {
@@ -59,11 +57,11 @@ export function applyAccepted(baseline: EnvSnapshot, accepted: DiffEntry[]): Env
   for (const entry of accepted) {
     const target = entry.scope === "User" ? user : system;
     if (entry.kind === "added") {
-      target[entry.name] = entry.value!;
+      target[entry.name] = entry.value;
     } else if (entry.kind === "removed") {
       delete target[entry.name];
     } else {
-      target[entry.name] = entry.newValue!;
+      target[entry.name] = entry.newValue;
     }
   }
 

--- a/src/lib/stagedToDiff.ts
+++ b/src/lib/stagedToDiff.ts
@@ -2,11 +2,19 @@ import type { StagedChange } from "../hooks/useStaged";
 import type { DiffEntry } from "./diff";
 
 export function stagedToDiff(staged: Map<string, StagedChange>): DiffEntry[] {
-  return Array.from(staged.values()).map((c): DiffEntry => {
-    if (c.kind === "delete")
-      return { kind: "removed", name: c.name, scope: c.scope, value: c.originalValue! };
-    if (c.originalValue === null)
-      return { kind: "added", name: c.name, scope: c.scope, value: c.newValue! };
-    return { kind: "changed", name: c.name, scope: c.scope, oldValue: c.originalValue, newValue: c.newValue! };
-  }).sort((a, b) => a.scope.localeCompare(b.scope) || a.name.localeCompare(b.name));
+  return Array.from(staged.values())
+    .map((c): DiffEntry => {
+      if (c.kind === "delete")
+        return { kind: "removed", name: c.name, scope: c.scope, value: c.originalValue };
+      if (c.originalValue === null)
+        return { kind: "added", name: c.name, scope: c.scope, value: c.newValue };
+      return {
+        kind: "changed",
+        name: c.name,
+        scope: c.scope,
+        oldValue: c.originalValue,
+        newValue: c.newValue,
+      };
+    })
+    .sort((a, b) => a.scope.localeCompare(b.scope) || a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Summary
- make diff and staged change entries discriminated unions so value fields are narrowed without non-null assertions
- remove remaining non-null assertions from diff, staged, snapshot, and apply flows
- satisfy exhaustive hook dependency warnings by using stable callbacks, explicit identities, and functional state updates
- remove the temporary Biome warning overrides for `useExhaustiveDependencies` and `noNonNullAssertion`
- run Biome safe fixes on the touched files only

Closes #78

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run build`
- `git diff --check`