### PR TITLE
chore: remove biome unused warning overrides

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,11 +18,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended",
-      "correctness": {
-        "noUnusedVariables": "warn",
-        "noUnusedImports": "warn"
-      }
+      "preset": "recommended"
     }
   },
   "javascript": {


### PR DESCRIPTION
## Summary
- remove the remaining Biome warning overrides for unused variables and unused imports
- return the linter rules to the recommended preset without source changes

Closes #80

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run build`