### PR TITLE
chore: ignore malformed temp profile directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ pnpm-debug.log*
 
 # Windows proc-macro DLLs that git picks up via %USERPROFILE% path expansion
 %USERPROFILE%/
+%USERP~1/


### PR DESCRIPTION
## Summary
- ignore the `%USERP~1/` temp-profile directory created when this Windows session has relative `TEMP` / `TMP` values
- keep it next to the existing `%USERPROFILE%/` ignore entry

## Verification
- created `%USERP~1\AppData\Local\Temp` locally and confirmed it does not appear in `git status`