### PR TITLE
chore: normalize temp dir for tauri builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "tauri": "node scripts/tauri.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "coverage": "vitest run --coverage",

--- a/scripts/tauri.mjs
+++ b/scripts/tauri.mjs
@@ -1,0 +1,43 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+function needsAbsoluteTemp(value) {
+  return !value || value.includes("%") || !isAbsolute(value);
+}
+
+function fallbackTempDir(env) {
+  if (env.LOCALAPPDATA && isAbsolute(env.LOCALAPPDATA)) {
+    return join(env.LOCALAPPDATA, "Temp");
+  }
+  if (env.USERPROFILE && isAbsolute(env.USERPROFILE)) {
+    return join(env.USERPROFILE, "AppData", "Local", "Temp");
+  }
+  return null;
+}
+
+const env = { ...process.env };
+
+if (process.platform === "win32" && (needsAbsoluteTemp(env.TEMP) || needsAbsoluteTemp(env.TMP))) {
+  const tempDir = fallbackTempDir(env);
+  if (tempDir) {
+    mkdirSync(tempDir, { recursive: true });
+    env.TEMP = tempDir;
+    env.TMP = tempDir;
+  }
+}
+
+const tauriCli = join(process.cwd(), "node_modules", "@tauri-apps", "cli", "tauri.js");
+
+const child = spawn(process.execPath, [tauriCli, ...process.argv.slice(2)], {
+  env,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- route `npm run tauri` through a small Node wrapper
- normalize broken Windows `TEMP` / `TMP` values before invoking the Tauri CLI
- fix local MSI bundling when `TEMP` is set to a relative `%USERP~1\AppData\Local\Temp` path

## Cause
WiX `light.exe` uses `TEMP` for binder scratch files. In the current Windows session, `TEMP` / `TMP` can be `%USERP~1\AppData\Local\Temp`, which is not an absolute path. When Tauri runs WiX from `src-tauri/target/release/wix/x64`, `light.exe` tries to create temp files under that working directory and fails with `DirectoryNotFoundException`.

## Verification
- `npm run tauri -- --version`
- `npm run tauri build -- --bundles msi`
- `npm run lint`
- `npm test -- --run`
- `git diff --check`