### PR TITLE
fix: improve select option contrast

### DIFF
--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -3,6 +3,7 @@ import { useI18n } from "../../hooks/useI18n";
 import { api } from "../../api";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
+import { Select } from "../ui/Select";
 
 interface AppHeaderProps {
   loading: boolean;
@@ -27,6 +28,10 @@ export function AppHeader({
   onToggleSnapshots, onToggleTheme, onLicenses,
 }: AppHeaderProps) {
   const { t, language, setLanguage } = useI18n();
+  const languageOptions = [
+    { value: "en", label: "English" },
+    { value: "ja", label: "日本語" },
+  ] as const;
 
   return (
     <header
@@ -102,17 +107,16 @@ export function AppHeader({
         >
           GitHub
         </Button>
-        <label className="flex items-center gap-1 text-xs text-dim cursor-pointer">
+        <div className="flex items-center gap-1 text-xs text-dim">
           <Icon name="globe" size={14} className="text-dim" />
-          <select
+          <Select
+            aria-label="Language"
             value={language}
-            onChange={(e) => setLanguage(e.target.value as "en" | "ja")}
-            className="bg-transparent text-xs text-dim cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded"
-          >
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-          </select>
-        </label>
+            onValueChange={setLanguage}
+            options={languageOptions}
+            className="text-xs"
+          />
+        </div>
         <Button
           variant="ghost"
           size="xs"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { resolveSecret } from "../../lib/secrets";
 import type { EnvVar, VarScope } from "../../types";
 import { Icon } from "../ui/Icon";
 import { SegmentedControl } from "../ui/SegmentedControl";
+import { Select } from "../ui/Select";
 import { TextInput } from "../ui/TextInput";
 
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
 
 const SCOPES = ["All", "User", "System"] as const;
 type ScopeFilter = (typeof SCOPES)[number];
+type SortOrder = "name-asc" | "name-desc" | "scope" | "staged";
 
 export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged }: Props) {
   const { t } = useI18n();
@@ -38,7 +40,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
     });
   };
 
-  const [sortBy, setSortBy] = useState<"name-asc" | "name-desc" | "scope" | "staged">("name-asc");
+  const [sortBy, setSortBy] = useState<SortOrder>("name-asc");
 
   const filtered = useMemo(
     () =>
@@ -78,6 +80,12 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
     label: s,
     count: s === "All" ? vars.length : counts[s as VarScope],
   }));
+  const sortOptions = [
+    { value: "name-asc", label: t("sidebar.sort_name_asc") },
+    { value: "name-desc", label: t("sidebar.sort_name_desc") },
+    { value: "scope", label: t("sidebar.sort_scope") },
+    { value: "staged", label: t("sidebar.sort_staged") },
+  ] satisfies Array<{ value: SortOrder; label: string }>;
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -148,17 +156,13 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
         ) : (
           <span />
         )}
-        <select
+        <Select
           aria-label="Sort order"
           value={sortBy}
-          onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
-          className="text-[10px] text-dim bg-transparent cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded"
-        >
-          <option value="name-asc">{t("sidebar.sort_name_asc")}</option>
-          <option value="name-desc">{t("sidebar.sort_name_desc")}</option>
-          <option value="scope">{t("sidebar.sort_scope")}</option>
-          <option value="staged">{t("sidebar.sort_staged")}</option>
-        </select>
+          onValueChange={setSortBy}
+          options={sortOptions}
+          className="text-[10px]"
+        />
       </div>
 
       <div

--- a/src/components/ui/Select.stories.tsx
+++ b/src/components/ui/Select.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { Select } from "./Select";
+
+const meta: Meta<typeof Select> = {
+  title: "Primitives/Select",
+  component: Select,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Language: Story = {
+  render: () => {
+    const [language, setLanguage] = useState("en");
+    return (
+      <Select
+        aria-label="Language"
+        value={language}
+        onValueChange={setLanguage}
+        options={[
+          { value: "en", label: "English" },
+          { value: "ja", label: "日本語" },
+        ]}
+      />
+    );
+  },
+};
+
+export const SortOrder: Story = {
+  render: () => {
+    const [sortBy, setSortBy] = useState("name-asc");
+    return (
+      <Select
+        aria-label="Sort order"
+        value={sortBy}
+        onValueChange={setSortBy}
+        options={[
+          { value: "name-asc", label: "Name A-Z" },
+          { value: "name-desc", label: "Name Z-A" },
+          { value: "scope", label: "Scope" },
+          { value: "staged", label: "Staged first" },
+        ]}
+        className="text-[10px]"
+      />
+    );
+  },
+};

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,43 @@
+import type { SelectHTMLAttributes } from "react";
+import { cn } from "../../lib/cn";
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+}
+
+interface Props<T extends string>
+  extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "value" | "onChange"> {
+  options: readonly SelectOption<T>[];
+  value: T;
+  onValueChange: (value: T) => void;
+}
+
+export function Select<T extends string>({
+  options,
+  value,
+  onValueChange,
+  className,
+  ...props
+}: Props<T>) {
+  return (
+    <select
+      {...props}
+      value={value}
+      onChange={(e) => onValueChange(e.target.value as T)}
+      className={cn(
+        "app-select bg-transparent text-dim cursor-pointer rounded transition-colors",
+        "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value} disabled={option.disabled}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -68,7 +68,7 @@
     outline: none;
   }
 
-  input, textarea {
+  input, textarea, select {
     font-family: inherit;
     font-size: 13px;
     outline: none;
@@ -78,4 +78,16 @@
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: var(--color-rim); border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: var(--color-dim); }
+}
+
+@layer components {
+  .app-select option {
+    background: var(--color-surface);
+    color: var(--color-fg);
+  }
+
+  .app-select option:checked {
+    background: var(--color-hover);
+    color: var(--color-fg);
+  }
 }


### PR DESCRIPTION
## Summary
- add a shared `Select` primitive for native select controls
- use it for language and sidebar sort selects
- scope native option contrast colors to the app select component
- add Storybook examples for the select primitive

## Verification
- `npm run lint`
- `npm run build`
- `npm test -- --run`
- `git diff --check HEAD~1..HEAD`