### PR TITLE
chore: ignore Storybook build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build outputs
 dist/
 dist-ssr/
+storybook-static/
 target/
 src-tauri/target/
 src-tauri/gen/


### PR DESCRIPTION
## Summary
- ignore Storybook production build output
- keep generated `storybook-static/` out of `git status` after local verification

## Verification
- created `storybook-static/` locally and confirmed it does not appear in `git status`