### PR TITLE
fix: sync Storybook docs theme

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,7 +14,7 @@ const config: StorybookConfig = {
   viteFinal: (config) => {
     if (isProd) config.base = "/envarly/storybook/";
     return config;
-  }
+  },
 };
 
 export default config;

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,45 @@
+.sbdocs-wrapper,
+.sbdocs-content {
+  background: var(--color-canvas);
+  color: var(--color-fg);
+}
+
+.sbdocs-content h1,
+.sbdocs-content h2,
+.sbdocs-content h3,
+.sbdocs-content h4,
+.sbdocs-content h5,
+.sbdocs-content h6,
+.sbdocs-content p,
+.sbdocs-content li,
+.sbdocs-content td,
+.sbdocs-content th {
+  color: var(--color-fg);
+}
+
+.sbdocs-content a {
+  color: var(--color-accent);
+}
+
+.sbdocs-content table,
+.sbdocs-content tr {
+  border-color: var(--color-rim-subtle);
+}
+
+.sbdocs-content thead,
+.sbdocs-content th {
+  background: var(--color-panel);
+}
+
+.sbdocs-content code,
+.docblock-source {
+  background: var(--color-surface);
+  color: var(--color-fg);
+}
+
+.docblock-argstable,
+.docblock-argstable-body,
+.docblock-argstable-head {
+  background: var(--color-panel);
+  color: var(--color-fg);
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,15 +1,38 @@
 import type { Preview } from "@storybook/react-vite";
+import { create } from "storybook/theming/create";
 import "../src/index.css";
 import "../src/i18n";
+import "./preview.css";
 
 // Mock Tauri invoke for all stories
-// @ts-ignore
+// @ts-expect-error
 window.__TAURI_INTERNALS__ = {};
 
 const BG: Record<string, string> = {
   dark: "#0f1117",
-  light: "#f5f5f5",
+  light: "#ffffff",
 };
+
+const docsTheme = create({
+  base: "dark",
+  appBg: "#0f1117",
+  appContentBg: "#161b22",
+  appPreviewBg: "#0f1117",
+  appBorderColor: "#69788c",
+  appBorderRadius: 4,
+  barBg: "#161b22",
+  barTextColor: "#99a3ad",
+  barSelectedColor: "#e6edf3",
+  barHoverColor: "#e6edf3",
+  colorPrimary: "#58a6ff",
+  colorSecondary: "#79bbff",
+  inputBg: "#1c2333",
+  inputBorder: "#69788c",
+  inputTextColor: "#e6edf3",
+  textColor: "#e6edf3",
+  textInverseColor: "#0f1117",
+  textMutedColor: "#99a3ad",
+});
 
 const preview: Preview = {
   globalTypes: {
@@ -32,12 +55,17 @@ const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: { matchers: { color: /(bg|color)$/i } },
+    docs: {
+      theme: docsTheme,
+    },
   },
   decorators: [
     (Story, context) => {
       const theme = (context.globals.theme as string) ?? "dark";
       document.documentElement.classList.toggle("light", theme === "light");
       document.documentElement.classList.toggle("dark", theme !== "light");
+      document.body.classList.toggle("light", theme === "light");
+      document.body.classList.toggle("dark", theme !== "light");
       document.body.style.background = BG[theme] ?? BG.dark;
       return Story();
     },


### PR DESCRIPTION
## Summary
- add an Envarly-colored Storybook Docs theme
- apply Docs-specific CSS so docs content follows the toolbar light/dark global via app color tokens
- sync `body` theme classes with the existing `html` theme classes in Storybook preview
- format Storybook config touched by this change

## Verification
- `npx biome check .storybook --max-diagnostics=100`
- `npm run lint`
- `npm run build`
- `npm run build-storybook`
- `git diff --check`

## Notes
- In-app browser automation was unavailable in this Codex session because the browser plugin failed during setup, so verification was limited to Storybook build and source inspection.