### PR TITLE
fix: improve path editor usability

### DIFF
--- a/src/components/DetailPanel/DetailPanel.test.tsx
+++ b/src/components/DetailPanel/DetailPanel.test.tsx
@@ -31,6 +31,13 @@ const pathVar: EnvVar = {
   listSeparator: ";",
 };
 
+const pathExtVar: EnvVar = {
+  name: "PATHEXT",
+  value: ".COM;.EXE;.BAT",
+  scope: "User",
+  listSeparator: ";",
+};
+
 describe("DetailPanel", () => {
   const onStage = vi.fn();
   const onStageDelete = vi.fn();
@@ -119,7 +126,24 @@ describe("DetailPanel", () => {
   it("shows PATH editor for path-like variable", () => {
     render_(pathVar);
     expect(screen.getByText(/drag to reorder/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /browse for folder/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /browse folder for/i })).toHaveLength(2);
+  });
+
+  it("does not show folder picker buttons for PATHEXT entries", () => {
+    render_(pathExtVar);
+    expect(screen.getByText(/drag to reorder/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse folder for/i })).not.toBeInTheDocument();
+  });
+
+  it("switches a list variable back to plain text editing", async () => {
+    const user = userEvent.setup();
+    render_(pathVar);
+
+    expect(screen.getByText(/drag to reorder/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /plain text/i }));
+
+    expect(screen.getByRole("textbox", { name: /value/i })).toHaveValue(pathVar.value);
+    expect(screen.queryByText(/drag to reorder/i)).not.toBeInTheDocument();
   });
 
   it("shows Delete button when not dirty and not staged", () => {

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -79,7 +79,7 @@ export function DetailPanel({
   onRegisterLocalUndo,
 }: Props) {
   const { t } = useI18n();
-  const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | null>(null);
+  const [overrideSeparator, setOverrideSeparator] = useState<";" | "," | "plain" | null>(null);
   const prevVarRef = useRef<{ name: string; scope: string } | null>(null);
   const variableName = variable?.name;
   const variableScope = variable?.scope;
@@ -180,7 +180,9 @@ export function DetailPanel({
     }
   };
 
-  const effectiveSeparator = overrideSeparator ?? variable.listSeparator;
+  const effectiveSeparator = overrideSeparator === "plain"
+    ? null
+    : (overrideSeparator ?? variable.listSeparator);
   const readOnly = variable.scope === "System" && !elevated;
   const showFolderPicker =
     !readOnly && effectiveSeparator === null && looksLikeSinglePath(variable.name, value);
@@ -256,9 +258,9 @@ export function DetailPanel({
       </div>
 
       {description && (
-        <div className="flex items-start gap-2.5 px-6 py-2 border-b border-rim-subtle bg-hover/40 shrink-0">
-          <Icon name="info" size={14} className="mt-px text-dim" />
-          <div className="flex items-baseline gap-2 flex-wrap">
+        <div className="flex items-center gap-2.5 px-6 py-2 border-b border-rim-subtle bg-hover/40 shrink-0">
+          <Icon name="info" size={14} className="text-dim" />
+          <div className="flex items-center gap-2 flex-wrap">
             <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-surface border border-rim text-dim shrink-0 select-none">
               {t(description.categoryKey)}
             </span>
@@ -305,7 +307,7 @@ export function DetailPanel({
               {effectiveSeparator !== null ? (
                 <button
                   type="button"
-                  onClick={() => setOverrideSeparator(null)}
+                  onClick={() => setOverrideSeparator("plain")}
                   className="text-[10px] text-dim hover:text-muted px-1.5 py-0.5 rounded hover:bg-hover transition-colors"
                 >
                   {t("detail.plain_text")}
@@ -338,6 +340,7 @@ export function DetailPanel({
               readOnly={readOnly}
               allVars={allVars}
               skipPathValidation={variable.name.toUpperCase() === "PATHEXT"}
+              allowFolderBrowse={variable.name.toUpperCase() !== "PATHEXT"}
               onBeforeReorder={onBeforeStructuralChange}
             />
           ) : effectiveSeparator === "," ? (

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { cn } from "../../lib/cn";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
@@ -29,14 +29,30 @@ export interface ListEntry {
 }
 
 interface RowProps {
+  index: number;
   entry: ListEntry;
+  inputRef: (el: HTMLInputElement | null) => void;
+  readOnly: boolean;
   onRemove: () => void;
   onEdit: (val: string) => void;
+  onBrowse?: () => void;
+  onFocusEntry: (index: number) => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
 }
 
-function SortableRow({ entry, onRemove, onEdit, onMoveUp, onMoveDown }: RowProps) {
+function SortableRow({
+  index,
+  entry,
+  inputRef,
+  readOnly,
+  onRemove,
+  onEdit,
+  onBrowse,
+  onFocusEntry,
+  onMoveUp,
+  onMoveDown,
+}: RowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: entry.id,
   });
@@ -47,19 +63,22 @@ function SortableRow({ entry, onRemove, onEdit, onMoveUp, onMoveDown }: RowProps
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
         "flex items-center border-b border-rim-subtle last:border-0 transition-colors",
+        "focus-within:ring-2 focus-within:ring-accent focus-within:ring-inset",
         isDragging ? "opacity-50 bg-hover" : "bg-canvas",
         entry.exists === false && "bg-danger/5",
       )}
     >
       <button
         type="button"
-        {...attributes}
-        {...listeners}
+        {...(readOnly ? {} : attributes)}
+        {...(readOnly ? {} : listeners)}
         aria-label="Drag to reorder"
         title="Drag to reorder"
+        disabled={readOnly}
         className={cn(
           "w-8 flex items-center justify-center shrink-0 self-stretch text-dim",
-          "cursor-grab active:cursor-grabbing select-none",
+          readOnly ? "cursor-default opacity-40" : "cursor-grab active:cursor-grabbing",
+          "select-none",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent",
         )}
       >
@@ -68,23 +87,38 @@ function SortableRow({ entry, onRemove, onEdit, onMoveUp, onMoveDown }: RowProps
 
       <div className="flex-1 py-1.5 pr-2">
         <input
+          ref={inputRef}
           aria-label={`Entry: ${entry.value}`}
           value={entry.value}
           onChange={(e) => onEdit(e.target.value)}
           onKeyDown={(e) => {
-            if (!e.altKey) return;
-            if (e.key === "ArrowUp") {
+            if (readOnly) return;
+            if (e.altKey && e.key === "ArrowUp") {
               e.preventDefault();
               onMoveUp();
+              return;
             }
-            if (e.key === "ArrowDown") {
+            if (e.altKey && e.key === "ArrowDown") {
               e.preventDefault();
               onMoveDown();
+              return;
+            }
+            if (!e.altKey && e.key === "ArrowUp") {
+              e.preventDefault();
+              onFocusEntry(index - 1);
+            }
+            if (!e.altKey && e.key === "ArrowDown") {
+              e.preventDefault();
+              onFocusEntry(index + 1);
             }
           }}
+          readOnly={readOnly}
           spellCheck={false}
           title="Alt+↑/↓ to reorder"
-          className="w-full bg-transparent font-mono text-[11px] text-fg focus:outline-none"
+          className={cn(
+            "w-full bg-transparent font-mono text-[11px] text-fg focus:outline-none",
+            readOnly && "cursor-default",
+          )}
         />
       </div>
 
@@ -103,14 +137,27 @@ function SortableRow({ entry, onRemove, onEdit, onMoveUp, onMoveDown }: RowProps
         </div>
       )}
 
-      <div className="w-7 flex items-center justify-center shrink-0">
-        <IconButton
-          icon="x"
-          aria-label={`Remove ${entry.value}`}
-          variant="danger"
-          onClick={onRemove}
-        />
-      </div>
+      {onBrowse && (
+        <div className="w-7 flex items-center justify-center shrink-0">
+          <IconButton
+            icon="folder"
+            aria-label={`Browse folder for ${entry.value}`}
+            title="Browse for folder"
+            onClick={onBrowse}
+          />
+        </div>
+      )}
+
+      {!readOnly && (
+        <div className="w-7 flex items-center justify-center shrink-0">
+          <IconButton
+            icon="x"
+            aria-label={`Remove ${entry.value}`}
+            variant="danger"
+            onClick={onRemove}
+          />
+        </div>
+      )}
     </li>
   );
 }
@@ -121,6 +168,7 @@ interface Props {
   onEntriesChange: (entries: ListEntry[]) => void;
   /** Called before structural changes (drag, remove, add) so callers can snapshot state. */
   onBeforeChange?: () => void;
+  onBrowseEntry?: (entry: ListEntry) => Promise<string | null>;
   readOnly?: boolean;
   addPlaceholder?: string;
 }
@@ -130,10 +178,12 @@ export function SortableListEditor({
   entries,
   onEntriesChange,
   onBeforeChange,
+  onBrowseEntry,
   readOnly = false,
   addPlaceholder = "Add entry…",
 }: Props) {
   const [newValue, setNewValue] = useState("");
+  const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
 
   const dupCount = useMemo(() => {
     const seen = new Set<string>();
@@ -148,6 +198,7 @@ export function SortableListEditor({
   }, [entries]);
 
   const handleDedup = () => {
+    if (readOnly) return;
     onBeforeChange?.();
     const seen = new Set<string>();
     onEntriesChange(
@@ -166,6 +217,7 @@ export function SortableListEditor({
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (readOnly) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     onBeforeChange?.();
@@ -178,14 +230,31 @@ export function SortableListEditor({
   };
 
   const removeEntry = (id: string) => {
+    if (readOnly) return;
     onBeforeChange?.();
     onEntriesChange(entries.filter((e) => e.id !== id));
   };
 
-  const editEntry = (id: string, val: string) =>
+  const editEntry = (id: string, val: string) => {
+    if (readOnly) return;
     onEntriesChange(entries.map((e) => (e.id === id ? { ...e, value: val, exists: null } : e)));
+  };
+
+  const browseEntry = async (entry: ListEntry) => {
+    if (readOnly) return;
+    if (!onBrowseEntry) return;
+    const selected = await onBrowseEntry(entry);
+    if (selected === null) return;
+    editEntry(entry.id, selected);
+  };
+
+  const focusEntry = (index: number) => {
+    inputRefs.current[index]?.focus();
+    inputRefs.current[index]?.select();
+  };
 
   const moveEntry = (id: string, dir: -1 | 1) => {
+    if (readOnly) return;
     const idx = entries.findIndex((e) => e.id === id);
     if (idx === -1) return;
     const next = idx + dir;
@@ -195,6 +264,7 @@ export function SortableListEditor({
   };
 
   const addEntry = (raw: string) => {
+    if (readOnly) return;
     const trimmed = raw.trim();
     if (!trimmed) return;
     onBeforeChange?.();
@@ -234,12 +304,19 @@ export function SortableListEditor({
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={entries.map((e) => e.id)} strategy={verticalListSortingStrategy}>
           <ol aria-label="List entries" className="border border-rim rounded overflow-hidden">
-            {entries.map((entry) => (
+            {entries.map((entry, index) => (
               <SortableRow
                 key={entry.id}
+                index={index}
                 entry={entry}
+                inputRef={(el) => {
+                  inputRefs.current[index] = el;
+                }}
+                readOnly={readOnly}
                 onRemove={() => removeEntry(entry.id)}
                 onEdit={(val) => editEntry(entry.id, val)}
+                onBrowse={onBrowseEntry ? () => void browseEntry(entry) : undefined}
+                onFocusEntry={focusEntry}
                 onMoveUp={() => moveEntry(entry.id, -1)}
                 onMoveDown={() => moveEntry(entry.id, 1)}
               />

--- a/src/components/PathEditor/PathEditor.test.tsx
+++ b/src/components/PathEditor/PathEditor.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../api";
@@ -11,6 +12,10 @@ vi.mock("../../api", () => ({
   },
 }));
 
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
 const A = "/usr/local/bin";
 const B = "/nonexistent/path";
 const C = "/usr/bin";
@@ -20,6 +25,7 @@ describe("PathEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.validatePaths).mockResolvedValue([true, false, true]);
+    vi.mocked(open).mockResolvedValue(null);
   });
 
   it("renders each path entry", () => {
@@ -71,6 +77,56 @@ describe("PathEditor", () => {
     const removeButtons = await screen.findAllByRole("button", { name: /^remove/i });
     await user.click(removeButtons[0]);
     expect(onChange).toHaveBeenCalledWith(C);
+  });
+
+  it("updates an entry with the selected folder path", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    vi.mocked(api.validatePaths).mockResolvedValue([true, true]);
+    vi.mocked(open).mockResolvedValue("/selected/bin");
+    render(<PathEditor rawValue={`${A};${C}`} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: `Browse folder for ${A}` }));
+
+    expect(open).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      defaultPath: A,
+    });
+    expect(onChange).toHaveBeenCalledWith(`/selected/bin;${C}`);
+  });
+
+  it("can hide folder picker buttons for non-folder path lists", () => {
+    render(<PathEditor rawValue=".COM;.EXE;.BAT" onChange={vi.fn()} allowFolderBrowse={false} />);
+
+    expect(screen.queryByRole("button", { name: /browse folder for/i })).not.toBeInTheDocument();
+  });
+
+  it("prevents row edits and controls when read-only", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<PathEditor rawValue={`${A};${C}`} onChange={onChange} readOnly />);
+
+    await user.type(screen.getByDisplayValue(A), "-edited");
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /^remove/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse folder for/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add/i })).not.toBeInTheDocument();
+  });
+
+  it("moves focus between entries with arrow keys", () => {
+    vi.mocked(api.validatePaths).mockResolvedValue([true, true]);
+    render(<PathEditor rawValue={`${A};${C}`} onChange={vi.fn()} />);
+
+    const first = screen.getByDisplayValue(A);
+    const second = screen.getByDisplayValue(C);
+    first.focus();
+    fireEvent.keyDown(first, { key: "ArrowDown" });
+    expect(second).toHaveFocus();
+
+    fireEvent.keyDown(second, { key: "ArrowUp" });
+    expect(first).toHaveFocus();
   });
 
   it("shows unresolvable reference warning when allVars is provided and a %VAR% is unknown", () => {

--- a/src/components/PathEditor/PathEditor.tsx
+++ b/src/components/PathEditor/PathEditor.tsx
@@ -1,3 +1,4 @@
+import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../api";
 import { lintPathValue } from "../../lib/lint";
@@ -15,6 +16,8 @@ interface Props {
   allVars?: EnvVar[];
   /** Skip filesystem existence checks (e.g. for PATHEXT whose entries are extensions, not paths). */
   skipPathValidation?: boolean;
+  /** Show folder picker buttons for entries. Disable for path-like lists that are not folders. */
+  allowFolderBrowse?: boolean;
   /** Called before structural changes (drag, add, remove) so parent can snapshot state for undo. */
   onBeforeReorder?: () => void;
 }
@@ -25,6 +28,7 @@ export function PathEditor({
   readOnly = false,
   allVars,
   skipPathValidation = false,
+  allowFolderBrowse = true,
   onBeforeReorder,
 }: Props) {
   const [entries, setEntries] = useState<ListEntry[]>([]);
@@ -86,6 +90,15 @@ export function PathEditor({
     onChange(next.map((e) => e.value).join(";"));
   };
 
+  const handleBrowseEntry = async (entry: ListEntry) => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath: entry.value.trim() || undefined,
+    });
+    return typeof selected === "string" ? selected : null;
+  };
+
   const invalidCount = entries.filter((e) => e.exists === false).length;
 
   const { unresolvedRefs, hasWhitespace } = useMemo(() => {
@@ -143,6 +156,7 @@ export function PathEditor({
         entries={entries}
         onEntriesChange={handleEntriesChange}
         onBeforeChange={onBeforeReorder}
+        onBrowseEntry={readOnly || !allowFolderBrowse ? undefined : handleBrowseEntry}
         readOnly={readOnly}
         addPlaceholder="Add new path…"
       />


### PR DESCRIPTION
## Summary
- Fix Plain text mode so list variables can switch back to the textarea editor
- Add per-entry folder browsing to PATH-style list rows, while keeping PATHEXT entries as plain list rows without folder browsing
- Make focused list rows clearer and let ArrowUp/ArrowDown move focus between rows while keeping Alt+ArrowUp/Down for reordering
- Apply read-only state consistently to list rows so non-admin System variables cannot be edited/reordered/removed
- Center the detail description info icon against the category badge/text

## Verification
- npm test -- --run
- npm run lint
- npm run build