### PR TITLE
fix: add folder picker for new path entries

### DIFF
--- a/src/components/ImportExportPanel/VarTable.tsx
+++ b/src/components/ImportExportPanel/VarTable.tsx
@@ -42,7 +42,6 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
         >
           {t("var_table.select_all")}
         </Button>
-        <span className="text-dim">·</span>
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -340,11 +340,11 @@ export function SortableListEditor({
 
       {!readOnly && (
         <div className="flex gap-2">
-          <div className="relative flex-1">
+          <div className="relative flex flex-1">
             <input
               aria-label="New entry"
               className={cn(
-                "w-full px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-xs text-fg",
+                "h-full min-h-10 w-full px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-xs text-fg",
                 onBrowseNewEntry && "pr-9",
                 "placeholder:text-muted transition-colors",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas focus:border-accent",
@@ -361,7 +361,7 @@ export function SortableListEditor({
                 aria-label="Browse folder to add"
                 title="Browse folder to add"
                 onClick={() => void browseNewEntry()}
-                className="absolute right-1 top-1/2 -translate-y-1/2 size-6"
+                className="absolute right-1.5 top-1/2 -translate-y-1/2"
               />
             )}
           </div>

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -340,27 +340,31 @@ export function SortableListEditor({
 
       {!readOnly && (
         <div className="flex gap-2">
-          <input
-            aria-label="New entry"
-            className={cn(
-              "flex-1 px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-xs text-fg",
-              "placeholder:text-muted transition-colors",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas focus:border-accent",
-            )}
-            placeholder={addPlaceholder}
-            value={newValue}
-            onChange={(e) => setNewValue(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && addEntry(newValue)}
-            onPaste={handlePaste}
-          />
-          {onBrowseNewEntry && (
-            <IconButton
-              icon="folder"
-              aria-label="Browse folder to add"
-              title="Browse folder to add"
-              onClick={() => void browseNewEntry()}
+          <div className="relative flex-1">
+            <input
+              aria-label="New entry"
+              className={cn(
+                "w-full px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-xs text-fg",
+                onBrowseNewEntry && "pr-9",
+                "placeholder:text-muted transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas focus:border-accent",
+              )}
+              placeholder={addPlaceholder}
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && addEntry(newValue)}
+              onPaste={handlePaste}
             />
-          )}
+            {onBrowseNewEntry && (
+              <IconButton
+                icon="folder"
+                aria-label="Browse folder to add"
+                title="Browse folder to add"
+                onClick={() => void browseNewEntry()}
+                className="absolute right-1 top-1/2 -translate-y-1/2 size-6"
+              />
+            )}
+          </div>
           <Button variant="primary" icon="plus" onClick={() => addEntry(newValue)}>
             Add
           </Button>

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -169,6 +169,7 @@ interface Props {
   /** Called before structural changes (drag, remove, add) so callers can snapshot state. */
   onBeforeChange?: () => void;
   onBrowseEntry?: (entry: ListEntry) => Promise<string | null>;
+  onBrowseNewEntry?: (currentValue: string) => Promise<string | null>;
   readOnly?: boolean;
   addPlaceholder?: string;
 }
@@ -179,6 +180,7 @@ export function SortableListEditor({
   onEntriesChange,
   onBeforeChange,
   onBrowseEntry,
+  onBrowseNewEntry,
   readOnly = false,
   addPlaceholder = "Add entry…",
 }: Props) {
@@ -246,6 +248,14 @@ export function SortableListEditor({
     const selected = await onBrowseEntry(entry);
     if (selected === null) return;
     editEntry(entry.id, selected);
+  };
+
+  const browseNewEntry = async () => {
+    if (readOnly) return;
+    if (!onBrowseNewEntry) return;
+    const selected = await onBrowseNewEntry(newValue);
+    if (selected === null) return;
+    addEntry(selected);
   };
 
   const focusEntry = (index: number) => {
@@ -343,6 +353,14 @@ export function SortableListEditor({
             onKeyDown={(e) => e.key === "Enter" && addEntry(newValue)}
             onPaste={handlePaste}
           />
+          {onBrowseNewEntry && (
+            <IconButton
+              icon="folder"
+              aria-label="Browse folder to add"
+              title="Browse folder to add"
+              onClick={() => void browseNewEntry()}
+            />
+          )}
           <Button variant="primary" icon="plus" onClick={() => addEntry(newValue)}>
             Add
           </Button>

--- a/src/components/PathEditor/PathEditor.test.tsx
+++ b/src/components/PathEditor/PathEditor.test.tsx
@@ -56,8 +56,40 @@ describe("PathEditor", () => {
     vi.mocked(api.validatePaths).mockResolvedValue([true, true]);
     render(<PathEditor rawValue={A} onChange={onChange} />);
     await user.type(screen.getByPlaceholderText(/add new path/i), "/new/path");
-    await user.click(screen.getByRole("button", { name: /add/i }));
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
     expect(onChange).toHaveBeenCalledWith(`${A};/new/path`);
+  });
+
+  it("adds a selected folder from the new entry controls", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    vi.mocked(api.validatePaths).mockResolvedValue([true, true]);
+    vi.mocked(open).mockResolvedValue("/selected/new");
+    render(<PathEditor rawValue={A} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /browse folder to add/i }));
+
+    expect(open).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      defaultPath: undefined,
+    });
+    expect(onChange).toHaveBeenCalledWith(`${A};/selected/new`);
+  });
+
+  it("uses the typed new entry value as the folder picker default path", async () => {
+    const user = userEvent.setup();
+    vi.mocked(open).mockResolvedValue(null);
+    render(<PathEditor rawValue={A} onChange={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText(/add new path/i), "/partial");
+    await user.click(screen.getByRole("button", { name: /browse folder to add/i }));
+
+    expect(open).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      defaultPath: "/partial",
+    });
   });
 
   it("adds entry on Enter key", async () => {
@@ -100,6 +132,7 @@ describe("PathEditor", () => {
     render(<PathEditor rawValue=".COM;.EXE;.BAT" onChange={vi.fn()} allowFolderBrowse={false} />);
 
     expect(screen.queryByRole("button", { name: /browse folder for/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse folder to add/i })).not.toBeInTheDocument();
   });
 
   it("prevents row edits and controls when read-only", async () => {
@@ -112,6 +145,7 @@ describe("PathEditor", () => {
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /^remove/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /browse folder for/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse folder to add/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /add/i })).not.toBeInTheDocument();
   });
 

--- a/src/components/PathEditor/PathEditor.tsx
+++ b/src/components/PathEditor/PathEditor.tsx
@@ -99,6 +99,15 @@ export function PathEditor({
     return typeof selected === "string" ? selected : null;
   };
 
+  const handleBrowseNewEntry = async (currentValue: string) => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath: currentValue.trim() || undefined,
+    });
+    return typeof selected === "string" ? selected : null;
+  };
+
   const invalidCount = entries.filter((e) => e.exists === false).length;
 
   const { unresolvedRefs, hasWhitespace } = useMemo(() => {
@@ -157,6 +166,7 @@ export function PathEditor({
         onEntriesChange={handleEntriesChange}
         onBeforeChange={onBeforeReorder}
         onBrowseEntry={readOnly || !allowFolderBrowse ? undefined : handleBrowseEntry}
+        onBrowseNewEntry={readOnly || !allowFolderBrowse ? undefined : handleBrowseNewEntry}
         readOnly={readOnly}
         addPlaceholder="Add new path…"
       />


### PR DESCRIPTION
## Summary
- Add a folder picker button inside the new path input
- Add the selected folder directly as a new path entry
- Reuse the typed new-entry value as the folder picker default path
- Keep the picker hidden for PATHEXT and read-only lists
- Remove the stray separator dot between Custom export selection actions

## Verification
- npm test -- --run src/components/ImportExportPanel/ImportExportPanel.test.tsx src/components/PathEditor/PathEditor.test.tsx
- npm run lint
- npm run build