### PR TITLE
fix: show apply failure feedback

### DIFF
--- a/src-tauri/src/env_store.rs
+++ b/src-tauri/src/env_store.rs
@@ -71,8 +71,8 @@ pub struct UnsupportedEnvValue {
     pub registry_type: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "changeType", rename_all = "camelCase")]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "changeType", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum EnvChange {
     Set {
         name: String,
@@ -771,6 +771,28 @@ mod tests {
         let value = &read_snapshot_with(&b).unwrap().user["EXPANDED"];
         assert_eq!(value.value, "%USERPROFILE%\\tools");
         assert_eq!(value.kind, Some(EnvValueKind::ExpandString));
+    }
+
+    #[test]
+    fn env_change_deserializes_camel_case_fields() {
+        let change: EnvChange = serde_json::from_value(serde_json::json!({
+            "changeType": "set",
+            "name": "EXPANDED",
+            "value": "%USERPROFILE%\\tools",
+            "valueKind": "ExpandString",
+            "scope": "User"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            change,
+            EnvChange::Set {
+                name: "EXPANDED".into(),
+                value: "%USERPROFILE%\\tools".into(),
+                value_kind: EnvValueKind::ExpandString,
+                scope: VarScope::User,
+            }
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ export default function App() {
     handleDiffApply,
     handleDiffDismiss,
     applyBusy,
+    applyError,
   } = useDiff(refresh, setDialog);
 
   const { handleRefresh } = useAppInit({
@@ -103,7 +104,7 @@ export default function App() {
     setSnapshotsOpen,
   });
 
-  const { handleApplyStaged, busy: stagedBusy } = useApplyStaged({
+  const { handleApplyStaged, busy: stagedBusy, error: stagedError } = useApplyStaged({
     staged,
     clearStaged,
     refresh,
@@ -223,9 +224,11 @@ export default function App() {
           staged={staged}
           stagedDiff={stagedDiff}
           stagedBusy={stagedBusy}
+          stagedError={stagedError}
           onApplyStaged={handleApplyStaged}
           diffEntries={diffEntries}
           applyBusy={applyBusy}
+          applyError={applyError}
           onDiffApply={handleDiffApply}
           onDiffDismiss={handleDiffDismiss}
           onStageImport={handleStageImport}

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -17,9 +17,11 @@ interface Props {
   staged: Map<string, StagedChange>;
   stagedDiff: DiffEntry[];
   stagedBusy: boolean;
+  stagedError: string | null;
   onApplyStaged: (takeSnapshot: boolean) => Promise<void>;
   diffEntries: DiffEntry[];
   applyBusy: boolean;
+  applyError: string | null;
   onDiffApply: (accepted: DiffEntry[], reverted: DiffEntry[]) => Promise<void>;
   onDiffDismiss: () => void;
   onStageImport: (
@@ -47,9 +49,11 @@ export function AppModals({
   staged,
   stagedDiff,
   stagedBusy,
+  stagedError,
   onApplyStaged,
   diffEntries,
   applyBusy,
+  applyError,
   onDiffApply,
   onDiffDismiss,
   onStageImport,
@@ -79,6 +83,7 @@ export function AppModals({
         <StagedModal
           diff={stagedDiff}
           busy={stagedBusy}
+          error={stagedError}
           onApply={onApplyStaged}
           onClose={() => setDialog(null)}
         />
@@ -96,6 +101,7 @@ export function AppModals({
             onApply={onDiffApply}
             onDismiss={onDiffDismiss}
             busy={applyBusy}
+            error={applyError}
           />
         </div>
       </Modal>

--- a/src/components/DiffPanel/DiffPanel.test.tsx
+++ b/src/components/DiffPanel/DiffPanel.test.tsx
@@ -94,4 +94,16 @@ describe("DiffPanel", () => {
     expect(screen.getByText(/−1 removed/i)).toBeInTheDocument();
     expect(screen.getByText(/~1 changed/i)).toBeInTheDocument();
   });
+
+  it("shows apply errors", () => {
+    render(
+      <DiffPanel
+        entries={entries}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        error="Registry error: access denied"
+      />,
+    );
+    expect(screen.getByText("Registry error: access denied")).toBeInTheDocument();
+  });
 });

--- a/src/components/DiffPanel/DiffPanel.tsx
+++ b/src/components/DiffPanel/DiffPanel.tsx
@@ -10,9 +10,10 @@ interface Props {
   onApply: (accepted: DiffEntry[], reverted: DiffEntry[]) => void;
   onDismiss: () => void;
   busy?: boolean;
+  error?: string | null;
 }
 
-export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
+export function DiffPanel({ entries, onApply, onDismiss, busy, error }: Props) {
   const { t } = useI18n();
   const [accepted, setAccepted] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(entries.map((e) => [`${e.scope}:${e.name}`, true])),
@@ -97,17 +98,26 @@ export function DiffPanel({ entries, onApply, onDismiss, busy }: Props) {
       </div>
 
       <div className="px-5 py-3 border-t border-rim shrink-0 flex gap-2 justify-end">
-        <Button variant="ghost" size="sm" onClick={onDismiss}>
-          {t("diff.dismiss")}
-        </Button>
-        <Button variant="primary" size="sm" onClick={handleApply} disabled={busy}>
-          {busy
-            ? t("diff.applying")
-            : t("diff.apply", {
-                accepted: acceptedCount,
-                reverted: entries.length - acceptedCount,
-              })}
-        </Button>
+        <div className="flex flex-1 flex-col gap-2">
+          {error && (
+            <p className="rounded border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+              {error}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={onDismiss} disabled={busy}>
+            {t("diff.dismiss")}
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleApply} disabled={busy}>
+            {busy
+              ? t("diff.applying")
+              : t("diff.apply", {
+                  accepted: acceptedCount,
+                  reverted: entries.length - acceptedCount,
+                })}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -13,6 +13,7 @@ type ViewMode = "delta" | "full";
 interface StagedModalProps {
   diff: DiffEntry[];
   busy: boolean;
+  error?: string | null;
   onApply: (takeSnapshot: boolean) => void;
   onClose: () => void;
 }
@@ -130,7 +131,7 @@ function ListEntries({ value, className }: { value: string; className?: string }
   );
 }
 
-export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) {
+export function StagedModal({ diff, busy, error, onApply, onClose }: StagedModalProps) {
   const { t } = useI18n();
   const [viewMode, setViewMode] = useState<ViewMode>("delta");
 
@@ -271,6 +272,11 @@ export function StagedModal({ diff, busy, onApply, onClose }: StagedModalProps) 
       </div>
 
       <div className="px-6 py-4 border-t border-rim shrink-0 flex flex-col gap-3">
+        {error && (
+          <p className="rounded border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </p>
+        )}
         <div className="flex gap-2 justify-end">
           <Button variant="ghost" size="md" onClick={onClose} disabled={busy}>
             {t("staged.cancel")}

--- a/src/hooks/useApplyStaged.test.ts
+++ b/src/hooks/useApplyStaged.test.ts
@@ -104,6 +104,20 @@ describe("useApplyStaged", () => {
     expect(params.setDialog).toHaveBeenCalledWith(null);
   });
 
+  it("keeps the modal open and exposes the error when apply fails", async () => {
+    vi.mocked(api.applyEnvChanges).mockRejectedValue("Registry error: access denied");
+    const params = makeParams();
+    const { result } = renderHook(() => useApplyStaged(params));
+
+    await act(async () => {
+      await result.current.handleApplyStaged(false);
+    });
+
+    expect(params.clearStaged).not.toHaveBeenCalled();
+    expect(params.setDialog).not.toHaveBeenCalled();
+    expect(result.current.error).toBe("Registry error: access denied");
+  });
+
   it("busy is true during apply and false after", async () => {
     let resolveFn!: () => void;
     vi.mocked(api.applyEnvChanges).mockReturnValue(

--- a/src/hooks/useApplyStaged.ts
+++ b/src/hooks/useApplyStaged.ts
@@ -24,10 +24,12 @@ export function useApplyStaged({
   setDialog,
 }: Params) {
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleApplyStaged = useCallback(
     async (_takeSnapshot: boolean) => {
       setBusy(true);
+      setError(null);
       try {
         const changes: EnvChange[] = Array.from(staged.values(), (change) =>
           change.kind === "delete"
@@ -54,6 +56,7 @@ export function useApplyStaged({
         await refreshPathStatus();
       } catch (err) {
         console.error("Failed to apply staged changes", err);
+        setError(String(err));
       } finally {
         setBusy(false);
       }
@@ -61,5 +64,5 @@ export function useApplyStaged({
     [staged, clearStaged, refresh, refreshPathStatus, baselineRef, setDialog],
   );
 
-  return { handleApplyStaged, busy };
+  return { handleApplyStaged, busy, error };
 }

--- a/src/hooks/useDiff.ts
+++ b/src/hooks/useDiff.ts
@@ -13,12 +13,14 @@ interface UseDiffResult {
   handleDiffApply: (accepted: DiffEntry[], reverted: DiffEntry[]) => Promise<void>;
   handleDiffDismiss: () => void;
   applyBusy: boolean;
+  applyError: string | null;
 }
 
 export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): UseDiffResult {
   const baselineRef = useRef<EnvSnapshot | null>(null);
   const [diffEntries, setDiffEntries] = useState<DiffEntry[]>([]);
   const [applyBusy, setApplyBusy] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
 
   const checkForExternalChanges = useCallback(async () => {
     if (!baselineRef.current) return;
@@ -39,6 +41,7 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
   const handleDiffApply = useCallback(
     async (accepted: DiffEntry[], reverted: DiffEntry[]) => {
       setApplyBusy(true);
+      setApplyError(null);
       try {
         for (const entry of reverted) {
           const scope = entry.scope as VarScope;
@@ -54,6 +57,7 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
         await refresh();
       } catch (err) {
         console.error("Failed to apply diff", err);
+        setApplyError(String(err));
       } finally {
         setApplyBusy(false);
       }
@@ -64,6 +68,7 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
   const handleDiffDismiss = useCallback(() => {
     if (baselineRef.current) baselineRef.current = applyAccepted(baselineRef.current, diffEntries);
     setDiffEntries([]);
+    setApplyError(null);
     setDialog(null);
   }, [diffEntries, setDialog]);
 
@@ -74,5 +79,6 @@ export function useDiff(refresh: () => Promise<void>, setDialog: SetDialog): Use
     handleDiffApply,
     handleDiffDismiss,
     applyBusy,
+    applyError,
   };
 }


### PR DESCRIPTION
## Summary
- fix staged apply deserialization so frontend valueKind is accepted by the Rust command
- show apply errors in the staged changes and external changes dialogs instead of only logging to console
- keep apply dialogs open when writes fail so the user can retry after fixing the cause

## Verification
- cargo test env_change_deserializes_camel_case_fields -- --nocapture
- cargo test atomic_apply -- --nocapture
- cargo test
- npm test -- --run src/hooks/useApplyStaged.test.ts
- npm test -- --run
- npm run lint
- npm run build
- npm run tauri -- build --no-bundle