### PR TITLE
fix: repair Storybook docs and stories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ src-tauri/gen/
 # Promo drafts (local only)
 promo/
 
+# WinGet submission drafts (submitted to microsoft/winget-pkgs)
+winget-manifests/
+
 # Editor
 .vscode/*
 !.vscode/extensions.json

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -4,6 +4,25 @@
   color: var(--color-fg);
 }
 
+.sb-show-main.sb-main-padded,
+.sb-show-main.sb-main-fullscreen {
+  overflow: auto;
+}
+
+#storybook-docs {
+  min-height: 100vh;
+  overflow: visible;
+}
+
+.sbdocs-wrapper {
+  min-height: 100vh;
+  overflow: visible;
+}
+
+.sbdocs-content {
+  overflow: visible;
+}
+
 .sbdocs-content h1,
 .sbdocs-content h2,
 .sbdocs-content h3,

--- a/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
+++ b/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
@@ -1,6 +1,55 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ComponentProps } from "react";
+import { useEffect } from "react";
 import { fn } from "storybook/test";
+import { api } from "../../api";
+import type { EnvSnapshot, EnvVar } from "../../types";
 import { ImportExportPanel } from "./ImportExportPanel";
+
+const storyVars: EnvVar[] = [
+  {
+    name: "JAVA_HOME",
+    value: "C:\\Program Files\\Java\\jdk-21",
+    valueKind: "String",
+    scope: "User",
+    listSeparator: null,
+  },
+  {
+    name: "PATH",
+    value: "%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\tanao\\.cargo\\bin",
+    valueKind: "ExpandString",
+    scope: "User",
+    listSeparator: ";",
+  },
+  {
+    name: "GITHUB_TOKEN",
+    value: "ghp_exampletoken1234567890",
+    valueKind: "String",
+    scope: "User",
+    listSeparator: null,
+  },
+  {
+    name: "WINDIR",
+    value: "C:\\Windows",
+    valueKind: "String",
+    scope: "System",
+    listSeparator: null,
+  },
+];
+
+const storySnapshot: EnvSnapshot = {
+  user: {
+    JAVA_HOME: { value: "C:\\Program Files\\Java\\jdk-21", kind: "String" },
+    PATH: {
+      value: "%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\tanao\\.cargo\\bin",
+      kind: "ExpandString",
+    },
+    GITHUB_TOKEN: { value: "ghp_exampletoken1234567890", kind: "String" },
+  },
+  system: {
+    WINDIR: { value: "C:\\Windows", kind: "String" },
+  },
+};
 
 const meta = {
   title: "Components/ImportExportPanel",
@@ -19,11 +68,47 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const ExportDefault: Story = {};
+const withStoryApi: Story["decorators"] = [
+  (Story) => {
+    api.getEnvVars = async () => storyVars;
+    api.getRegistrySnapshot = async () => storySnapshot;
+    api.exportVars = async () => "C:\\Users\\tanao\\Downloads\\envarly-20260712.json";
+    api.exportCustomVars = async () =>
+      "C:\\Users\\tanao\\Downloads\\envarly-custom-20260712.json";
+    api.parseImport = async () => storySnapshot;
+    return <Story />;
+  },
+];
+
+function CustomExportStory(args: ComponentProps<typeof ImportExportPanel>) {
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      const custom = Array.from(document.querySelectorAll("label")).find((label) =>
+        label.textContent?.includes("Custom"),
+      );
+      custom?.click();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  return <ImportExportPanel {...args} />;
+}
+
+export const ExportDefault: Story = {
+  decorators: withStoryApi,
+};
+
+export const CustomExport: Story = {
+  decorators: withStoryApi,
+  render: (args) => <CustomExportStory {...args} />,
+};
 
 export const ImportEmpty: Story = {
+  decorators: withStoryApi,
   play: async ({ canvasElement }) => {
-    const btn = canvasElement.querySelector("button[class*='import']");
-    (btn as HTMLButtonElement | null)?.click();
+    const importTab = Array.from(canvasElement.querySelectorAll("label")).find((label) =>
+      label.textContent?.includes("Import"),
+    );
+    importTab?.click();
   },
 };


### PR DESCRIPTION
## Summary
- restore scrolling in Storybook Docs pages while keeping Canvas stories usable
- update the Import / Export Storybook stories with realistic mocked data and a current Custom export state
- ignore local WinGet manifest drafts now that they are submitted to microsoft/winget-pkgs instead of this repo

## Verification
- npm run build-storybook
- npm run lint
- npm test -- --run src/components/ImportExportPanel/ImportExportPanel.test.tsx
- Edge + Playwright check for scrollable Docs iframe
- Edge + Playwright check for Custom export story without the old Select all separator dot

Closes #95
Closes #96