### PR TITLE
fix: update licenses product metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 iray-tno
+Copyright (c) 2025-2026 iray-tno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/LicensesPanel/LicensesPanel.test.tsx
+++ b/src/components/LicensesPanel/LicensesPanel.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import packageMetadata from "../../../package.json";
+import { LicensesPanel } from "./LicensesPanel";
+
+describe("LicensesPanel", () => {
+  it("shows the current product version and copyright years", () => {
+    render(<LicensesPanel />);
+
+    expect(screen.getByText(`Version ${packageMetadata.version}`)).toBeInTheDocument();
+    expect(screen.getByText(/Copyright © 2025-2026 iray-tno/)).toBeInTheDocument();
+    expect(screen.getByText(/Copyright \(c\) 2025-2026 iray-tno/)).toBeInTheDocument();
+  });
+});

--- a/src/components/LicensesPanel/LicensesPanel.tsx
+++ b/src/components/LicensesPanel/LicensesPanel.tsx
@@ -1,5 +1,6 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useMemo, useState } from "react";
+import packageMetadata from "../../../package.json";
 import licensesData from "../../assets/oss-licenses.json";
 import { cn } from "../../lib/cn";
 import { Icon } from "../ui/Icon";
@@ -21,7 +22,7 @@ const ALL: Record<Ecosystem, LicenseEntry[]> = {
 
 const MIT_TEXT = `MIT License
 
-Copyright (c) 2025 iray-tno
+Copyright (c) 2025-2026 iray-tno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -122,7 +123,10 @@ export function LicensesPanel() {
           <div className="flex items-start justify-between gap-4">
             <div>
               <p className="text-sm font-semibold text-fg">Envarly</p>
-              <p className="text-xs text-dim mt-0.5">MIT License · Copyright © 2025 iray-tno</p>
+              <p className="text-xs text-muted mt-0.5">Version {packageMetadata.version}</p>
+              <p className="text-xs text-dim mt-0.5">
+                MIT License · Copyright © 2025-2026 iray-tno
+              </p>
             </div>
             <button
               type="button"


### PR DESCRIPTION
## Summary

- show the Envarly version from package metadata in the Licenses panel
- update the copyright range to 2025-2026 in the panel and LICENSE
- cover the displayed version and copyright text with a component test

## Verification

- npm test -- --run src/components/LicensesPanel/LicensesPanel.test.tsx
- npm run lint
- npm run build
- npm run check-version

Closes #93