### PR TITLE
fix: make Tauri the default dev runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ cd src-tauri && cargo fetch && cd ..  # prefetch Rust crates
 ## Development
 
 ```sh
-npm run tauri dev     # start Tauri + Vite dev server (hot-reload)
+npm run dev           # start Envarly with Tauri + Vite hot reload
+npm run dev:web       # frontend only; Windows environment data is unavailable
 ```
+
+Run these commands from the repository root. If mise is not activated in the current PowerShell
+session, use `mise exec -- npm run dev`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.2.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/tauri.mjs dev",
+    "dev:web": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "node scripts/tauri.mjs",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "1.2.1",
   "identifier": "com.envarly.app",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "npm run dev:web",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,15 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+
+describe("api runtime detection", () => {
+  beforeEach(() => {
+    vi.mocked(isTauri).mockReturnValue(false);
+  });
+
+  it("explains how to start the app when opened without Tauri", async () => {
+    await expect(api.getEnvVars()).rejects.toThrow(
+      "Tauri runtime unavailable. Start Envarly with `npm run dev`.",
+    );
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { createDemoApi, loadDemoFixture } from "./demo/createDemoApi";
 import type {
   EnvChange,
@@ -78,6 +78,9 @@ const normalApi: EnvarlyApi = {
 let apiPromise: Promise<EnvarlyApi> | null = null;
 
 async function getApi(): Promise<EnvarlyApi> {
+  if (!isTauri()) {
+    throw new Error("Tauri runtime unavailable. Start Envarly with `npm run dev`.");
+  }
   if (!apiPromise) {
     apiPromise = normalApi
       .getLaunchOptions()

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -40,6 +40,7 @@ i18n.use(initReactI18next).init({
 // Mock Tauri's invoke — components never call it directly (they go through api.ts)
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
+  isTauri: vi.fn(() => true),
 }));
 
 // jsdom does not implement matchMedia


### PR DESCRIPTION
## Summary
- make `npm run dev` launch the full Tauri app with access to Windows environment data
- move the Vite-only frontend to the explicit `npm run dev:web` command
- report an actionable error when the frontend is opened without the Tauri runtime
- document the repository-root and mise-based development commands

## Verification
- `npm test -- --run` (230 tests passed)
- `npm run lint`
- `npm run build`
- `npm run check-version`
- manually verified `npm run dev`
- manually verified `mise exec -- npm run dev`
- confirmed the development Tauri backend loaded 23 environment variables without inspecting their values

Closes #92