### PR TITLE
feat: add subtle UI motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { useI18n } from "./hooks/useI18n";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useLocalUndo } from "./hooks/useLocalUndo";
 import { usePathStatus } from "./hooks/usePathStatus";
+import { usePresence } from "./hooks/usePresence";
 import { useStaged } from "./hooks/useStaged";
 import { useStagingHandlers } from "./hooks/useStagingHandlers";
 import { useTheme } from "./hooks/useTheme";
@@ -35,6 +36,7 @@ export default function App() {
   const [elevated, setElevated] = useState(false);
   const [dialog, setDialog] = useState<Dialog>(null);
   const [snapshotsOpen, setSnapshotsOpen] = useState(false);
+  const snapshotsPresence = usePresence(snapshotsOpen);
   const diagnostics = useDiagnostics(vars);
 
   const {
@@ -104,7 +106,11 @@ export default function App() {
     setSnapshotsOpen,
   });
 
-  const { handleApplyStaged, busy: stagedBusy, error: stagedError } = useApplyStaged({
+  const {
+    handleApplyStaged,
+    busy: stagedBusy,
+    error: stagedError,
+  } = useApplyStaged({
     staged,
     clearStaged,
     refresh,
@@ -201,20 +207,25 @@ export default function App() {
             />
           </div>
 
-          {snapshotsOpen && (
-            <div className="w-[420px] shrink-0 flex flex-col border-l border-rim bg-panel overflow-hidden">
-              <div className="flex items-center justify-between px-5 py-3 border-b border-rim shrink-0">
-                <span className="text-sm font-semibold text-fg">{t("header.snapshots")}</span>
-                <IconButton
-                  aria-label="Close snapshots"
-                  icon="x"
-                  onClick={() => setSnapshotsOpen(false)}
-                />
+          {snapshotsPresence.mounted && (
+            <aside
+              className="motion-snapshot-panel shrink-0 border-l border-rim overflow-hidden"
+              data-state={snapshotsPresence.state}
+            >
+              <div className="motion-snapshot-content w-[420px] h-full flex flex-col bg-panel">
+                <div className="flex items-center justify-between px-5 py-3 border-b border-rim shrink-0">
+                  <span className="text-sm font-semibold text-fg">{t("header.snapshots")}</span>
+                  <IconButton
+                    aria-label="Close snapshots"
+                    icon="x"
+                    onClick={() => setSnapshotsOpen(false)}
+                  />
+                </div>
+                <div className="flex-1 overflow-hidden">
+                  <SnapshotPanel onStageSnapshot={handleStageSnapshot} />
+                </div>
               </div>
-              <div className="flex-1 overflow-hidden">
-                <SnapshotPanel onStageSnapshot={handleStageSnapshot} />
-              </div>
-            </div>
+            </aside>
           )}
         </main>
 

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMemo, useRef, useState } from "react";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import { cn } from "../../lib/cn";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
@@ -39,6 +40,7 @@ interface RowProps {
   onFocusEntry: (index: number) => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  reducedMotion: boolean;
 }
 
 function SortableRow({
@@ -52,9 +54,16 @@ function SortableRow({
   onFocusEntry,
   onMoveUp,
   onMoveDown,
+  reducedMotion,
 }: RowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: entry.id,
+    transition: reducedMotion
+      ? null
+      : {
+          duration: 160,
+          easing: "cubic-bezier(0.2, 0, 0, 1)",
+        },
   });
 
   return (
@@ -62,7 +71,7 @@ function SortableRow({
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        "flex items-center border-b border-rim-subtle last:border-0 transition-colors",
+        "motion-sortable-row flex items-center border-b border-rim-subtle last:border-0 transition-colors",
         "focus-within:ring-2 focus-within:ring-accent focus-within:ring-inset",
         isDragging ? "opacity-50 bg-hover" : "bg-canvas",
         entry.exists === false && "bg-danger/5",
@@ -186,6 +195,7 @@ export function SortableListEditor({
 }: Props) {
   const [newValue, setNewValue] = useState("");
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const reducedMotion = useReducedMotion();
 
   const dupCount = useMemo(() => {
     const seen = new Set<string>();
@@ -329,6 +339,7 @@ export function SortableListEditor({
                 onFocusEntry={focusEntry}
                 onMoveUp={() => moveEntry(entry.id, -1)}
                 onMoveDown={() => moveEntry(entry.id, 1)}
+                reducedMotion={reducedMotion}
               />
             ))}
             {entries.length === 0 && (

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,77 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Modal } from "./Modal";
+
+function mediaQuery(media: string, matches: boolean): MediaQueryList {
+  return {
+    matches,
+    media,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+}
+
+describe("Modal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(window.matchMedia).mockImplementation((query) =>
+      mediaQuery(query, query.includes("dark")),
+    );
+  });
+
+  it("keeps the dialog mounted while its exit motion completes", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(
+      <Modal open title="Example" onClose={vi.fn()}>
+        Content
+      </Modal>,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-state", "open");
+
+    rerender(
+      <Modal open={false} title="Example" onClose={vi.fn()}>
+        Content
+      </Modal>,
+    );
+
+    expect(container.querySelector('[role="dialog"]')).toHaveAttribute("data-state", "closed");
+    act(() => vi.advanceTimersByTime(180));
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  it("closes when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open title="Example" onClose={onClose}>
+        Content
+      </Modal>,
+    );
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not wait for exit motion when reduced motion is requested", () => {
+    vi.useFakeTimers();
+    vi.mocked(window.matchMedia).mockImplementation((query) => mediaQuery(query, true));
+    const { container, rerender } = render(
+      <Modal open title="Example" onClose={vi.fn()}>
+        Content
+      </Modal>,
+    );
+
+    rerender(
+      <Modal open={false} title="Example" onClose={vi.fn()}>
+        Content
+      </Modal>,
+    );
+    act(() => vi.runOnlyPendingTimers());
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useId } from "react";
+import { usePresence } from "../../hooks/usePresence";
 import { cn } from "../../lib/cn";
 import { IconButton } from "./IconButton";
 
@@ -31,6 +32,7 @@ export function Modal({
   children,
 }: Props) {
   const titleId = useId();
+  const presence = usePresence(open);
 
   useEffect(() => {
     if (!open) return;
@@ -41,11 +43,15 @@ export function Modal({
     return () => window.removeEventListener("keydown", handler);
   }, [open, onClose]);
 
-  if (!open) return null;
+  if (!presence.mounted) return null;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-6"
+      className={cn(
+        "fixed inset-0 z-50 flex items-center justify-center p-6",
+        presence.state === "closed" && "pointer-events-none",
+      )}
+      data-state={presence.state}
       role="dialog"
       aria-modal="true"
       aria-label={title ? undefined : ariaLabel}
@@ -53,7 +59,8 @@ export function Modal({
     >
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-canvas/70 backdrop-blur-sm"
+        className="motion-modal-backdrop absolute inset-0 bg-canvas/70 backdrop-blur-sm"
+        data-state={presence.state}
         onClick={onClose}
         aria-hidden="true"
       />
@@ -63,8 +70,10 @@ export function Modal({
         className={cn(
           "relative z-10 w-full flex flex-col bg-panel border border-rim rounded-lg shadow-xl",
           "max-h-[85vh] overflow-hidden",
+          "motion-modal-panel",
           sizeCls[size],
         )}
+        data-state={presence.state}
       >
         {title && (
           <div className="flex items-center justify-between px-6 py-4 border-b border-rim shrink-0">

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -27,7 +27,8 @@ export function Select<T extends string>({
       value={value}
       onChange={(e) => onValueChange(e.target.value as T)}
       className={cn(
-        "app-select bg-transparent text-dim cursor-pointer rounded transition-colors",
+        "app-select bg-transparent text-dim cursor-pointer rounded",
+        "transition-[color,background-color,border-color,box-shadow,transform] duration-150 ease-out active:scale-[0.99]",
         "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         className,

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "./useReducedMotion";
+
+export type PresenceState = "open" | "closed";
+
+export function usePresence(open: boolean, exitDuration = 180) {
+  const reducedMotion = useReducedMotion();
+  const [mounted, setMounted] = useState(open);
+  const [state, setState] = useState<PresenceState>(open ? "open" : "closed");
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setState("open");
+      return;
+    }
+
+    if (!mounted) return;
+
+    setState("closed");
+    const timeout = window.setTimeout(() => setMounted(false), reducedMotion ? 0 : exitDuration);
+    return () => window.clearTimeout(timeout);
+  }, [exitDuration, mounted, open, reducedMotion]);
+
+  return { mounted, state };
+}

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+const query = "(prefers-reduced-motion: reduce)";
+
+function getInitialPreference() {
+  return typeof window !== "undefined" && "matchMedia" in window
+    ? window.matchMedia(query).matches
+    : false;
+}
+
+export function useReducedMotion() {
+  const [reducedMotion, setReducedMotion] = useState(getInitialPreference);
+
+  useEffect(() => {
+    if (!("matchMedia" in window)) return;
+
+    const media = window.matchMedia(query);
+    const handleChange = () => setReducedMotion(media.matches);
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, []);
+
+  return reducedMotion;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,92 @@
 }
 
 @layer components {
+  @keyframes modal-backdrop-in {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes modal-backdrop-out {
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes modal-panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.985);
+    }
+  }
+
+  @keyframes modal-panel-out {
+    to {
+      opacity: 0;
+      transform: translateY(5px) scale(0.99);
+    }
+  }
+
+  @keyframes snapshot-panel-in {
+    from {
+      width: 0;
+      opacity: 0;
+    }
+  }
+
+  @keyframes snapshot-content-in {
+    from {
+      transform: translateX(12px);
+    }
+  }
+
+  .motion-modal-backdrop[data-state="open"] {
+    animation: modal-backdrop-in 140ms ease-out both;
+  }
+
+  .motion-modal-backdrop[data-state="closed"] {
+    animation: modal-backdrop-out 120ms ease-in both;
+  }
+
+  .motion-modal-panel[data-state="open"] {
+    animation: modal-panel-in 160ms cubic-bezier(0.2, 0, 0, 1) both;
+  }
+
+  .motion-modal-panel[data-state="closed"] {
+    animation: modal-panel-out 120ms ease-in both;
+  }
+
+  .motion-snapshot-panel {
+    width: 420px;
+    opacity: 1;
+    transition:
+      width 180ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 120ms ease-out;
+  }
+
+  .motion-snapshot-panel[data-state="open"] {
+    animation: snapshot-panel-in 180ms cubic-bezier(0.2, 0, 0, 1) both;
+  }
+
+  .motion-snapshot-panel[data-state="closed"] {
+    width: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .motion-snapshot-content {
+    transform: translateX(0);
+    transition: transform 180ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .motion-snapshot-panel[data-state="open"] .motion-snapshot-content {
+    animation: snapshot-content-in 180ms cubic-bezier(0.2, 0, 0, 1) both;
+  }
+
+  .motion-snapshot-panel[data-state="closed"] .motion-snapshot-content {
+    transform: translateX(12px);
+  }
+
   .app-select option {
     background: var(--color-surface);
     color: var(--color-fg);
@@ -105,5 +191,17 @@
   .app-select option:checked {
     background: var(--color-hover);
     color: var(--color-fg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-modal-backdrop,
+  .motion-modal-panel,
+  .motion-snapshot-panel,
+  .motion-snapshot-content,
+  .motion-sortable-row,
+  .app-select {
+    animation-duration: 0.01ms;
+    transition-duration: 0.01ms;
   }
 }


### PR DESCRIPTION
## Summary
- add short enter and exit motion to modal backdrops and panels
- animate the snapshot sidebar width and content position without layout overlap
- tune dnd-kit row settling and native Select trigger feedback
- respect prefers-reduced-motion in CSS and JavaScript
- keep closing overlays mounted only for the exit duration

Native select menus remain OS-managed; only the trigger feedback is animated.

## Verification
- npm run lint
- npm test -- --run (232 passed)
- npm run test:storybook -- --run (86 passed)
- npm run build
- npm run build-storybook
- npm run tauri -- build --debug --no-bundle
- verified Modal timing and browser console in Storybook
- verified snapshot sidebar layout in the demo-mode Tauri app

Closes #90