### PR TITLE
chore: update plist dependency

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2589,9 +2589,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary
- update plist from 1.9.0 to 1.10.0
- update transitive quick-xml from 0.39.4 to 0.41.0
- resolve RUSTSEC-2026-0194 and RUSTSEC-2026-0195
- keep the lockfile change limited to those two packages

## Verification
- cargo audit (0 vulnerabilities; existing allowed warnings remain)
- cargo test --quiet --manifest-path src-tauri/Cargo.toml (68 passed)
- cargo clippy --manifest-path src-tauri/Cargo.toml (passes with 4 existing warnings on Rust 1.96)

Closes #26