### PR TITLE
chore: clean up Rust audit and Clippy warnings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-broadcast"

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -24,20 +24,22 @@ mod dpapi {
     use std::ptr;
     use windows_sys::Win32::Foundation::LocalFree;
     use windows_sys::Win32::Security::Cryptography::{
-        CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB,
-        CRYPTPROTECT_UI_FORBIDDEN,
+        CryptProtectData, CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
     };
 
     pub fn protect(data: &[u8]) -> Result<Vec<u8>, EnvarlyError> {
         unsafe {
-            let mut input = CRYPT_INTEGER_BLOB {
+            let input = CRYPT_INTEGER_BLOB {
                 cbData: data.len() as u32,
                 pbData: data.as_ptr() as *mut u8,
             };
-            let mut output = CRYPT_INTEGER_BLOB { cbData: 0, pbData: ptr::null_mut() };
+            let mut output = CRYPT_INTEGER_BLOB {
+                cbData: 0,
+                pbData: ptr::null_mut(),
+            };
 
             let ok = CryptProtectData(
-                &mut input,
+                &input,
                 ptr::null(),
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -61,14 +63,17 @@ mod dpapi {
 
     pub fn unprotect(data: &[u8]) -> Result<Vec<u8>, EnvarlyError> {
         unsafe {
-            let mut input = CRYPT_INTEGER_BLOB {
+            let input = CRYPT_INTEGER_BLOB {
                 cbData: data.len() as u32,
                 pbData: data.as_ptr() as *mut u8,
             };
-            let mut output = CRYPT_INTEGER_BLOB { cbData: 0, pbData: ptr::null_mut() };
+            let mut output = CRYPT_INTEGER_BLOB {
+                cbData: 0,
+                pbData: ptr::null_mut(),
+            };
 
             let ok = CryptUnprotectData(
-                &mut input,
+                &input,
                 ptr::null_mut(),
                 ptr::null_mut(),
                 ptr::null_mut(),

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -361,7 +361,7 @@ pub fn parse_reg(content: &str) -> Result<EnvSnapshot, EnvarlyError> {
             continue;
         }
         if let Some(is_user) = current {
-            if let Some((name, value)) = parse_reg_entry(&line) {
+            if let Some((name, value)) = parse_reg_entry(line) {
                 if is_user {
                     user.insert(name, value);
                 } else {

--- a/src-tauri/src/snapshot.rs
+++ b/src-tauri/src/snapshot.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::crypto;
 use crate::env_store::EnvSnapshot;
@@ -37,7 +37,7 @@ fn snapshots_dir() -> Result<PathBuf, EnvarlyError> {
     Ok(dir)
 }
 
-fn write_snap(path: &PathBuf, meta: &SnapshotMeta) -> Result<(), EnvarlyError> {
+fn write_snap(path: &Path, meta: &SnapshotMeta) -> Result<(), EnvarlyError> {
     let json = serde_json::to_vec(meta)?;
     let encrypted = crypto::protect(&json)?;
     fs::write(path, encrypted)
@@ -45,7 +45,7 @@ fn write_snap(path: &PathBuf, meta: &SnapshotMeta) -> Result<(), EnvarlyError> {
     Ok(())
 }
 
-fn read_snap(path: &PathBuf) -> Result<SnapshotMeta, EnvarlyError> {
+fn read_snap(path: &Path) -> Result<SnapshotMeta, EnvarlyError> {
     let encrypted = fs::read(path)
         .map_err(|e| EnvarlyError::Snapshot(format!("Cannot read snapshot file: {e}")))?;
     let json = crypto::unprotect(&encrypted)?;
@@ -117,7 +117,7 @@ pub fn save_snapshot(snapshot: EnvSnapshot, label: &str) -> Result<SnapshotMeta,
 pub fn save_snapshot_to(
     snapshot: EnvSnapshot,
     label: &str,
-    dir: &PathBuf,
+    dir: &Path,
 ) -> Result<SnapshotMeta, EnvarlyError> {
     let now = Utc::now();
     let id = now.format("%Y%m%dT%H%M%SZ").to_string();
@@ -139,7 +139,7 @@ pub fn list_snapshots() -> Result<Vec<SnapshotMeta>, EnvarlyError> {
     list_snapshots_from(&snapshots_dir()?)
 }
 
-pub fn list_snapshots_from(dir: &PathBuf) -> Result<Vec<SnapshotMeta>, EnvarlyError> {
+pub fn list_snapshots_from(dir: &Path) -> Result<Vec<SnapshotMeta>, EnvarlyError> {
     let mut metas: Vec<SnapshotMeta> = Vec::new();
     for entry in fs::read_dir(dir)
         .map_err(|e| EnvarlyError::Snapshot(format!("Cannot read snapshots dir: {e}")))?
@@ -161,7 +161,7 @@ pub fn rename_snapshot(id: &str, label: &str) -> Result<SnapshotMeta, EnvarlyErr
     rename_snapshot_in(id, label, &snapshots_dir()?)
 }
 
-fn rename_snapshot_in(id: &str, label: &str, dir: &PathBuf) -> Result<SnapshotMeta, EnvarlyError> {
+fn rename_snapshot_in(id: &str, label: &str, dir: &Path) -> Result<SnapshotMeta, EnvarlyError> {
     let label = label.trim();
     if label.is_empty() {
         return Err(EnvarlyError::Snapshot(
@@ -184,7 +184,7 @@ pub fn delete_snapshot(id: &str) -> Result<(), EnvarlyError> {
 }
 
 #[cfg(test)]
-pub fn delete_snapshot_from(id: &str, dir: &PathBuf) -> Result<(), EnvarlyError> {
+pub fn delete_snapshot_from(id: &str, dir: &Path) -> Result<(), EnvarlyError> {
     let path = dir.join(format!("{id}.snap"));
     fs::remove_file(&path)
         .map_err(|e| EnvarlyError::Snapshot(format!("Cannot delete snapshot: {e}")))?;
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn list_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let list = list_snapshots_from(&dir.path().to_path_buf()).unwrap();
+        let list = list_snapshots_from(dir.path()).unwrap();
         assert!(list.is_empty());
     }
 
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn delete_nonexistent_returns_error() {
         let dir = tempfile::tempdir().unwrap();
-        let result = delete_snapshot_from("no-such-id", &dir.path().to_path_buf());
+        let result = delete_snapshot_from("no-such-id", dir.path());
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- update anyhow from 1.0.102 to 1.0.103 to remove RUSTSEC-2026-0190 from the audit report
- remove unnecessary mutable DPAPI input references
- simplify a redundant REG parser borrow
- accept Path instead of PathBuf references in snapshot helpers
- remove now-unnecessary test path allocations

## Verification
- cargo audit (0 vulnerabilities; anyhow warning removed)
- cargo test --quiet --manifest-path src-tauri/Cargo.toml (68 passed)
- cargo clippy --all-targets --all-features --manifest-path src-tauri/Cargo.toml -- -D warnings
- rustfmt --check on all touched Rust files