### PR TITLE
ci: enforce Rust formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,10 +126,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+        working-directory: src-tauri
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -2,7 +2,11 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
-#[command(name = "envarly", about = "Windows environment variable manager", version)]
+#[command(
+    name = "envarly",
+    about = "Windows environment variable manager",
+    version
+)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -140,7 +144,11 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
             crate::path_manage::cleanup_path(dry_run);
         }
 
-        Command::Export { scope, format, output } => {
+        Command::Export {
+            scope,
+            format,
+            output,
+        } => {
             let snapshot = env_store::read_snapshot()?;
             let scope_str = match scope {
                 ScopeArg::User => "User",
@@ -148,11 +156,11 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
                 ScopeArg::All => "All",
             };
             let content = match format {
-                ExportFormat::Json    => export::to_json(&snapshot, scope_str),
-                ExportFormat::Reg     => export::to_reg(&snapshot, scope_str),
-                ExportFormat::Ps1     => export::to_ps1(&snapshot, scope_str),
-                ExportFormat::DscV2   => export::to_dsc_v2(&snapshot, scope_str),
-                ExportFormat::DscV3   => export::to_dsc_v3(&snapshot, scope_str),
+                ExportFormat::Json => export::to_json(&snapshot, scope_str),
+                ExportFormat::Reg => export::to_reg(&snapshot, scope_str),
+                ExportFormat::Ps1 => export::to_ps1(&snapshot, scope_str),
+                ExportFormat::DscV2 => export::to_dsc_v2(&snapshot, scope_str),
+                ExportFormat::DscV3 => export::to_dsc_v3(&snapshot, scope_str),
                 ExportFormat::Ansible => export::to_ansible(&snapshot, scope_str),
             };
             match output {

--- a/src-tauri/src/env_store.rs
+++ b/src-tauri/src/env_store.rs
@@ -72,7 +72,11 @@ pub struct UnsupportedEnvValue {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(tag = "changeType", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "changeType",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum EnvChange {
     Set {
         name: String,

--- a/src-tauri/src/path_manage.rs
+++ b/src-tauri/src/path_manage.rs
@@ -9,8 +9,7 @@ use winreg::RegKey;
 use crate::error::EnvarlyError;
 
 const USER_ENV_KEY: &str = "Environment";
-const SYSTEM_ENV_KEY: &str =
-    r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+const SYSTEM_ENV_KEY: &str = r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
 const PATH_NAME: &str = "Path";
 
 // ── Pure helpers (testable without registry) ──────────────────────────────
@@ -18,7 +17,10 @@ const PATH_NAME: &str = "Path";
 /// Returns a new PATH string with `dir` appended, or `None` if already present.
 pub fn compute_add(current: &str, dir: &str) -> Option<String> {
     let dir_lc = dir.to_lowercase();
-    if current.split(';').any(|p| p.trim().to_lowercase() == dir_lc) {
+    if current
+        .split(';')
+        .any(|p| p.trim().to_lowercase() == dir_lc)
+    {
         return None;
     }
     Some(if current.trim_end_matches(';').is_empty() {
@@ -48,12 +50,20 @@ pub fn compute_remove(current: &str, dir: &str) -> Option<String> {
 #[cfg(windows)]
 fn open_path_key(user: bool, write: bool) -> Result<RegKey, EnvarlyError> {
     if user {
-        let flags = if write { KEY_SET_VALUE | KEY_QUERY_VALUE } else { KEY_QUERY_VALUE };
+        let flags = if write {
+            KEY_SET_VALUE | KEY_QUERY_VALUE
+        } else {
+            KEY_QUERY_VALUE
+        };
         RegKey::predef(HKEY_CURRENT_USER)
             .open_subkey_with_flags(USER_ENV_KEY, flags)
             .map_err(EnvarlyError::Registry)
     } else {
-        let flags = if write { KEY_SET_VALUE | KEY_QUERY_VALUE } else { KEY_QUERY_VALUE };
+        let flags = if write {
+            KEY_SET_VALUE | KEY_QUERY_VALUE
+        } else {
+            KEY_QUERY_VALUE
+        };
         RegKey::predef(HKEY_LOCAL_MACHINE)
             .open_subkey_with_flags(SYSTEM_ENV_KEY, flags)
             .map_err(EnvarlyError::Registry)
@@ -83,10 +93,7 @@ fn write_path_str(key: &RegKey, value: &str) -> Result<(), EnvarlyError> {
         .get_raw_value(PATH_NAME)
         .map(|rv| rv.vtype)
         .unwrap_or(winreg::enums::RegType::REG_EXPAND_SZ);
-    let mut bytes: Vec<u8> = value
-        .encode_utf16()
-        .flat_map(|w| w.to_le_bytes())
-        .collect();
+    let mut bytes: Vec<u8> = value.encode_utf16().flat_map(|w| w.to_le_bytes()).collect();
     bytes.extend([0u8, 0u8]); // null terminator
     key.set_raw_value(PATH_NAME, &winreg::RegValue { bytes, vtype })
         .map_err(EnvarlyError::Registry)
@@ -223,10 +230,7 @@ mod tests {
 
     #[test]
     fn add_trims_trailing_semicolons() {
-        assert_eq!(
-            compute_add(r"C:\a;", r"C:\b"),
-            Some(r"C:\a;C:\b".into())
-        );
+        assert_eq!(compute_add(r"C:\a;", r"C:\b"), Some(r"C:\a;C:\b".into()));
     }
 
     #[test]
@@ -249,9 +253,6 @@ mod tests {
 
     #[test]
     fn remove_is_case_insensitive() {
-        assert_eq!(
-            compute_remove(r"C:\FOO", r"C:\foo"),
-            Some(String::new())
-        );
+        assert_eq!(compute_remove(r"C:\FOO", r"C:\foo"), Some(String::new()));
     }
 }


### PR DESCRIPTION
## Summary
- format the remaining Rust sources with the current stable rustfmt
- install the rustfmt component in the Rust lint job
- run cargo fmt --all -- --check before Clippy
- keep the formatting and CI changes in separate commits

## Verification
- cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --all-targets --all-features --manifest-path src-tauri/Cargo.toml -- -D warnings
- cargo test --quiet --manifest-path src-tauri/Cargo.toml (68 passed)