### PR TITLE
fix: smooth list and select motion

### DIFF
--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -125,6 +125,7 @@ export function AppHeader({
             value={language}
             onValueChange={setLanguage}
             options={languageOptions}
+            density="compact"
             className="text-xs"
           />
         </div>

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -331,7 +331,8 @@ export function DetailPanel({
               value={valueKindSelection}
               onValueChange={setValueKindSelection}
               disabled={readOnly}
-              className="w-full max-w-sm px-2.5 py-1.5 bg-surface border border-rim text-sm text-fg"
+              containerClassName="w-full max-w-sm"
+              className="w-full px-2.5 py-1.5 bg-surface border border-rim text-sm text-fg"
             />
             {resolvedValueKind === "String" && expandedValue && (
               <div className="flex items-center gap-2 text-xs text-warn">

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@dnd-kit/core";
 import {
   arrayMove,
+  defaultAnimateLayoutChanges,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
@@ -21,6 +22,19 @@ import { cn } from "../../lib/cn";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { IconButton } from "../ui/IconButton";
+
+type LayoutChangeArgs = Parameters<typeof defaultAnimateLayoutChanges>[0];
+
+function animateLayoutChanges(args: LayoutChangeArgs) {
+  return (
+    defaultAnimateLayoutChanges(args) ||
+    (args.previousItems !== args.items && args.index !== args.newIndex)
+  );
+}
+
+function disableLayoutChanges() {
+  return false;
+}
 
 export interface ListEntry {
   id: string;
@@ -58,6 +72,7 @@ function SortableRow({
 }: RowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: entry.id,
+    animateLayoutChanges: reducedMotion ? disableLayoutChanges : animateLayoutChanges,
     transition: reducedMotion
       ? null
       : {

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -9,32 +9,18 @@ import {
 } from "@dnd-kit/core";
 import {
   arrayMove,
-  defaultAnimateLayoutChanges,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 import { cn } from "../../lib/cn";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { IconButton } from "../ui/IconButton";
-
-type LayoutChangeArgs = Parameters<typeof defaultAnimateLayoutChanges>[0];
-
-function animateLayoutChanges(args: LayoutChangeArgs) {
-  return (
-    defaultAnimateLayoutChanges(args) ||
-    (args.previousItems !== args.items && args.index !== args.newIndex)
-  );
-}
-
-function disableLayoutChanges() {
-  return false;
-}
 
 export interface ListEntry {
   id: string;
@@ -47,6 +33,8 @@ interface RowProps {
   index: number;
   entry: ListEntry;
   inputRef: (el: HTMLInputElement | null) => void;
+  rowRef: (el: HTMLLIElement | null) => void;
+  keyboardOffset?: number;
   readOnly: boolean;
   onRemove: () => void;
   onEdit: (val: string) => void;
@@ -61,6 +49,8 @@ function SortableRow({
   index,
   entry,
   inputRef,
+  rowRef,
+  keyboardOffset,
   readOnly,
   onRemove,
   onEdit,
@@ -72,7 +62,6 @@ function SortableRow({
 }: RowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: entry.id,
-    animateLayoutChanges: reducedMotion ? disableLayoutChanges : animateLayoutChanges,
     transition: reducedMotion
       ? null
       : {
@@ -83,8 +72,22 @@ function SortableRow({
 
   return (
     <li
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      ref={(el) => {
+        setNodeRef(el);
+        rowRef(el);
+      }}
+      style={{
+        transform:
+          keyboardOffset === undefined
+            ? CSS.Transform.toString(transform)
+            : `translateY(${keyboardOffset}px)`,
+        transition:
+          keyboardOffset === undefined
+            ? transition
+            : keyboardOffset === 0
+              ? "transform 160ms cubic-bezier(0.2, 0, 0, 1)"
+              : "none",
+      }}
       className={cn(
         "motion-sortable-row flex items-center border-b border-rim-subtle last:border-0 transition-colors",
         "focus-within:ring-2 focus-within:ring-accent focus-within:ring-inset",
@@ -210,7 +213,50 @@ export function SortableListEditor({
 }: Props) {
   const [newValue, setNewValue] = useState("");
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const rowRefs = useRef(new Map<string, HTMLLIElement>());
+  const keyboardLayoutRef = useRef<Map<string, number> | null>(null);
+  const [keyboardOffsets, setKeyboardOffsets] = useState(new Map<string, number>());
+  const keyboardFrameRef = useRef<number | null>(null);
+  const keyboardTimerRef = useRef<number | null>(null);
   const reducedMotion = useReducedMotion();
+
+  useLayoutEffect(() => {
+    const previousLayout = keyboardLayoutRef.current;
+    keyboardLayoutRef.current = null;
+    if (!previousLayout || reducedMotion) return;
+
+    const offsets = new Map<string, number>();
+    for (const entry of entries) {
+      const row = rowRefs.current.get(entry.id);
+      const previousTop = previousLayout.get(entry.id);
+      if (!row || previousTop === undefined) continue;
+
+      const offset = previousTop - row.getBoundingClientRect().top;
+      if (offset !== 0) offsets.set(entry.id, offset);
+    }
+
+    if (offsets.size === 0) return;
+    if (keyboardFrameRef.current !== null) cancelAnimationFrame(keyboardFrameRef.current);
+    if (keyboardTimerRef.current !== null) window.clearTimeout(keyboardTimerRef.current);
+
+    setKeyboardOffsets(offsets);
+    keyboardFrameRef.current = requestAnimationFrame(() => {
+      setKeyboardOffsets(new Map([...offsets.keys()].map((id) => [id, 0])));
+      keyboardTimerRef.current = window.setTimeout(() => {
+        setKeyboardOffsets(new Map());
+        keyboardTimerRef.current = null;
+      }, 160);
+      keyboardFrameRef.current = null;
+    });
+  }, [entries, reducedMotion]);
+
+  useLayoutEffect(
+    () => () => {
+      if (keyboardFrameRef.current !== null) cancelAnimationFrame(keyboardFrameRef.current);
+      if (keyboardTimerRef.current !== null) window.clearTimeout(keyboardTimerRef.current);
+    },
+    [],
+  );
 
   const dupCount = useMemo(() => {
     const seen = new Set<string>();
@@ -294,6 +340,14 @@ export function SortableListEditor({
     if (idx === -1) return;
     const next = idx + dir;
     if (next < 0 || next >= entries.length) return;
+    keyboardLayoutRef.current = reducedMotion
+      ? null
+      : new Map(
+          entries.flatMap((entry) => {
+            const row = rowRefs.current.get(entry.id);
+            return row ? [[entry.id, row.getBoundingClientRect().top] as const] : [];
+          }),
+        );
     onBeforeChange?.();
     onEntriesChange(arrayMove(entries, idx, next));
   };
@@ -347,6 +401,11 @@ export function SortableListEditor({
                 inputRef={(el) => {
                   inputRefs.current[index] = el;
                 }}
+                rowRef={(el) => {
+                  if (el) rowRefs.current.set(entry.id, el);
+                  else rowRefs.current.delete(entry.id);
+                }}
+                keyboardOffset={keyboardOffsets.get(entry.id)}
                 readOnly={readOnly}
                 onRemove={() => removeEntry(entry.id)}
                 onEdit={(val) => editEntry(entry.id, val)}

--- a/src/components/NewVarModal/NewVarModal.tsx
+++ b/src/components/NewVarModal/NewVarModal.tsx
@@ -89,6 +89,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
           ]}
           value={valueKind}
           onValueChange={setValueKind}
+          containerClassName="w-full"
           className="w-full px-2.5 py-1.5 bg-surface border border-rim text-sm text-fg"
         />
       </div>

--- a/src/components/PathEditor/PathEditor.test.tsx
+++ b/src/components/PathEditor/PathEditor.test.tsx
@@ -163,6 +163,16 @@ describe("PathEditor", () => {
     expect(first).toHaveFocus();
   });
 
+  it("reorders entries with Alt and arrow keys", () => {
+    const onChange = vi.fn();
+    vi.mocked(api.validatePaths).mockResolvedValue([true, true]);
+    render(<PathEditor rawValue={`${A};${C}`} onChange={onChange} />);
+
+    fireEvent.keyDown(screen.getByDisplayValue(A), { key: "ArrowDown", altKey: true });
+
+    expect(onChange).toHaveBeenCalledWith(`${C};${A}`);
+  });
+
   it("shows unresolvable reference warning when allVars is provided and a %VAR% is unknown", () => {
     const knownVars: EnvVar[] = [
       { name: "SystemRoot", scope: "System", value: "C:\\Windows", listSeparator: null },

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -165,6 +165,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
           value={sortBy}
           onValueChange={setSortBy}
           options={sortOptions}
+          density="compact"
           className="text-[10px]"
         />
       </div>

--- a/src/components/ui/Select.stories.tsx
+++ b/src/components/ui/Select.stories.tsx
@@ -18,6 +18,7 @@ export const Language: Story = {
         aria-label="Language"
         value={language}
         onValueChange={setLanguage}
+        density="compact"
         options={[
           { value: "en", label: "English" },
           { value: "ja", label: "日本語" },
@@ -35,6 +36,7 @@ export const SortOrder: Story = {
         aria-label="Sort order"
         value={sortBy}
         onValueChange={setSortBy}
+        density="compact"
         options={[
           { value: "name-asc", label: "Name A-Z" },
           { value: "name-desc", label: "Name Z-A" },

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -40,7 +40,7 @@ export function Select<T extends string>({
           "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
           "disabled:opacity-50 disabled:cursor-not-allowed",
           className,
-          compact ? "pl-1 pr-5" : "pl-2.5 pr-7",
+          compact ? "pl-1 pr-5" : "pl-2 pr-6",
         )}
       >
         {options.map((option) => (
@@ -54,7 +54,7 @@ export function Select<T extends string>({
         size={12}
         className={cn(
           "pointer-events-none absolute top-1/2 -translate-y-1/2 text-dim",
-          compact ? "right-1" : "right-2.5",
+          compact ? "right-1" : "right-2",
           props.disabled && "opacity-50",
         )}
       />

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -14,6 +14,7 @@ interface Props<T extends string>
   value: T;
   onValueChange: (value: T) => void;
   containerClassName?: string;
+  density?: "regular" | "compact";
 }
 
 export function Select<T extends string>({
@@ -22,8 +23,11 @@ export function Select<T extends string>({
   onValueChange,
   className,
   containerClassName,
+  density = "regular",
   ...props
 }: Props<T>) {
+  const compact = density === "compact";
+
   return (
     <span className={cn("relative inline-flex", containerClassName)}>
       <select
@@ -31,12 +35,12 @@ export function Select<T extends string>({
         value={value}
         onChange={(e) => onValueChange(e.target.value as T)}
         className={cn(
-          "app-select appearance-none bg-transparent text-dim cursor-pointer rounded pl-1.5",
+          "app-select appearance-none bg-transparent text-dim cursor-pointer rounded",
           "transition-[color,background-color,border-color,box-shadow] duration-150 ease-out",
           "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
           "disabled:opacity-50 disabled:cursor-not-allowed",
           className,
-          "pr-6",
+          compact ? "pl-1 pr-5" : "pl-2.5 pr-7",
         )}
       >
         {options.map((option) => (
@@ -49,7 +53,8 @@ export function Select<T extends string>({
         name="chevron-down"
         size={12}
         className={cn(
-          "pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-dim",
+          "pointer-events-none absolute top-1/2 -translate-y-1/2 text-dim",
+          compact ? "right-1" : "right-2.5",
           props.disabled && "opacity-50",
         )}
       />

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -31,7 +31,7 @@ export function Select<T extends string>({
         value={value}
         onChange={(e) => onValueChange(e.target.value as T)}
         className={cn(
-          "app-select appearance-none bg-transparent text-dim cursor-pointer rounded",
+          "app-select appearance-none bg-transparent text-dim cursor-pointer rounded pl-1.5",
           "transition-[color,background-color,border-color,box-shadow] duration-150 ease-out",
           "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
           "disabled:opacity-50 disabled:cursor-not-allowed",

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -28,7 +28,7 @@ export function Select<T extends string>({
       onChange={(e) => onValueChange(e.target.value as T)}
       className={cn(
         "app-select bg-transparent text-dim cursor-pointer rounded",
-        "transition-[color,background-color,border-color,box-shadow,transform] duration-150 ease-out active:scale-[0.99]",
+        "transition-[color,background-color,border-color,box-shadow] duration-150 ease-out",
         "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         className,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,5 +1,6 @@
 import type { SelectHTMLAttributes } from "react";
 import { cn } from "../../lib/cn";
+import { Icon } from "./Icon";
 
 export interface SelectOption<T extends string> {
   value: T;
@@ -12,6 +13,7 @@ interface Props<T extends string>
   options: readonly SelectOption<T>[];
   value: T;
   onValueChange: (value: T) => void;
+  containerClassName?: string;
 }
 
 export function Select<T extends string>({
@@ -19,26 +21,38 @@ export function Select<T extends string>({
   value,
   onValueChange,
   className,
+  containerClassName,
   ...props
 }: Props<T>) {
   return (
-    <select
-      {...props}
-      value={value}
-      onChange={(e) => onValueChange(e.target.value as T)}
-      className={cn(
-        "app-select bg-transparent text-dim cursor-pointer rounded",
-        "transition-[color,background-color,border-color,box-shadow] duration-150 ease-out",
-        "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
-        "disabled:opacity-50 disabled:cursor-not-allowed",
-        className,
-      )}
-    >
-      {options.map((option) => (
-        <option key={option.value} value={option.value} disabled={option.disabled}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+    <span className={cn("relative inline-flex", containerClassName)}>
+      <select
+        {...props}
+        value={value}
+        onChange={(e) => onValueChange(e.target.value as T)}
+        className={cn(
+          "app-select appearance-none bg-transparent text-dim cursor-pointer rounded",
+          "transition-[color,background-color,border-color,box-shadow] duration-150 ease-out",
+          "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          className,
+          "pr-6",
+        )}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value} disabled={option.disabled}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <Icon
+        name="chevron-down"
+        size={12}
+        className={cn(
+          "pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-dim",
+          props.disabled && "opacity-50",
+        )}
+      />
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- smooth Select interactions by removing native press scaling
- use the shared SVG chevron with balanced regular and compact spacing
- animate Alt+Up/Down list reordering with a CSS FLIP transition
- preserve reduced-motion behavior
- cover keyboard reordering with a regression test

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run test:storybook -- --run`
- `npm run build`
- `npm run tauri -- build`
- verified Select spacing and keyboard reorder motion in Storybook