### PR TITLE
style: align spacing to the 8px grid

### DIFF
--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -50,7 +50,7 @@ export function AppHeader({
       style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
     >
       <div
-        className="flex items-center gap-1.5"
+        className="flex items-center gap-1"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <Button variant="ghost" size="sm" icon="refresh" onClick={onRefresh} disabled={loading}>

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -228,7 +228,7 @@ export function DetailPanel({
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Header — fixed height so button appearance doesn't shift layout */}
       <div className="flex items-center gap-3 px-6 h-[60px] border-b border-rim-subtle shrink-0">
-        <div className="flex items-center gap-2.5 flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
           <h2 className="font-mono font-semibold text-base text-fg truncate">{variable.name}</h2>
           <Badge variant={variable.scope === "User" ? "user" : "system"}>{variable.scope}</Badge>
           {readOnly && (
@@ -237,7 +237,7 @@ export function DetailPanel({
               <button
                 type="button"
                 onClick={() => api.restartAsAdmin()}
-                className="text-[10px] text-accent hover:text-accent-hi px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors shrink-0"
+                className="text-[10px] text-accent hover:text-accent-hi px-2 py-1 rounded hover:bg-accent/10 transition-colors shrink-0"
                 title="Restart as administrator to edit system variables"
               >
                 {t("detail.restart_admin")}
@@ -245,12 +245,12 @@ export function DetailPanel({
             </>
           )}
           {isStagedSet && !dirty && (
-            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent shrink-0">
+            <span className="text-[10px] font-semibold px-2 py-1 rounded bg-accent/15 text-accent shrink-0">
               {t("detail.staged_badge")}
             </span>
           )}
           {isStagedDelete && (
-            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-danger/15 text-danger shrink-0">
+            <span className="text-[10px] font-semibold px-2 py-1 rounded bg-danger/15 text-danger shrink-0">
               {t("detail.staged_delete_badge")}
             </span>
           )}
@@ -279,10 +279,10 @@ export function DetailPanel({
       </div>
 
       {description && (
-        <div className="flex items-center gap-2.5 px-6 py-2 border-b border-rim-subtle bg-hover/40 shrink-0">
+        <div className="flex items-center gap-2 px-6 py-2 border-b border-rim-subtle bg-hover/40 shrink-0">
           <Icon name="info" size={14} className="text-dim" />
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-surface border border-rim text-dim shrink-0 select-none">
+            <span className="inline-flex items-center px-2 py-1 rounded text-[10px] font-semibold bg-surface border border-rim text-dim shrink-0 select-none">
               {t(description.categoryKey)}
             </span>
             <p className="text-xs text-muted leading-relaxed">{t(description.summaryKey)}</p>
@@ -307,7 +307,7 @@ export function DetailPanel({
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-1">
             <label
               htmlFor="detail-value-kind"
               className="text-xs font-semibold text-muted uppercase tracking-wide"
@@ -332,7 +332,7 @@ export function DetailPanel({
               onValueChange={setValueKindSelection}
               disabled={readOnly}
               containerClassName="w-full max-w-sm"
-              className="w-full px-2.5 py-1.5 bg-surface border border-rim text-sm text-fg"
+              className="w-full px-2 py-2 bg-surface border border-rim text-sm text-fg"
             />
             {resolvedValueKind === "String" && expandedValue && (
               <div className="flex items-center gap-2 text-xs text-warn">
@@ -358,7 +358,7 @@ export function DetailPanel({
                 <button
                   type="button"
                   onClick={() => onStageAddToPath(variable.scope as "User" | "System")}
-                  className="text-[10px] text-accent hover:text-accent-hi px-1.5 py-0.5 rounded hover:bg-accent/10 transition-colors"
+                  className="text-[10px] text-accent hover:text-accent-hi px-2 py-1 rounded hover:bg-accent/10 transition-colors"
                   title="Stage adding Envarly install directory to this PATH variable"
                 >
                   {t("detail.add_to_path")}
@@ -370,7 +370,7 @@ export function DetailPanel({
                 <button
                   type="button"
                   onClick={() => setOverrideSeparator("plain")}
-                  className="text-[10px] text-dim hover:text-muted px-1.5 py-0.5 rounded hover:bg-hover transition-colors"
+                  className="text-[10px] text-dim hover:text-muted px-2 py-1 rounded hover:bg-hover transition-colors"
                 >
                   {t("detail.plain_text")}
                 </button>
@@ -379,14 +379,14 @@ export function DetailPanel({
                   <button
                     type="button"
                     onClick={() => setOverrideSeparator(";")}
-                    className="text-[10px] text-dim hover:text-muted px-1.5 py-0.5 rounded hover:bg-hover transition-colors"
+                    className="text-[10px] text-dim hover:text-muted px-2 py-1 rounded hover:bg-hover transition-colors"
                   >
                     {t("detail.list_semicolon")}
                   </button>
                   <button
                     type="button"
                     onClick={() => setOverrideSeparator(",")}
-                    className="text-[10px] text-dim hover:text-muted px-1.5 py-0.5 rounded hover:bg-hover transition-colors"
+                    className="text-[10px] text-dim hover:text-muted px-2 py-1 rounded hover:bg-hover transition-colors"
                   >
                     {t("detail.list_comma")}
                   </button>
@@ -438,7 +438,7 @@ export function DetailPanel({
           )}
 
           {/* Metadata */}
-          <div className="flex flex-col gap-1.5 pt-2 border-t border-rim-subtle mt-1">
+          <div className="flex flex-col gap-1 pt-2 border-t border-rim-subtle mt-1">
             {[
               [t("detail.meta_scope"), variable.scope],
               [t("detail.meta_length_label"), t("detail.meta_length", { count: value.length })],

--- a/src/components/DiagnosticsPanel/DiagnosticsPanel.tsx
+++ b/src/components/DiagnosticsPanel/DiagnosticsPanel.tsx
@@ -38,7 +38,7 @@ export function DiagnosticsPanel({ diagnostics, elevated, onStageAction }: Props
           return (
             <div
               key={diagnostic.id}
-              className="flex items-start gap-3 px-4 py-2.5 border-b border-rim-subtle last:border-0"
+              className="flex items-start gap-3 px-4 py-2 border-b border-rim-subtle last:border-0"
             >
               <Badge variant={diagnostic.scope === "User" ? "user" : "system"}>
                 {diagnostic.scope}

--- a/src/components/DiffPanel/EntryRow.tsx
+++ b/src/components/DiffPanel/EntryRow.tsx
@@ -56,7 +56,7 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
         !accepted && "border-dashed",
       )}
     >
-      <div className="flex items-center gap-2.5 px-3 py-2">
+      <div className="flex items-center gap-2 px-3 py-2">
         <input
           type="checkbox"
           checked={accepted}
@@ -73,7 +73,7 @@ export function EntryRow({ entry, accepted, onToggle }: EntryRowProps) {
         </span>
         <span
           className={cn(
-            "text-[10px] uppercase tracking-wide font-semibold shrink-0 px-1.5 py-0.5 rounded",
+            "text-[10px] uppercase tracking-wide font-semibold shrink-0 px-2 py-1 rounded",
             KIND_COLORS[entry.kind],
           )}
         >

--- a/src/components/ImportExportPanel/VarTable.tsx
+++ b/src/components/ImportExportPanel/VarTable.tsx
@@ -38,7 +38,7 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
           size="sm"
           onClick={() => onToggleAll(true)}
           disabled={allChecked}
-          className="px-1.5 py-0.5"
+          className="px-2 py-1"
         >
           {t("var_table.select_all")}
         </Button>
@@ -47,7 +47,7 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
           size="sm"
           onClick={() => onToggleAll(false)}
           disabled={noneChecked}
-          className="px-1.5 py-0.5"
+          className="px-2 py-1"
         >
           {t("var_table.deselect_all")}
         </Button>
@@ -60,7 +60,7 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
         <table className="w-full text-xs">
           <thead>
             <tr className="border-b border-rim bg-surface text-muted uppercase text-[10px] tracking-wide">
-              <th className="w-8 px-2 py-1.5 text-center">
+              <th className="w-8 px-2 py-2 text-center">
                 <input
                   type="checkbox"
                   checked={allChecked}
@@ -69,9 +69,9 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
                   aria-label="Select all"
                 />
               </th>
-              <th className="px-3 py-1.5 text-left">{t("var_table.col_name")}</th>
-              <th className="px-3 py-1.5 text-left">{t("var_table.col_scope")}</th>
-              <th className="px-3 py-1.5 text-left">{t("var_table.col_value")}</th>
+              <th className="px-3 py-2 text-left">{t("var_table.col_name")}</th>
+              <th className="px-3 py-2 text-left">{t("var_table.col_scope")}</th>
+              <th className="px-3 py-2 text-left">{t("var_table.col_value")}</th>
             </tr>
           </thead>
           <tbody>
@@ -89,7 +89,7 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
                       : "bg-canvas opacity-40 hover:opacity-60",
                   )}
                 >
-                  <td className="px-2 py-1.5 text-center">
+                  <td className="px-2 py-2 text-center">
                     <input
                       type="checkbox"
                       checked={!!checked[key]}
@@ -99,8 +99,8 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
                       aria-label={v.name}
                     />
                   </td>
-                  <td className="px-3 py-1.5 font-mono font-semibold text-fg">
-                    <span className="flex items-center gap-1.5">
+                  <td className="px-3 py-2 font-mono font-semibold text-fg">
+                    <span className="flex items-center gap-1">
                       {v.name}
                       {secret && (
                         <span
@@ -113,8 +113,8 @@ export function VarTable({ vars, checked, onToggle, onToggleAll }: VarTableProps
                       )}
                     </span>
                   </td>
-                  <td className="px-3 py-1.5 text-muted">{v.scope}</td>
-                  <td className="px-3 py-1.5 font-mono text-muted truncate max-w-xs">
+                  <td className="px-3 py-2 text-muted">{v.scope}</td>
+                  <td className="px-3 py-2 font-mono text-muted truncate max-w-xs">
                     {secret ? "••••••••" : v.value}
                   </td>
                 </tr>

--- a/src/components/LicensesPanel/LicensesPanel.tsx
+++ b/src/components/LicensesPanel/LicensesPanel.tsx
@@ -94,7 +94,7 @@ export function LicensesPanel() {
       {/* Top-level tabs */}
       <div className="px-5 pt-4 pb-0 border-b border-rim shrink-0">
         <h2 className="text-sm font-semibold text-fg mb-3">Licenses</h2>
-        <div className="flex gap-0.5">
+        <div className="flex gap-1">
           {(
             [
               ["envarly", "Envarly"],
@@ -106,7 +106,7 @@ export function LicensesPanel() {
               type="button"
               onClick={() => setTab(t)}
               className={cn(
-                "px-3 py-1.5 rounded-t text-xs font-medium transition-colors -mb-px border-b",
+                "px-3 py-2 rounded-t text-xs font-medium transition-colors -mb-px border-b",
                 tab === t
                   ? "bg-canvas text-fg border-canvas"
                   : "text-muted hover:bg-hover hover:text-fg border-transparent",
@@ -146,7 +146,7 @@ export function LicensesPanel() {
           {/* Third-party sub-header */}
           <div className="px-5 py-3 border-b border-rim-subtle shrink-0">
             <div className="flex items-center gap-2">
-              <div className="flex gap-0.5 shrink-0">
+              <div className="flex gap-1 shrink-0">
                 {(["npm", "rust"] as Ecosystem[]).map((e) => (
                   <button
                     key={e}

--- a/src/components/ListEditor/SortableListEditor.tsx
+++ b/src/components/ListEditor/SortableListEditor.tsx
@@ -112,7 +112,7 @@ function SortableRow({
         <Icon name="grip" size={16} />
       </button>
 
-      <div className="flex-1 py-1.5 pr-2">
+      <div className="flex-1 py-2 pr-2">
         <input
           ref={inputRef}
           aria-label={`Entry: ${entry.value}`}
@@ -381,7 +381,7 @@ export function SortableListEditor({
   return (
     <div className="flex flex-col gap-2">
       {!readOnly && dupCount > 0 && (
-        <div className="flex items-center justify-between px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs">
+        <div className="flex items-center justify-between px-2 py-2 rounded border border-warn/30 bg-warn/10 text-warn text-xs">
           <span>
             {dupCount} duplicate {dupCount === 1 ? "entry" : "entries"}
           </span>
@@ -429,7 +429,7 @@ export function SortableListEditor({
             <input
               aria-label="New entry"
               className={cn(
-                "h-full min-h-10 w-full px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-xs text-fg",
+                "h-full min-h-10 w-full px-2 py-2 bg-surface border border-rim rounded font-mono text-xs text-fg",
                 onBrowseNewEntry && "pr-9",
                 "placeholder:text-muted transition-colors",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas focus:border-accent",

--- a/src/components/NewVarModal/NewVarModal.tsx
+++ b/src/components/NewVarModal/NewVarModal.tsx
@@ -40,7 +40,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
 
   return (
     <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-4">
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <label
           className="text-xs font-semibold text-muted uppercase tracking-wide"
           htmlFor="newvar-name"
@@ -56,7 +56,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
           spellCheck={false}
           placeholder={t("new_var.placeholder_name")}
           className={cn(
-            "px-2.5 py-1.5 bg-surface border rounded font-mono text-sm text-fg",
+            "px-2 py-2 bg-surface border rounded font-mono text-sm text-fg",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:border-accent",
             alreadyExists ? "border-danger" : "border-rim",
           )}
@@ -66,7 +66,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
         )}
       </div>
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <label
           className="text-xs font-semibold text-muted uppercase tracking-wide"
           htmlFor="newvar-value-kind"
@@ -90,11 +90,11 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
           value={valueKind}
           onValueChange={setValueKind}
           containerClassName="w-full"
-          className="w-full px-2.5 py-1.5 bg-surface border border-rim text-sm text-fg"
+          className="w-full px-2 py-2 bg-surface border border-rim text-sm text-fg"
         />
       </div>
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <p className="text-xs font-semibold text-muted uppercase tracking-wide">
           {t("new_var.scope")}
         </p>
@@ -113,7 +113,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
         />
       </div>
 
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-1">
         <label
           className="text-xs font-semibold text-muted uppercase tracking-wide"
           htmlFor="newvar-value"
@@ -128,7 +128,7 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
           rows={3}
           placeholder={t("new_var.placeholder_value")}
           className={cn(
-            "px-2.5 py-1.5 bg-surface border border-rim rounded font-mono text-sm text-fg resize-none",
+            "px-2 py-2 bg-surface border border-rim rounded font-mono text-sm text-fg resize-none",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:border-accent",
           )}
         />

--- a/src/components/PathEditor/PathEditor.tsx
+++ b/src/components/PathEditor/PathEditor.tsx
@@ -136,7 +136,7 @@ export function PathEditor({
     >
       {hasWhitespace && (
         <div
-          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          className="px-2 py-2 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
           role="alert"
         >
           Some entries have leading or trailing spaces — remove them to avoid lookup failures
@@ -144,7 +144,7 @@ export function PathEditor({
       )}
       {unresolvedRefs.length > 0 && (
         <div
-          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          className="px-2 py-2 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
           role="alert"
         >
           {unresolvedRefs.length} unresolvable{" "}
@@ -154,7 +154,7 @@ export function PathEditor({
       )}
       {invalidCount > 0 && (
         <div
-          className="px-2.5 py-1.5 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
+          className="px-2 py-2 rounded border border-warn/30 bg-warn/10 text-warn text-xs"
           role="alert"
         >
           {invalidCount} path{invalidCount > 1 ? "s" : ""} not found on disk

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -140,13 +140,13 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
         />
       </div>
 
-      <div className="px-3 pb-1.5 flex items-center justify-between">
+      <div className="px-3 pb-2 flex items-center justify-between">
         {secretCount > 0 ? (
           <button
             type="button"
             onClick={() => setSecretsOnly((v) => !v)}
             className={cn(
-              "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors",
+              "inline-flex items-center gap-1 px-2 py-1 rounded-full text-[10px] font-medium transition-colors",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
               secretsOnly
                 ? "bg-warn/20 text-warn border border-warn/40"
@@ -204,7 +204,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
                     onClick={() => onSelect(v)}
                     onKeyDown={handleKeyDown}
                     className={cn(
-                      "flex min-w-0 flex-1 items-center gap-2 px-4 py-2.5 text-left rounded",
+                      "flex min-w-0 flex-1 items-center gap-2 px-4 py-2 text-left rounded",
                       "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset",
                     )}
                   >
@@ -251,7 +251,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
                     aria-label={`Copy value of ${v.name}`}
                     title="Copy value"
                     className={cn(
-                      "shrink-0 text-[10px] px-1 py-0.5 rounded transition-all",
+                      "shrink-0 text-[10px] px-1 py-1 rounded transition-all",
                       "mr-2 opacity-0 group-hover:opacity-100 focus:opacity-100",
                       copiedKey === key ? "text-success" : "text-dim hover:text-muted",
                     )}
@@ -270,7 +270,7 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
         <button
           type="button"
           onClick={onCreateNew}
-          className="w-full inline-flex items-center gap-1.5 text-left text-xs text-dim hover:text-muted px-2 py-1.5 rounded hover:bg-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="w-full inline-flex items-center gap-1 text-left text-xs text-dim hover:text-muted px-2 py-2 rounded hover:bg-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           <Icon name="plus" size={12} />
           {t("sidebar.new_var")}

--- a/src/components/SnapshotPanel/SnapshotDiffRow.tsx
+++ b/src/components/SnapshotPanel/SnapshotDiffRow.tsx
@@ -12,13 +12,13 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
 
   return (
     <tr className="border-b border-rim-subtle last:border-0 text-xs">
-      <td className="px-2 py-1.5 w-5 text-center font-mono font-bold shrink-0">
+      <td className="px-2 py-2 w-5 text-center font-mono font-bold shrink-0">
         {entry.kind === "added" && <span className="text-success">+</span>}
         {entry.kind === "removed" && <span className="text-danger">−</span>}
         {entry.kind === "changed" && <span className="text-warn">~</span>}
       </td>
-      <td className="px-2 py-1.5 font-mono font-semibold text-fg whitespace-nowrap">
-        <span className="flex items-center gap-1.5">
+      <td className="px-2 py-2 font-mono font-semibold text-fg whitespace-nowrap">
+        <span className="flex items-center gap-1">
           {entry.name}
           {secret && (
             <span className="inline-flex items-center gap-1 text-[9px] font-medium text-warn">
@@ -28,10 +28,10 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
           )}
         </span>
       </td>
-      <td className="px-2 py-1.5 text-muted w-12">{entry.scope[0]}</td>
-      <td className="px-2 py-1.5 font-mono text-muted max-w-xs truncate">
+      <td className="px-2 py-2 text-muted w-12">{entry.scope[0]}</td>
+      <td className="px-2 py-2 font-mono text-muted max-w-xs truncate">
         {entry.kind === "changed" ? (
-          <span className="flex flex-col gap-0.5">
+          <span className="flex flex-col gap-1">
             {entry.oldValueKind !== entry.newValueKind && (
               <span className="text-[10px] text-dim">
                 {registryKindLabel(entry.oldValueKind)} → {registryKindLabel(entry.newValueKind)}
@@ -45,7 +45,7 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
         )}
       </td>
       {secret && (
-        <td className="px-2 py-1.5">
+        <td className="px-2 py-2">
           <button
             type="button"
             onClick={() => setRevealed((r) => !r)}
@@ -76,11 +76,11 @@ export function DiffTable({ diff }: { diff: DiffEntry[] }) {
         <table className="w-full">
           <thead>
             <tr className="border-b border-rim bg-surface text-muted text-[10px] uppercase tracking-wide">
-              <th className="px-2 py-1.5 w-5" />
-              <th className="px-2 py-1.5 text-left">Name</th>
-              <th className="px-2 py-1.5 text-left">Scope</th>
-              <th className="px-2 py-1.5 text-left">Value</th>
-              <th className="px-2 py-1.5 w-10" />
+              <th className="px-2 py-2 w-5" />
+              <th className="px-2 py-2 text-left">Name</th>
+              <th className="px-2 py-2 text-left">Scope</th>
+              <th className="px-2 py-2 text-left">Value</th>
+              <th className="px-2 py-2 w-10" />
             </tr>
           </thead>
           <tbody>

--- a/src/components/SnapshotPanel/SnapshotPanel.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.tsx
@@ -231,7 +231,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
       ) : (
         <div className="flex flex-col gap-2">
           {comparingFrom && (
-            <div className="flex items-center justify-between px-2.5 py-1.5 rounded border border-accent/30 bg-accent/10 text-accent text-xs">
+            <div className="flex items-center justify-between px-2 py-2 rounded border border-accent/30 bg-accent/10 text-accent text-xs">
               <span>{t("snapshot.comparing_hint", { label: comparingFrom.label })}</span>
               <Button variant="link" size="xs" onClick={handleCancelCompare}>
                 {t("snapshot.cancel")}
@@ -248,15 +248,12 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                 key={s.id}
                 data-snapshot-id={s.id}
                 className={cn(
-                  "flex flex-col gap-2 px-3.5 py-2.5 bg-panel border rounded",
+                  "flex flex-col gap-2 px-4 py-2 bg-panel border rounded",
                   isComparingSource ? "border-accent/40 bg-accent/5" : "border-rim",
                 )}
               >
                 {editingId === s.id ? (
-                  <form
-                    className="flex items-center gap-1.5"
-                    onSubmit={(e) => handleRename(e, s.id)}
-                  >
+                  <form className="flex items-center gap-1" onSubmit={(e) => handleRename(e, s.id)}>
                     <input
                       ref={renameInputRef}
                       aria-label={t("snapshot.rename_label")}
@@ -268,7 +265,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                           handleCancelRename();
                         }
                       }}
-                      className="h-8 min-w-0 flex-1 rounded border border-rim bg-surface px-2.5 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                      className="h-8 min-w-0 flex-1 rounded border border-rim bg-surface px-2 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                     />
                     <IconButton
                       aria-label={t("snapshot.save_rename")}
@@ -297,7 +294,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                   <p className="text-[11px] text-dim">{formatDate(s.createdAt)}</p>
                 </div>
                 {editingId !== s.id && (
-                  <div className="flex min-h-8 items-center gap-1.5">
+                  <div className="flex min-h-8 items-center gap-1">
                     {comparingFrom ? (
                       !isComparingSource && (
                         <Button
@@ -339,7 +336,7 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
                         >
                           {t("snapshot.compare")}
                         </Button>
-                        <span className="ml-auto flex items-center gap-0.5">
+                        <span className="ml-auto flex items-center gap-1">
                           <IconButton
                             aria-label={t("snapshot.rename")}
                             icon="pencil"

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -60,7 +60,7 @@ function ListDiffDelta({ oldValue, newValue }: { oldValue: string; newValue: str
   }
 
   return (
-    <div className="flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto">
+    <div className="flex flex-col gap-1 mt-1 max-h-48 overflow-y-auto">
       {keyedEntries(removed, "removed").map(({ entry, key }) => (
         <p key={key} className="font-mono text-[11px] text-danger break-all">
           <span className="select-none mr-1">−</span>
@@ -93,7 +93,7 @@ function ListDiffFull({ oldValue, newValue }: { oldValue: string; newValue: stri
   const seen = new Map<string, number>();
 
   return (
-    <div className="flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto">
+    <div className="flex flex-col gap-1 mt-1 max-h-48 overflow-y-auto">
       {rows.map((r) => {
         const keyBase = `${r.status}:${r.entry}`;
         const count = seen.get(keyBase) ?? 0;
@@ -121,7 +121,7 @@ function ListDiffFull({ oldValue, newValue }: { oldValue: string; newValue: stri
 
 function ListEntries({ value, className }: { value: string; className?: string }) {
   return (
-    <div className={cn("flex flex-col gap-0.5 mt-1 max-h-48 overflow-y-auto", className)}>
+    <div className={cn("flex flex-col gap-1 mt-1 max-h-48 overflow-y-auto", className)}>
       {keyedEntries(splitList(value), "entry").map(({ entry, key }) => (
         <p key={key} className="font-mono text-[11px] break-all">
           {entry}
@@ -191,7 +191,7 @@ export function StagedModal({ diff, busy, error, onApply, onClose }: StagedModal
                   type="button"
                   onClick={() => setViewMode(mode)}
                   className={cn(
-                    "px-2.5 py-0.5 capitalize transition-colors",
+                    "px-2 py-1 capitalize transition-colors",
                     viewMode === mode
                       ? "bg-accent text-canvas font-semibold"
                       : "text-muted hover:text-fg hover:bg-hover",
@@ -257,7 +257,7 @@ export function StagedModal({ diff, busy, error, onApply, onClose }: StagedModal
                     <ListDiffFull oldValue={entry.oldValue ?? ""} newValue={entry.newValue ?? ""} />
                   )
                 ) : (
-                  <div className="flex flex-col gap-0.5">
+                  <div className="flex flex-col gap-1">
                     <p className="font-mono text-[11px] text-danger line-through break-all">
                       {entry.oldValue}
                     </p>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -23,7 +23,7 @@ const variantCls: Record<Variant, string> = {
 
 const sizeCls: Record<Size, string> = {
   xs: "px-2 py-1 text-xs",
-  sm: "px-4 py-2.5 text-sm",
+  sm: "px-4 py-2 text-sm",
   md: "px-5 py-3 text-sm font-medium",
 };
 
@@ -41,7 +41,7 @@ export function Button({
       type="button"
       {...props}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded font-medium transition-colors",
+        "inline-flex items-center gap-1 rounded font-medium transition-colors",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         variantCls[variant],

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -23,12 +23,12 @@ export function SegmentedControl<T extends string>({
   className,
 }: Props<T>) {
   return (
-    <div role="radiogroup" aria-label={label} className={cn("flex gap-0.5", className)}>
+    <div role="radiogroup" aria-label={label} className={cn("flex gap-1", className)}>
       {options.map((opt) => (
         <label
           key={opt.value}
           className={cn(
-            "flex items-center gap-1.5 px-4 py-2 rounded text-sm transition-colors",
+            "flex items-center gap-1 px-4 py-2 rounded text-sm transition-colors",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas",
             opt.disabled && "opacity-40 cursor-not-allowed",
             value === opt.value ? "bg-surface text-fg" : "text-muted hover:bg-hover hover:text-fg",
@@ -43,7 +43,7 @@ export function SegmentedControl<T extends string>({
           />
           {opt.label}
           {opt.count !== undefined && (
-            <span className="text-xs px-1.5 py-0.5 rounded-full bg-hover text-dim leading-none">
+            <span className="text-xs px-2 py-1 rounded-full bg-hover text-dim leading-none">
               {opt.count}
             </span>
           )}

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -21,7 +21,7 @@ export function TextInput({ label, labelHidden = false, error, className, id, ..
         id={inputId}
         {...props}
         className={cn(
-          "px-4 py-2.5 bg-surface border rounded text-fg text-sm transition-colors",
+          "px-4 py-2 bg-surface border rounded text-fg text-sm transition-colors",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canvas",
           error ? "border-danger" : "border-rim focus:border-accent",
           "placeholder:text-muted disabled:opacity-60 disabled:cursor-not-allowed",

--- a/src/stories/Colors.stories.tsx
+++ b/src/stories/Colors.stories.tsx
@@ -34,7 +34,7 @@ function SwatchRow({ colors }: { colors: typeof semanticColors }) {
   return (
     <div className="flex flex-wrap gap-3">
       {colors.map((c) => (
-        <div key={c.name} className="flex flex-col gap-1.5 w-32">
+        <div key={c.name} className="flex flex-col gap-1 w-32">
           <div className={`${c.cls} h-14 rounded border border-rim`} />
           <p className="text-xs font-semibold text-fg">{c.label}</p>
           <p className="text-[10px] text-dim">{c.desc}</p>

--- a/src/stories/Spacing.stories.tsx
+++ b/src/stories/Spacing.stories.tsx
@@ -7,11 +7,8 @@ const meta: Meta = {
 export default meta;
 
 const steps = [
-  { token: "0.5", px: "2px" },
   { token: "1", px: "4px" },
-  { token: "1.5", px: "6px" },
   { token: "2", px: "8px" },
-  { token: "2.5", px: "10px" },
   { token: "3", px: "12px" },
   { token: "4", px: "16px" },
   { token: "5", px: "20px" },
@@ -23,10 +20,10 @@ const steps = [
 ];
 
 const patterns = [
-  { label: "Button padding", cls: "px-3 py-1.5", desc: "px-3 py-1.5" },
+  { label: "Button padding", cls: "px-3 py-2", desc: "px-3 py-2" },
   { label: "Panel padding", cls: "px-5 py-4", desc: "px-5 py-4" },
   { label: "Section gap", cls: "gap-4", desc: "gap-4 (between fields)" },
-  { label: "Inline chip gap", cls: "gap-1.5", desc: "gap-1.5 (badge + text)" },
+  { label: "Inline chip gap", cls: "gap-1", desc: "gap-1 (badge + text)" },
 ];
 
 export const Scale: StoryObj = {
@@ -36,6 +33,9 @@ export const Scale: StoryObj = {
         <h2 className="text-sm font-semibold text-muted uppercase tracking-wide border-b border-rim pb-2">
           Spacing scale
         </h2>
+        <p className="text-xs text-dim">
+          Use an 8px base rhythm with a 4px half-step for compact layouts.
+        </p>
         <div className="flex flex-col gap-2">
           {steps.map((s) => (
             <div key={s.token} className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- document an 8px base spacing rhythm with a 4px half-step in Storybook
- normalize fractional padding and gap utilities across controls, tables, forms, and dense panels
- keep the existing 2px margin offsets that serve as optical alignment adjustments

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run test:storybook -- --run`
- `npm run build`
- `npm run tauri -- build`
- confirmed there are no fractional padding or gap utilities under `src`
- visually reviewed spacing docs, forms, PATH editing, Import/Export, snapshots, and buttons in Storybook