### PR TITLE
fix: enable snapshot panel scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,7 +181,7 @@ export default function App() {
           </div>
         )}
 
-        <main className="flex flex-1 overflow-hidden">
+        <main className="flex flex-1 min-h-0 overflow-hidden">
           <Sidebar
             vars={effectiveVars}
             selected={selected}
@@ -209,10 +209,10 @@ export default function App() {
 
           {snapshotsPresence.mounted && (
             <aside
-              className="motion-snapshot-panel shrink-0 border-l border-rim overflow-hidden"
+              className="motion-snapshot-panel min-h-0 shrink-0 border-l border-rim overflow-hidden"
               data-state={snapshotsPresence.state}
             >
-              <div className="motion-snapshot-content w-[420px] h-full flex flex-col bg-panel">
+              <div className="motion-snapshot-content w-[420px] h-full min-h-0 flex flex-col bg-panel">
                 <div className="flex items-center justify-between px-5 py-3 border-b border-rim shrink-0">
                   <span className="text-sm font-semibold text-fg">{t("header.snapshots")}</span>
                   <IconButton
@@ -221,7 +221,7 @@ export default function App() {
                     onClick={() => setSnapshotsOpen(false)}
                   />
                 </div>
-                <div className="flex-1 overflow-hidden">
+                <div className="flex-1 min-h-0 overflow-hidden">
                   <SnapshotPanel onStageSnapshot={handleStageSnapshot} />
                 </div>
               </div>

--- a/src/components/SnapshotPanel/SnapshotDiffRow.tsx
+++ b/src/components/SnapshotPanel/SnapshotDiffRow.tsx
@@ -29,7 +29,7 @@ export function DiffRow({ entry }: { entry: DiffEntry }) {
         </span>
       </td>
       <td className="px-2 py-2 text-muted w-12">{entry.scope[0]}</td>
-      <td className="px-2 py-2 font-mono text-muted max-w-xs truncate">
+      <td className="px-2 py-2 font-mono text-muted whitespace-nowrap">
         {entry.kind === "changed" ? (
           <span className="flex flex-col gap-1">
             {entry.oldValueKind !== entry.newValueKind && (
@@ -72,15 +72,25 @@ export function DiffTable({ diff }: { diff: DiffEntry[] }) {
         {changed > 0 && <span className="text-warn">~{changed} changed</span>}
       </div>
 
-      <div className="rounded border border-rim overflow-hidden max-h-80 overflow-y-auto">
-        <table className="w-full">
+      <section
+        data-testid="snapshot-diff-scroll"
+        aria-label="Snapshot differences"
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Scrollable content must be keyboard reachable.
+        tabIndex={0}
+        className="rounded border border-rim max-h-80 overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <table className="w-max min-w-full">
           <thead>
             <tr className="border-b border-rim bg-surface text-muted text-[10px] uppercase tracking-wide">
-              <th className="px-2 py-2 w-5" />
+              <th className="px-2 py-2 w-5">
+                <span className="sr-only">Change</span>
+              </th>
               <th className="px-2 py-2 text-left">Name</th>
               <th className="px-2 py-2 text-left">Scope</th>
               <th className="px-2 py-2 text-left">Value</th>
-              <th className="px-2 py-2 w-10" />
+              <th className="px-2 py-2 w-10">
+                <span className="sr-only">Actions</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -89,7 +99,7 @@ export function DiffTable({ diff }: { diff: DiffEntry[] }) {
             ))}
           </tbody>
         </table>
-      </div>
+      </section>
     </>
   );
 }

--- a/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
@@ -42,6 +42,22 @@ const manySnapshots = Array.from(
   }),
 );
 
+const wideDiffSnapshot: SnapshotMeta = {
+  ...storySnapshots[1],
+  id: "snapshot-wide-diff",
+  label: "Before consolidating development tool directories",
+  snapshot: {
+    user: {
+      PATH: {
+        value:
+          "C:\\Program Files\\Java\\jdk-21\\bin;C:\\Program Files\\Git\\cmd;C:\\Users\\dev\\AppData\\Local\\Programs\\Python\\Python313\\Scripts;C:\\Users\\dev\\.cargo\\bin",
+        kind: "ExpandString",
+      },
+    },
+    system: {},
+  },
+};
+
 const meta: Meta<typeof SnapshotPanel> = {
   title: "Components/SnapshotPanel",
   component: SnapshotPanel,
@@ -96,5 +112,29 @@ export const ManySnapshots: Story = {
     if (!scrollRegion) return;
     scrollRegion.scrollTop = scrollRegion.scrollHeight;
     expect(scrollRegion.scrollTop).toBeGreaterThan(0);
+  },
+};
+
+export const WidePreviewDiff: Story = {
+  parameters: { snapshotFixtures: [wideDiffSnapshot] },
+  play: async ({ canvasElement }) => {
+    const previewButton = await waitFor(() => {
+      const button = canvasElement.querySelector<HTMLButtonElement>("[data-snapshot-id] button");
+      expect(button).toBeTruthy();
+      return button;
+    });
+    previewButton?.click();
+
+    const scrollRegion = await waitFor(() => {
+      const region = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="snapshot-diff-scroll"]',
+      );
+      expect(region?.scrollWidth).toBeGreaterThan(region?.clientWidth ?? 0);
+      return region;
+    });
+
+    if (!scrollRegion) return;
+    scrollRegion.scrollLeft = scrollRegion.scrollWidth;
+    expect(scrollRegion.scrollLeft).toBeGreaterThan(0);
   },
 };

--- a/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor } from "storybook/test";
 import { api } from "../../api";
 import type { EnvSnapshot, SnapshotMeta } from "../../types";
 import { SnapshotPanel } from "./SnapshotPanel";
@@ -31,14 +32,26 @@ const currentSnapshot: EnvSnapshot = {
   system: {},
 };
 
+const manySnapshots = Array.from(
+  { length: 12 },
+  (_, index): SnapshotMeta => ({
+    ...storySnapshots[index % storySnapshots.length],
+    id: `snapshot-${index + 1}`,
+    createdAt: new Date(Date.UTC(2026, 6, 12 - index, 9)).toISOString(),
+    label: `Snapshot ${index + 1}: developer environment before toolchain update`,
+  }),
+);
+
 const meta: Meta<typeof SnapshotPanel> = {
   title: "Components/SnapshotPanel",
   component: SnapshotPanel,
   parameters: { layout: "fullscreen" },
   args: { onStageSnapshot: () => {} },
   decorators: [
-    (Story) => {
-      let snapshots = storySnapshots.map((snapshot) => ({ ...snapshot }));
+    (Story, context) => {
+      const fixtures =
+        (context.parameters.snapshotFixtures as SnapshotMeta[] | undefined) ?? storySnapshots;
+      let snapshots = fixtures.map((snapshot) => ({ ...snapshot }));
       api.listSnapshots = async () => snapshots.map((snapshot) => ({ ...snapshot }));
       api.createSnapshot = async (label) => {
         const created = { ...storySnapshots[0], id: "snapshot-new", label };
@@ -69,3 +82,19 @@ export default meta;
 type Story = StoryObj<typeof SnapshotPanel>;
 
 export const Default: Story = {};
+
+export const ManySnapshots: Story = {
+  parameters: { snapshotFixtures: manySnapshots },
+  play: async ({ canvasElement }) => {
+    const scrollRegion = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="snapshot-panel-scroll"]',
+    );
+    await waitFor(() =>
+      expect(scrollRegion?.scrollHeight).toBeGreaterThan(scrollRegion?.clientHeight ?? 0),
+    );
+
+    if (!scrollRegion) return;
+    scrollRegion.scrollTop = scrollRegion.scrollHeight;
+    expect(scrollRegion.scrollTop).toBeGreaterThan(0);
+  },
+};

--- a/src/components/SnapshotPanel/SnapshotPanel.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.tsx
@@ -184,7 +184,10 @@ export function SnapshotPanel({ onStageSnapshot }: Props) {
   };
 
   return (
-    <div className="w-full px-5 py-5 flex flex-col gap-4 overflow-y-auto">
+    <div
+      data-testid="snapshot-panel-scroll"
+      className="h-full min-h-0 w-full px-5 py-5 flex flex-col gap-4 overflow-y-auto"
+    >
       <div>
         <h2 className="text-sm font-semibold text-fg mb-1">{t("snapshot.title")}</h2>
         <p className="text-xs text-muted">{t("snapshot.description")}</p>


### PR DESCRIPTION
## Summary
- propagate `min-h-0` through the app and snapshot sidebar flex containers
- make SnapshotPanel fill its available height so the sidebar can scroll vertically
- allow Preview and Compare diff tables to scroll horizontally without truncating long values
- make the diff scroll region keyboard reachable and label previously empty table headers
- add many-snapshot and wide-diff Storybook interaction tests for vertical and horizontal scrolling

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run test:storybook -- --run`
- `npm run build`
- `npm run tauri -- build`