### PR TITLE
feat: check GitHub releases for updates

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "bitflags 2.13.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1007,6 +1007,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs-next",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
@@ -1123,12 +1124,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1141,6 +1151,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1635,6 +1651,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2143,6 +2175,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2476,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2853,15 +2945,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2926,6 +3022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +3043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2996,6 +3110,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3891,6 +4028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,6 +4404,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5134,6 +5287,12 @@ dependencies = [
  "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.7.1"
+reqwest = { version = "0.13", default-features = false, features = ["json", "native-tls"] }
 winreg = "0.55"
 windows-sys = { version = "0.59", features = [
   "Win32_UI_WindowsAndMessaging",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod export;
 pub mod launch;
 pub mod path;
 pub mod snapshot;
+pub mod update;

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+const REPO_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/iray-tno/envarly/releases/latest";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub version: String,
+    pub url: String,
+}
+
+#[derive(Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+/// Checks GitHub for a newer release than the running version. Returns `None`
+/// on any failure (offline, rate-limited, etc.) — this is a best-effort,
+/// non-critical check and should never surface an error to the user.
+#[tauri::command]
+pub async fn check_for_update() -> Option<UpdateInfo> {
+    match fetch_latest_release().await {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("update check failed: {e}");
+            None
+        }
+    }
+}
+
+async fn fetch_latest_release() -> Result<Option<UpdateInfo>, reqwest::Error> {
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("envarly/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let release: GithubRelease = client
+        .get(REPO_LATEST_RELEASE_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let latest = release.tag_name.trim_start_matches('v');
+    let current = env!("CARGO_PKG_VERSION");
+
+    Ok(if is_newer(latest, current) {
+        Some(UpdateInfo {
+            version: latest.to_string(),
+            url: release.html_url,
+        })
+    } else {
+        None
+    })
+}
+
+fn parse_version(v: &str) -> Vec<u32> {
+    v.split('.').map(|part| part.parse().unwrap_or(0)).collect()
+}
+
+fn is_newer(candidate: &str, current: &str) -> bool {
+    parse_version(candidate) > parse_version(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_detects_patch_bump() {
+        assert!(is_newer("1.2.2", "1.2.1"));
+        assert!(!is_newer("1.2.1", "1.2.1"));
+        assert!(!is_newer("1.2.0", "1.2.1"));
+    }
+
+    #[test]
+    fn is_newer_detects_minor_and_major_bump() {
+        assert!(is_newer("1.3.0", "1.2.9"));
+        assert!(is_newer("2.0.0", "1.9.9"));
+        assert!(!is_newer("1.9.9", "2.0.0"));
+    }
+
+    #[test]
+    fn is_newer_handles_missing_segments() {
+        assert!(is_newer("1.3", "1.2.9"));
+        assert!(!is_newer("1.2", "1.2.1"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::path::get_path_proposal,
             commands::launch::get_launch_options,
             commands::launch::read_demo_fixture,
+            commands::update::check_for_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running envarly");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { usePresence } from "./hooks/usePresence";
 import { useStaged } from "./hooks/useStaged";
 import { useStagingHandlers } from "./hooks/useStagingHandlers";
 import { useTheme } from "./hooks/useTheme";
+import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import type { DiagnosticAction, EnvironmentDiagnostic } from "./lib/environmentDiagnostics";
 import { stagedToDiff } from "./lib/stagedToDiff";
 import type { EnvVar } from "./types";
@@ -83,6 +84,8 @@ export default function App() {
   });
 
   useKeyboardShortcuts(undo, redo, localUndoRef);
+
+  const updateInfo = useUpdateCheck();
 
   const {
     handleStage,
@@ -168,6 +171,7 @@ export default function App() {
           onToggleSnapshots={() => setSnapshotsOpen((o) => !o)}
           onToggleTheme={toggleTheme}
           onLicenses={() => setDialog("licenses")}
+          updateInfo={updateInfo}
         />
 
         {(elevated ? !systemPathInEnv : !userPathInEnv) && !pathBannerDismissed && (

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,7 @@ import type {
   EnvVar,
   SnapshotMeta,
   UnsupportedEnvValue,
+  UpdateInfo,
   VarScope,
 } from "./types";
 
@@ -47,6 +48,7 @@ export interface EnvarlyApi {
     systemHasEntry: boolean;
   }>;
   getPathProposal: (scope: "User" | "System") => Promise<string | null>;
+  checkForUpdate: () => Promise<UpdateInfo | null>;
 }
 
 const normalApi: EnvarlyApi = {
@@ -73,6 +75,7 @@ const normalApi: EnvarlyApi = {
       "get_path_status",
     ),
   getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
+  checkForUpdate: () => invoke<UpdateInfo | null>("check_for_update"),
 };
 
 let apiPromise: Promise<EnvarlyApi> | null = null;
@@ -134,4 +137,5 @@ export const api: EnvarlyApi = {
   parseImport: async (content, format) => (await getApi()).parseImport(content, format),
   getPathStatus: async () => (await getApi()).getPathStatus(),
   getPathProposal: async (scope) => (await getApi()).getPathProposal(scope),
+  checkForUpdate: async () => (await getApi()).checkForUpdate(),
 };

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof AppHeader> = {
     elevated: false,
     snapshotsOpen: false,
     theme: "dark",
+    updateInfo: null,
   },
   argTypes: {
     loading: { control: "boolean" },
@@ -46,4 +47,8 @@ export const SnapshotsOpen: Story = {
 
 export const Loading: Story = {
   args: { loading: true },
+};
+
+export const UpdateAvailable: Story = {
+  args: { updateInfo: { version: "1.3.0", url: "https://github.com/iray-tno/envarly/releases" } },
 };

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { api } from "../../api";
 import { useI18n } from "../../hooks/useI18n";
+import type { UpdateInfo } from "../../types";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { Select } from "../ui/Select";
@@ -20,6 +21,7 @@ interface AppHeaderProps {
   onToggleSnapshots: () => void;
   onToggleTheme: () => void;
   onLicenses: () => void;
+  updateInfo: UpdateInfo | null;
 }
 
 export function AppHeader({
@@ -37,6 +39,7 @@ export function AppHeader({
   onToggleSnapshots,
   onToggleTheme,
   onLicenses,
+  updateInfo,
 }: AppHeaderProps) {
   const { t, language, setLanguage } = useI18n();
   const languageOptions = [
@@ -107,6 +110,18 @@ export function AppHeader({
             <Icon name="shield" size={14} />
             {t("header.administrator")}
           </span>
+        )}
+        {updateInfo && (
+          <Button
+            variant="ghost"
+            size="xs"
+            icon="info"
+            onClick={() => openUrl(updateInfo.url)}
+            title={t("header.update_available_title")}
+            className="text-accent"
+          >
+            {t("header.update_available", { version: updateInfo.version })}
+          </Button>
         )}
         <Button
           variant="ghost"

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -191,5 +191,6 @@ export function createDemoApi(
       }
       return [fixture.installDir, ...entries].join(";");
     },
+    checkForUpdate: async () => null,
   };
 }

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { api } from "../api";
+import type { UpdateInfo } from "../types";
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const STORAGE_KEY = "envarly.lastUpdateCheck";
+
+export function useUpdateCheck() {
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+
+  useEffect(() => {
+    const lastChecked = Number(localStorage.getItem(STORAGE_KEY) ?? 0);
+    if (Date.now() - lastChecked < CHECK_INTERVAL_MS) return;
+
+    void api
+      .checkForUpdate()
+      .then((info) => {
+        localStorage.setItem(STORAGE_KEY, String(Date.now()));
+        if (info) setUpdateInfo(info);
+      })
+      .catch(() => {});
+  }, []);
+
+  return updateInfo;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,7 +39,9 @@
     "run_as_admin": "Run as admin",
     "run_as_admin_title": "System variables are read-only. Restart as administrator to edit them.",
     "administrator": "Administrator",
-    "licenses": "Licenses"
+    "licenses": "Licenses",
+    "update_available": "Update available: v{{version}}",
+    "update_available_title": "A new version of Envarly is available. Click to view the release."
   },
   "path_banner": {
     "prefix": "Envarly is not in your {{scope}} PATH — add it to run",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -39,7 +39,9 @@
     "run_as_admin": "管理者として実行",
     "run_as_admin_title": "システム変数は読み取り専用です。編集するには管理者として再起動してください。",
     "administrator": "管理者モード",
-    "licenses": "ライセンス"
+    "licenses": "ライセンス",
+    "update_available": "アップデートあり: v{{version}}",
+    "update_available_title": "新しいバージョンのEnvarlyがあります。クリックしてリリースページを見る。"
   },
   "path_banner": {
     "prefix": "Envarly が {{scope}} の PATH に含まれていません — ターミナルから",

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,11 @@ export interface SnapshotMeta {
   snapshot: EnvSnapshot;
 }
 
+export interface UpdateInfo {
+  version: string;
+  url: string;
+}
+
 export type EnvChange =
   | {
       changeType: "set";


### PR DESCRIPTION
## Summary
- Adds a `check_for_update` Tauri command that fetches the latest GitHub release and compares it to the running version, done server-side (Rust + reqwest/native-tls) so the CSP doesn't need to allow external origins from the webview
- Frontend rate-limits the check to once per day via `localStorage` and shows a subtle badge in the header when a newer version is available; clicking it opens the release page
- Fails silently (returns `None`) on any error (offline, rate-limited, etc.) — this is a best-effort, non-critical check

## Test plan
- [ ] Build the app and confirm no update badge appears when already on the latest version
- [ ] Temporarily point at an older tag or lower `CARGO_PKG_VERSION` to confirm the badge appears and links to the release page
- [ ] Confirm the check doesn't re-fire on every launch within 24h (clear `localStorage` key `envarly.lastUpdateCheck` to force a re-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv