### PR TITLE
feat: show a progress bar and log while applying staged changes

### DIFF
--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -1,7 +1,24 @@
+use serde::Serialize;
+use tauri::Emitter;
+
 use crate::env_store;
 use crate::error::EnvarlyError;
 use crate::model::{EnvChange, EnvSnapshot, EnvValueKind, EnvVar, UnsupportedEnvValue, VarScope};
 use crate::snapshot;
+
+/// Emitted on the "apply-progress" channel as each staged change is applied,
+/// so the frontend can render a progress bar and a per-variable log.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyProgressEvent {
+    pub index: usize,
+    pub total: usize,
+    pub name: String,
+    pub scope: VarScope,
+    pub action: &'static str,
+    pub success: bool,
+    pub error: Option<String>,
+}
 
 #[tauri::command]
 pub fn get_env_vars() -> Result<Vec<EnvVar>, EnvarlyError> {
@@ -34,10 +51,30 @@ pub fn delete_env_var(name: String, scope: VarScope) -> Result<(), EnvarlyError>
 }
 
 #[tauri::command]
-pub fn apply_env_changes(changes: Vec<EnvChange>) -> Result<(), EnvarlyError> {
+pub fn apply_env_changes(
+    app: tauri::AppHandle,
+    changes: Vec<EnvChange>,
+) -> Result<(), EnvarlyError> {
     let snapshot = env_store::read_snapshot()?;
     snapshot::save_snapshot(snapshot, "auto: before apply")?;
-    env_store::apply_changes(&changes)
+    env_store::apply_changes(&changes, |index, total, change, result| {
+        let (name, scope, action) = match change {
+            EnvChange::Set { name, scope, .. } => (name.clone(), scope.clone(), "set"),
+            EnvChange::Delete { name, scope } => (name.clone(), scope.clone(), "delete"),
+        };
+        let _ = app.emit(
+            "apply-progress",
+            ApplyProgressEvent {
+                index,
+                total,
+                name,
+                scope,
+                action,
+                success: result.is_ok(),
+                error: result.as_ref().err().map(|e| e.to_string()),
+            },
+        );
+    })
 }
 
 /// Returns true when the process has write access to HKLM (admin / elevated).

--- a/src-tauri/src/env_store.rs
+++ b/src-tauri/src/env_store.rs
@@ -207,10 +207,12 @@ pub fn delete_var_with(
 pub fn apply_changes_with(
     backend: &dyn EnvBackend,
     changes: &[EnvChange],
+    mut on_progress: impl FnMut(usize, usize, &EnvChange, &Result<(), EnvarlyError>),
 ) -> Result<(), EnvarlyError> {
     let baseline = read_snapshot_with(backend)?;
+    let total = changes.len();
 
-    for change in changes {
+    for (index, change) in changes.iter().enumerate() {
         let result = match change {
             EnvChange::Set {
                 name,
@@ -231,6 +233,8 @@ pub fn apply_changes_with(
             }
             .and_then(|()| verify_value(backend, name, scope, None)),
         };
+
+        on_progress(index, total, change, &result);
 
         if let Err(error) = result {
             let rollback = restore_snapshot_with(backend, &baseline);
@@ -330,8 +334,11 @@ pub fn delete_var(name: &str, scope: &VarScope) -> Result<(), EnvarlyError> {
 }
 
 #[cfg(windows)]
-pub fn apply_changes(changes: &[EnvChange]) -> Result<(), EnvarlyError> {
-    apply_changes_with(&WinregBackend, changes)
+pub fn apply_changes(
+    changes: &[EnvChange],
+    on_progress: impl FnMut(usize, usize, &EnvChange, &Result<(), EnvarlyError>),
+) -> Result<(), EnvarlyError> {
+    apply_changes_with(&WinregBackend, changes, on_progress)
 }
 
 #[cfg(windows)]
@@ -544,6 +551,7 @@ mod tests {
                 value_kind: EnvValueKind::ExpandString,
                 scope: VarScope::User,
             }],
+            |_, _, _, _| {},
         )
         .unwrap();
 
@@ -573,6 +581,7 @@ mod tests {
                     scope: VarScope::System,
                 },
             ],
+            |_, _, _, _| {},
         );
 
         assert!(result.is_err());
@@ -580,5 +589,32 @@ mod tests {
             read_snapshot_with(&b).unwrap().user["KEEP"].value,
             "original"
         );
+    }
+
+    #[test]
+    fn apply_reports_progress_for_each_change() {
+        let b = backend();
+        let mut seen: Vec<(usize, usize, bool)> = Vec::new();
+        apply_changes_with(
+            &b,
+            &[
+                EnvChange::Set {
+                    name: "A".into(),
+                    value: "1".into(),
+                    value_kind: EnvValueKind::String,
+                    scope: VarScope::User,
+                },
+                EnvChange::Set {
+                    name: "B".into(),
+                    value: "2".into(),
+                    value_kind: EnvValueKind::String,
+                    scope: VarScope::User,
+                },
+            ],
+            |index, total, _change, result| seen.push((index, total, result.is_ok())),
+        )
+        .unwrap();
+
+        assert_eq!(seen, vec![(0, 2, true), (1, 2, true)]);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,6 +114,8 @@ export default function App() {
     handleApplyStaged,
     busy: stagedBusy,
     error: stagedError,
+    progress: stagedProgress,
+    log: stagedLog,
   } = useApplyStaged({
     staged,
     clearStaged,
@@ -249,6 +251,8 @@ export default function App() {
           stagedDiff={stagedDiff}
           stagedBusy={stagedBusy}
           stagedError={stagedError}
+          stagedProgress={stagedProgress}
+          stagedLog={stagedLog}
           onApplyStaged={handleApplyStaged}
           diffEntries={diffEntries}
           applyBusy={applyBusy}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,8 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { createDemoApi, loadDemoFixture } from "./demo/createDemoApi";
 import type {
+  ApplyProgressEvent,
   EnvChange,
   EnvSnapshot,
   EnvValueKind,
@@ -49,6 +51,13 @@ export interface EnvarlyApi {
   }>;
   getPathProposal: (scope: "User" | "System") => Promise<string | null>;
   checkForUpdate: () => Promise<UpdateInfo | null>;
+  /**
+   * Subscribe to per-variable progress while `applyEnvChanges` runs. Resolves
+   * once the listener is actually registered — callers must await this before
+   * invoking `applyEnvChanges`, or fast applies can finish (and emit all their
+   * events) before the subscription exists to hear them.
+   */
+  onApplyProgress: (callback: (event: ApplyProgressEvent) => void) => Promise<() => void>;
 }
 
 const normalApi: EnvarlyApi = {
@@ -76,6 +85,8 @@ const normalApi: EnvarlyApi = {
     ),
   getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
   checkForUpdate: () => invoke<UpdateInfo | null>("check_for_update"),
+  onApplyProgress: async (callback) =>
+    listen<ApplyProgressEvent>("apply-progress", (event) => callback(event.payload)),
 };
 
 let apiPromise: Promise<EnvarlyApi> | null = null;
@@ -138,4 +149,5 @@ export const api: EnvarlyApi = {
   getPathStatus: async () => (await getApi()).getPathStatus(),
   getPathProposal: async (scope) => (await getApi()).getPathProposal(scope),
   checkForUpdate: async () => (await getApi()).checkForUpdate(),
+  onApplyProgress: async (callback) => (await getApi()).onApplyProgress(callback),
 };

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -1,7 +1,13 @@
 import { useI18n } from "../../hooks/useI18n";
 import type { StagedChange } from "../../hooks/useStaged";
 import type { DiffEntry } from "../../lib/diff";
-import type { EnvValueKind, EnvValueKindSelection, EnvVar, VarScope } from "../../types";
+import type {
+  ApplyProgressEvent,
+  EnvValueKind,
+  EnvValueKindSelection,
+  EnvVar,
+  VarScope,
+} from "../../types";
 import { DiffPanel } from "../DiffPanel/DiffPanel";
 import { ImportExportPanel } from "../ImportExportPanel/ImportExportPanel";
 import { LicensesPanel } from "../LicensesPanel/LicensesPanel";
@@ -18,6 +24,8 @@ interface Props {
   stagedDiff: DiffEntry[];
   stagedBusy: boolean;
   stagedError: string | null;
+  stagedProgress: { index: number; total: number } | null;
+  stagedLog: ApplyProgressEvent[];
   onApplyStaged: (takeSnapshot: boolean) => Promise<void>;
   diffEntries: DiffEntry[];
   applyBusy: boolean;
@@ -50,6 +58,8 @@ export function AppModals({
   stagedDiff,
   stagedBusy,
   stagedError,
+  stagedProgress,
+  stagedLog,
   onApplyStaged,
   diffEntries,
   applyBusy,
@@ -84,6 +94,8 @@ export function AppModals({
           diff={stagedDiff}
           busy={stagedBusy}
           error={stagedError}
+          progress={stagedProgress}
+          log={stagedLog}
           onApply={onApplyStaged}
           onClose={() => setDialog(null)}
         />

--- a/src/components/StagedModal/ApplyProgress.tsx
+++ b/src/components/StagedModal/ApplyProgress.tsx
@@ -1,0 +1,54 @@
+import { useI18n } from "../../hooks/useI18n";
+import { cn } from "../../lib/cn";
+import type { ApplyProgressEvent } from "../../types";
+import { Icon } from "../ui/Icon";
+
+interface Props {
+  progress: { index: number; total: number } | null;
+  log: ApplyProgressEvent[];
+}
+
+export function ApplyProgress({ progress, log }: Props) {
+  const { t } = useI18n();
+  const percent = progress ? Math.round(((progress.index + 1) / progress.total) * 100) : 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {progress && (
+        <div className="flex items-center gap-2">
+          <div className="h-1.5 flex-1 rounded-full bg-rim overflow-hidden">
+            <div
+              className="h-full bg-accent transition-[width] duration-150"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <span className="text-[10px] text-dim shrink-0">
+            {t("staged.apply_progress_count", {
+              current: progress.index + 1,
+              total: progress.total,
+            })}
+          </span>
+        </div>
+      )}
+      {log.length > 0 && (
+        <div className="flex flex-col gap-0.5 max-h-32 overflow-y-auto font-mono text-[11px]">
+          {log.map((entry) => (
+            <p
+              key={`${entry.index}:${entry.scope}:${entry.name}`}
+              className={cn(
+                "flex items-center gap-1",
+                entry.success ? "text-muted" : "text-danger",
+              )}
+            >
+              <Icon name={entry.success ? "check" : "x"} size={12} className="shrink-0" />
+              <span className="truncate">
+                {entry.action} {entry.scope}:{entry.name}
+                {!entry.success && entry.error ? ` — ${entry.error}` : ""}
+              </span>
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/StagedModal/StagedModal.stories.tsx
+++ b/src/components/StagedModal/StagedModal.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof StagedModal> = {
   title: "Components/StagedModal",
   component: StagedModal,
   tags: ["autodocs"],
-  args: { busy: false },
+  args: { busy: false, progress: null, log: [] },
   argTypes: { busy: { control: "boolean" } },
 };
 export default meta;
@@ -49,5 +49,29 @@ export const CriticalVar: Story = {
 };
 
 export const Busy: Story = {
-  args: { diff: [added, changed], busy: true },
+  args: {
+    diff: [added, changed],
+    busy: true,
+    progress: { index: 1, total: 2 },
+    log: [
+      {
+        index: 0,
+        total: 2,
+        name: "NEW_VAR",
+        scope: "User",
+        action: "set",
+        success: true,
+        error: null,
+      },
+      {
+        index: 1,
+        total: 2,
+        name: "PATH",
+        scope: "User",
+        action: "set",
+        success: false,
+        error: "registry verification failed",
+      },
+    ],
+  },
 };

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -3,8 +3,10 @@ import { useI18n } from "../../hooks/useI18n";
 import { cn } from "../../lib/cn";
 import type { DiffEntry } from "../../lib/diff";
 import { registryKindLabel } from "../../lib/envValueKind";
+import type { ApplyProgressEvent } from "../../types";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
+import { ApplyProgress } from "./ApplyProgress";
 import { ListDiffDelta, ListDiffFull, ListEntries } from "./ListDiff";
 import { entryHasListValue, isList } from "./listDiffUtils";
 
@@ -16,11 +18,21 @@ interface StagedModalProps {
   diff: DiffEntry[];
   busy: boolean;
   error?: string | null;
+  progress: { index: number; total: number } | null;
+  log: ApplyProgressEvent[];
   onApply: (takeSnapshot: boolean) => void;
   onClose: () => void;
 }
 
-export function StagedModal({ diff, busy, error, onApply, onClose }: StagedModalProps) {
+export function StagedModal({
+  diff,
+  busy,
+  error,
+  progress,
+  log,
+  onApply,
+  onClose,
+}: StagedModalProps) {
   const { t } = useI18n();
   const [viewMode, setViewMode] = useState<ViewMode>("delta");
 
@@ -159,6 +171,7 @@ export function StagedModal({ diff, busy, error, onApply, onClose }: StagedModal
       </div>
 
       <div className="px-6 py-4 border-t border-rim shrink-0 flex flex-col gap-3">
+        {busy && <ApplyProgress progress={progress} log={log} />}
         {error && (
           <p className="rounded border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
             {error}

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -192,5 +192,6 @@ export function createDemoApi(
       return [fixture.installDir, ...entries].join(";");
     },
     checkForUpdate: async () => null,
+    onApplyProgress: async () => () => {},
   };
 }

--- a/src/hooks/useApplyStaged.test.ts
+++ b/src/hooks/useApplyStaged.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../api";
+import type { ApplyProgressEvent } from "../types";
 import { useApplyStaged } from "./useApplyStaged";
 import type { StagedChange } from "./useStaged";
 
@@ -11,6 +12,7 @@ vi.mock("../api", () => ({
     applyEnvChanges: vi.fn(),
     createSnapshot: vi.fn(),
     getRegistrySnapshot: vi.fn(),
+    onApplyProgress: vi.fn(async () => () => {}),
   },
 }));
 
@@ -148,5 +150,43 @@ describe("useApplyStaged", () => {
       await applyPromise;
     });
     expect(result.current.busy).toBe(false);
+  });
+
+  it("tracks progress and log from apply-progress events, then unsubscribes", async () => {
+    let capturedCallback: ((event: ApplyProgressEvent) => void) | undefined;
+    const unsubscribe = vi.fn();
+    vi.mocked(api.onApplyProgress).mockImplementation(async (cb) => {
+      capturedCallback = cb;
+      return unsubscribe;
+    });
+    const change: StagedChange = {
+      kind: "set",
+      name: "A",
+      scope: "User",
+      originalValue: null,
+      originalValueKind: null,
+      newValue: "1",
+      newValueKind: "String",
+    };
+    const params = makeParams({ staged: makeStaged([["User:A", change]]) });
+    const { result } = renderHook(() => useApplyStaged(params));
+
+    await act(async () => {
+      const promise = result.current.handleApplyStaged(false);
+      capturedCallback?.({
+        index: 0,
+        total: 1,
+        name: "A",
+        scope: "User",
+        action: "set",
+        success: true,
+        error: null,
+      });
+      await promise;
+    });
+
+    expect(result.current.progress).toEqual({ index: 0, total: 1 });
+    expect(result.current.log).toHaveLength(1);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useApplyStaged.ts
+++ b/src/hooks/useApplyStaged.ts
@@ -1,7 +1,7 @@
 import type { RefObject } from "react";
 import { useCallback, useState } from "react";
 import { api } from "../api";
-import type { EnvChange, EnvSnapshot } from "../types";
+import type { ApplyProgressEvent, EnvChange, EnvSnapshot } from "../types";
 import type { StagedChange } from "./useStaged";
 
 type SetDialog = (d: "importexport" | "changes" | "staged" | "licenses" | "newvar" | null) => void;
@@ -25,11 +25,21 @@ export function useApplyStaged({
 }: Params) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ index: number; total: number } | null>(null);
+  const [log, setLog] = useState<ApplyProgressEvent[]>([]);
 
   const handleApplyStaged = useCallback(
     async (_takeSnapshot: boolean) => {
       setBusy(true);
       setError(null);
+      setProgress(null);
+      setLog([]);
+      // Must resolve before applyEnvChanges is called, or a fast apply can
+      // emit all its progress events before this subscription exists to hear them.
+      const unsubscribe = await api.onApplyProgress((event) => {
+        setProgress({ index: event.index, total: event.total });
+        setLog((prev) => [...prev, event]);
+      });
       try {
         const changes: EnvChange[] = Array.from(staged.values(), (change) =>
           change.kind === "delete"
@@ -58,11 +68,12 @@ export function useApplyStaged({
         console.error("Failed to apply staged changes", err);
         setError(String(err));
       } finally {
+        unsubscribe();
         setBusy(false);
       }
     },
     [staged, clearStaged, refresh, refreshPathStatus, baselineRef, setDialog],
   );
 
-  return { handleApplyStaged, busy, error };
+  return { handleApplyStaged, busy, error, progress, log };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,6 +127,7 @@
     "apply_one": "Apply {{count}} change to registry",
     "apply_other": "Apply {{count}} changes to registry",
     "applying": "Applying…",
+    "apply_progress_count": "{{current}} / {{total}}",
     "kind_added": "ADDED",
     "kind_removed": "REMOVED",
     "kind_changed": "CHANGED"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -127,6 +127,7 @@
     "apply_one": "{{count}} 件の変更をレジストリに適用",
     "apply_other": "{{count}} 件の変更をレジストリに適用",
     "applying": "適用中…",
+    "apply_progress_count": "{{current}} / {{total}}",
     "kind_added": "追加",
     "kind_removed": "削除",
     "kind_changed": "変更"

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,16 @@ export interface UpdateInfo {
   url: string;
 }
 
+export interface ApplyProgressEvent {
+  index: number;
+  total: number;
+  name: string;
+  scope: VarScope;
+  action: "set" | "delete";
+  success: boolean;
+  error: string | null;
+}
+
 export type EnvChange =
   | {
       changeType: "set";


### PR DESCRIPTION
## Summary
- `apply_changes_with` takes a per-change progress callback; the `apply_env_changes` Tauri command emits an `apply-progress` event for each variable as it's applied (success or failure), while keeping the existing atomic all-or-nothing rollback behavior unchanged
- Frontend subscribes via a new `api.onApplyProgress`, awaited before calling `applyEnvChanges` — subscribing after would race a fast apply, since events emitted before a listener attaches are simply lost with Tauri's event system
- Staged-changes modal shows a progress bar and a scrolling per-variable log (✓/✗) while applying

## Test plan
- [ ] Stage several variable changes, click Apply, confirm the progress bar and log entries appear for each variable
- [ ] Stage a change that will fail (e.g. a System-scope change while not elevated) and confirm the log shows the failure and the rollback still occurs
- [ ] Stage a single change and confirm progress still shows correctly for just one item (this was the original race-condition repro — fast applies with few items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv