### PR TITLE
test: cover previously untested component states in Storybook

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Boom(): never {
+  throw new Error("Story-triggered crash for the ErrorBoundary demo");
+}
+
+const meta: Meta<typeof ErrorBoundary> = {
+  title: "Components/ErrorBoundary",
+  component: ErrorBoundary,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof ErrorBoundary>;
+
+export const Crashed: Story = {
+  render: () => (
+    <ErrorBoundary>
+      <Boom />
+    </ErrorBoundary>
+  ),
+};

--- a/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
+++ b/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { useEffect } from "react";
-import { fn } from "storybook/test";
+import { fn, within } from "storybook/test";
 import { api } from "../../api";
 import type { EnvSnapshot, EnvVar } from "../../types";
 import { ImportExportPanel } from "./ImportExportPanel";
@@ -110,5 +110,16 @@ export const ImportEmpty: Story = {
       label.textContent?.includes("Import"),
     );
     importTab?.click();
+  },
+};
+
+export const SecretWarning: Story = {
+  decorators: withStoryApi,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const exportButton = await canvas.findByRole("button", { name: /\.json/i });
+    exportButton.click();
+    // "GitHub" (the secret service name) isn't translated, so it's a safe locale-agnostic anchor.
+    await canvas.findByText(/github/i);
   },
 };

--- a/src/components/LicensesPanel/LicensesPanel.stories.tsx
+++ b/src/components/LicensesPanel/LicensesPanel.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor } from "storybook/test";
+import { LicensesPanel } from "./LicensesPanel";
+
+const meta: Meta<typeof LicensesPanel> = {
+  title: "Components/LicensesPanel",
+  component: LicensesPanel,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="h-[600px] w-[700px] bg-panel flex flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof LicensesPanel>;
+
+export const Envarly: Story = {};
+
+export const ThirdParty: Story = {
+  play: async ({ canvasElement }) => {
+    const thirdPartyTab = await waitFor(() => {
+      const button = Array.from(canvasElement.querySelectorAll("button")).find((btn) =>
+        btn.textContent?.includes("Third-party"),
+      );
+      expect(button).toBeTruthy();
+      return button;
+    });
+    thirdPartyTab?.click();
+
+    await waitFor(() => {
+      expect(canvasElement.querySelector("table")).toBeTruthy();
+    });
+  },
+};

--- a/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
+++ b/src/components/SnapshotPanel/SnapshotPanel.stories.tsx
@@ -115,6 +115,34 @@ export const ManySnapshots: Story = {
   },
 };
 
+export const Compare: Story = {
+  play: async ({ canvasElement }) => {
+    // Button text is localized, so navigate by structural position instead:
+    // each card renders [Preview, Compare, rename-icon, delete-icon] normally,
+    // and just [Compare with] once a compare source is picked.
+    const cards = await waitFor(() => {
+      const els = Array.from(canvasElement.querySelectorAll<HTMLElement>("[data-snapshot-id]"));
+      expect(els.length).toBeGreaterThanOrEqual(2);
+      return els;
+    });
+
+    const compareButton = cards[0].querySelectorAll("button")[1];
+    compareButton.click();
+
+    const compareWithButton = await waitFor(() => {
+      const button = cards[1].querySelector("button");
+      expect(button).toBeTruthy();
+      return button;
+    });
+    compareWithButton?.click();
+
+    await waitFor(() => {
+      const dialog = canvasElement.ownerDocument.querySelector<HTMLElement>('[role="dialog"]');
+      expect(dialog?.parentElement).toBe(canvasElement.ownerDocument.body);
+    });
+  },
+};
+
 export const WidePreviewDiff: Story = {
   parameters: { snapshotFixtures: [wideDiffSnapshot] },
   play: async ({ canvasElement }) => {


### PR DESCRIPTION
## Summary
Found while investigating the a11y CI failure on #126 (a story missing required props crashed the whole test run) — audited which components had states no story ever reached, since the same class of bug could be hiding elsewhere silently.

- `ImportExportPanel`: new `SecretWarning` story exercises `ExportConfirm`, which no existing story reached
- `SnapshotPanel`: new `Compare` story exercises `SnapshotCompare`/`SnapshotDiffRow`, which no existing story reached
- `LicensesPanel`: added stories (had none at all)
- `ErrorBoundary`: added a story showing the crashed fallback UI (had none — new component, this session)

Play-function selectors use structural queries (`data-snapshot-id`, role, non-translated substrings like "GitHub" or ".json") instead of translated button text, since the test environment's default locale is Japanese and text-based selectors silently failed against it.

## Test plan
- [x] `vitest --project=storybook --run` — 26 files, 94 tests, all pass
- [x] `vitest run --project=unit` — 237 tests, all pass
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv