### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -2,7 +2,7 @@ export const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
-export const VERSION = '1.2.1';
+export const VERSION = '1.3.0';
 
 export type LandingCopy = {
   lang: 'en' | 'ja';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envarly",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envarly",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/tauri.mjs dev",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "biome format --write src",
     "gen-licenses": "node scripts/gen-licenses.mjs",
     "check-version": "node scripts/check-version.mjs",
-    "version": "node scripts/sync-version.mjs && git add src-tauri/tauri.conf.json src-tauri/Cargo.toml"
+    "version": "node scripts/sync-version.mjs && git add src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock lp/src/lib/lpContent.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -8,12 +8,18 @@ const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version
 const tauri = JSON.parse(readFileSync(join(root, "src-tauri", "tauri.conf.json"), "utf8")).version;
 const cargo = readFileSync(join(root, "src-tauri", "Cargo.toml"), "utf8")
   .match(/^version = "([^"]+)"/m)?.[1];
+const cargoLock = readFileSync(join(root, "src-tauri", "Cargo.lock"), "utf8")
+  .match(/\[\[package\]\]\nname = "envarly"\nversion = "([^"]+)"/)?.[1];
+const lpContent = readFileSync(join(root, "lp", "src", "lib", "lpContent.ts"), "utf8")
+  .match(/export const VERSION = '([^']+)';/)?.[1];
 
 console.log(`package.json:      ${pkg}`);
 console.log(`tauri.conf.json:   ${tauri}`);
 console.log(`Cargo.toml:        ${cargo}`);
+console.log(`Cargo.lock:        ${cargoLock}`);
+console.log(`lpContent.ts:      ${lpContent}`);
 
-if (pkg !== tauri || pkg !== cargo) {
+if (pkg !== tauri || pkg !== cargo || pkg !== cargoLock || pkg !== lpContent) {
   console.error("\nVersion mismatch! Run: npm version <patch|minor|major>");
   process.exit(1);
 }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -19,4 +19,22 @@ const cargo = readFileSync(cargoPath, "utf8").replace(
 );
 writeFileSync(cargoPath, cargo);
 
-console.log(`synced version ${version} → tauri.conf.json, Cargo.toml`);
+// Cargo.lock — the envarly package's own (self-referential) locked version
+const cargoLockPath = join(root, "src-tauri", "Cargo.lock");
+const cargoLock = readFileSync(cargoLockPath, "utf8").replace(
+  /(\[\[package\]\]\nname = "envarly"\nversion = ")[^"]*(")/,
+  `$1${version}$2`
+);
+writeFileSync(cargoLockPath, cargoLock);
+
+// Landing page version display
+const lpContentPath = join(root, "lp", "src", "lib", "lpContent.ts");
+const lpContent = readFileSync(lpContentPath, "utf8").replace(
+  /export const VERSION = '[^']*';/,
+  `export const VERSION = '${version}';`
+);
+writeFileSync(lpContentPath, lpContent);
+
+console.log(
+  `synced version ${version} → tauri.conf.json, Cargo.toml, Cargo.lock, lpContent.ts`
+);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.2.1"
+version = "1.3.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
## Summary
Version bump for the 1.3.0 release. Since v1.2.1:

- feat: check GitHub releases for updates (#125)
- feat: show a progress bar and log while applying staged changes (#126)
- refactor: large internal cleanup (env_store/export/commands module splits, DetailPanel/Sidebar/StagedModal/SnapshotPanel component splits) (#124)
- test: Storybook coverage improvements (#127)

After merging, I'll tag `v1.3.0` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv