### PR TITLE
docs: update README/lp for 1.3.0 features and current module layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,77 +240,15 @@ Snapshots are stored as JSON files under `%LOCALAPPDATA%\Envarly\snapshots\`. Ea
 
 ```
 envarly/
-├── src/                          # React frontend
-│   ├── api.ts                    # Tauri invoke wrappers; demo/real API gate; apply-progress event bridge
-│   ├── types.ts                  # Shared TypeScript types
-│   ├── context/
-│   │   └── ThemeContext.tsx      # Dark/light theme context
-│   ├── hooks/
-│   │   ├── useEnvVars.ts         # Variable list data hook
-│   │   ├── useStaged.ts          # Staging area hook; wires stagingLogic.ts into React state
-│   │   ├── stagingLogic.ts       # Pure Map transforms for staging (set/delete/import/snapshot) — no React
-│   │   ├── useAppInit.ts         # Startup sequencing; exposes `initializing` for the loading screen
-│   │   ├── useApplyStaged.ts     # Atomic apply + apply-progress event subscription for the log/bar
-│   │   ├── useDiff.ts            # External-change detection + selective apply
-│   │   ├── useDiagnostics.ts     # Environment diagnostics (unsupported values, dangling paths)
-│   │   ├── usePathStatus.ts      # PATH banner state + stage-add-to-PATH
-│   │   ├── useUpdateCheck.ts     # Daily GitHub release check, rate-limited via localStorage
-│   │   ├── useUndoStack.ts       # Generic undo/redo stack (stage-level operations)
-│   │   ├── useStagingHandlers.ts # Orchestrates stageSet/stageDelete/stageImport/stageSnapshot
-│   │   └── useTheme.ts           # Theme persistence + toggle
-│   ├── lib/
-│   │   ├── cn.ts                 # clsx + tailwind-merge helper
-│   │   ├── diff.ts               # Pure diff computation (no side effects)
-│   │   ├── lint.ts               # %VAR% reference lint for path values; Windows built-in allowlist
-│   │   └── secrets.ts            # Secret detection: name-based + value pattern (35+ token formats)
-│   └── components/
-│       ├── ui/                   # Atomic UI primitives (Button, Modal, Badge, …)
-│       ├── AppHeader/            # Top bar: refresh, staged-changes count, apply/discard, update badge
-│       ├── AppLoading/           # Full-screen loading state shown until the variable list is ready
-│       ├── ErrorBoundary/        # Catches uncaught render errors; shows a diagnosable crash screen
-│       ├── Sidebar/              # Variable list with search, scope filter, ⚠ Secrets tab
-│       ├── DetailPanel/          # Variable editor with local undo (Ctrl+Z pre-stage)
-│       ├── PathEditor/           # Drag-and-drop list editor + path validation + %VAR% lint
-│       ├── ListEditor/           # Generic sortable list editor (comma/semicolon separator)
-│       ├── PathBanner/           # Banner shown when Envarly is not yet in PATH
-│       ├── StagedModal/          # Apply confirmation: per-entry Delta/Full diff + apply progress/log
-│       ├── NewVarModal/          # New variable creation dialog
-│       ├── SnapshotPanel/        # Snapshot list, create, restore, compare
-│       ├── DiffPanel/            # External-change diff with selective apply
-│       ├── DiagnosticsPanel/     # Environment diagnostics banner
-│       ├── ImportExportPanel/    # File import / export UI
-│       └── LicensesPanel/        # OSS licenses: Envarly (MIT) + third-party (npm + Rust)
-├── public/
-│   └── theme-init.js             # Runs before React; sets theme class to avoid flash
-├── src-tauri/
-│   ├── icons/source/             # Logo SVG sources (aurora + monochrome)
-│   ├── wix/                      # WiX installer template + branded images; PATH cleanup CA
-│   └── src/                      # Rust backend
-│       ├── main.rs               # Entry point; CLI dispatch then GUI launch
-│       ├── lib.rs                # Tauri builder + command registration
-│       ├── cli.rs                # clap CLI (get / list / export)
-│       ├── commands/             # Tauri commands, one module per domain (env, snapshot, export, path, launch, update)
-│       ├── model.rs              # Shared domain types (EnvValue, EnvVar, EnvSnapshot, EnvChange, …)
-│       ├── env_store.rs          # EnvBackend trait + backend-agnostic business logic + MemBackend (tests)
-│       ├── env_backend.rs        # WinregBackend — the Windows registry implementation of EnvBackend
-│       ├── export/               # JSON, .reg, and IaC format serialisation / parsing, one module per format
-│       ├── path_manage.rs        # PATH status check + propose-add logic (install dir detection)
-│       ├── path_backend.rs       # Windows registry access for the PATH value
-│       ├── snapshot.rs           # Snapshot persistence (%LOCALAPPDATA%\Envarly)
-│       └── error.rs              # EnvarlyError (thiserror + Serialize)
-├── lp/                           # Astro landing page (published to GitHub Pages)
-├── scripts/
-│   ├── sync-version.mjs          # Propagates package.json version to tauri.conf.json, Cargo.toml, Cargo.lock, lp/src/lib/lpContent.ts
-│   ├── check-version.mjs         # Verifies all version fields match
-│   └── gen-licenses.mjs          # Generates src/assets/oss-licenses.json
-├── .github/workflows/
-│   ├── test.yml                  # Per-push test + version check
-│   ├── release.yml               # Tag-triggered Windows build
-│   └── security.yml              # Weekly vulnerability audit
-├── .mise.toml                    # Tool versions (Node 22, Rust stable)
-├── biome.json                    # Lint / format config
-└── vitest.config.ts              # Test config
+├── src/              # React frontend — components/, hooks/, lib/, api.ts, types.ts
+├── src-tauri/         # Rust backend — Tauri commands, registry access, export formats, snapshots
+├── lp/                # Astro landing page (published to GitHub Pages)
+├── scripts/           # Version sync/check, license generation
+├── docs/              # Release/distribution notes
+└── .github/workflows/ # CI: tests, release builds, security audit
 ```
+
+Frontend code is organized by feature under `src/components/`, with shared hooks in `src/hooks/` and framework-agnostic logic in `src/lib/`. The Rust backend mirrors this: `src-tauri/src/commands/` holds one module per domain (env, snapshot, export, path, launch, update), with the underlying logic in `env_store.rs` (backend-agnostic) and `env_backend.rs` (the Windows registry implementation).
 
 ## Architecture notes
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 - **Dark / light mode** — follows system preference on first launch; persists across sessions; no flash on load
 - **Snapshot / time-travel** — save named snapshots, restore to any previous state
 - **Diff detection** — detects registry changes made by other processes while Envarly is open; shows a diff with selective apply (accept or revert per entry)
+- **Apply progress & log** — a progress bar and per-variable log (✓/✗) show exactly what happened while staged changes are written to the registry
+- **Update check** — checks GitHub Releases once per day; shows a subtle header badge linking to the release when a newer version is available
 - **Import / Export** — read/write `.json` and `.reg` formats; export to IaC formats (PowerShell script, DSC v2/v3, Ansible playbook)
   - *Custom export*: pick individual variables, with secret-variable warnings
   - *Import merge strategy*: Merge (additive) or Replace (sync — removes variables not in the file)
@@ -41,7 +43,7 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 | Desktop shell | Tauri v2 |
 | Frontend | React 19 + TypeScript |
 | Styling | Tailwind CSS v4 |
-| Rust backend | winreg, clap, serde\_json, chrono, thiserror |
+| Rust backend | winreg, clap, serde\_json, chrono, thiserror, reqwest (native-tls) |
 | Linter / formatter | Biome |
 | JS tests | Vitest + @testing-library/react |
 | Rust tests | cargo test (MemBackend — no real registry writes) |
@@ -107,7 +109,8 @@ Release artifact policy and installer checks are documented in [docs/distributio
 
 ```sh
 npm version patch     # or minor / major
-# → bumps package.json, syncs tauri.conf.json and Cargo.toml, commits + tags
+# → bumps package.json, syncs tauri.conf.json, Cargo.toml, Cargo.lock, and
+#   lp/src/lib/lpContent.ts, commits + tags
 git push --follow-tags
 # → triggers the Release workflow on GitHub Actions (builds installer, uploads to GitHub Releases)
 ```
@@ -238,13 +241,20 @@ Snapshots are stored as JSON files under `%LOCALAPPDATA%\Envarly\snapshots\`. Ea
 ```
 envarly/
 ├── src/                          # React frontend
-│   ├── api.ts                    # Tauri invoke wrappers
+│   ├── api.ts                    # Tauri invoke wrappers; demo/real API gate; apply-progress event bridge
 │   ├── types.ts                  # Shared TypeScript types
 │   ├── context/
 │   │   └── ThemeContext.tsx      # Dark/light theme context
 │   ├── hooks/
 │   │   ├── useEnvVars.ts         # Variable list data hook
-│   │   ├── useStaged.ts          # Staging area: Map<"Scope:name", StagedChange>; effectiveVars merge
+│   │   ├── useStaged.ts          # Staging area hook; wires stagingLogic.ts into React state
+│   │   ├── stagingLogic.ts       # Pure Map transforms for staging (set/delete/import/snapshot) — no React
+│   │   ├── useAppInit.ts         # Startup sequencing; exposes `initializing` for the loading screen
+│   │   ├── useApplyStaged.ts     # Atomic apply + apply-progress event subscription for the log/bar
+│   │   ├── useDiff.ts            # External-change detection + selective apply
+│   │   ├── useDiagnostics.ts     # Environment diagnostics (unsupported values, dangling paths)
+│   │   ├── usePathStatus.ts      # PATH banner state + stage-add-to-PATH
+│   │   ├── useUpdateCheck.ts     # Daily GitHub release check, rate-limited via localStorage
 │   │   ├── useUndoStack.ts       # Generic undo/redo stack (stage-level operations)
 │   │   ├── useStagingHandlers.ts # Orchestrates stageSet/stageDelete/stageImport/stageSnapshot
 │   │   └── useTheme.ts           # Theme persistence + toggle
@@ -254,24 +264,20 @@ envarly/
 │   │   ├── lint.ts               # %VAR% reference lint for path values; Windows built-in allowlist
 │   │   └── secrets.ts            # Secret detection: name-based + value pattern (35+ token formats)
 │   └── components/
-│       ├── ui/                   # Atomic UI primitives
-│       │   ├── Badge.tsx
-│       │   ├── Button.tsx
-│       │   ├── IconButton.tsx
-│       │   ├── Modal.tsx
-│       │   ├── SegmentedControl.tsx
-│       │   ├── TextInput.tsx
-│       │   └── Textarea.tsx
-│       ├── AppHeader/            # Top bar: refresh, staged-changes count, apply/discard, menu
+│       ├── ui/                   # Atomic UI primitives (Button, Modal, Badge, …)
+│       ├── AppHeader/            # Top bar: refresh, staged-changes count, apply/discard, update badge
+│       ├── AppLoading/           # Full-screen loading state shown until the variable list is ready
+│       ├── ErrorBoundary/        # Catches uncaught render errors; shows a diagnosable crash screen
 │       ├── Sidebar/              # Variable list with search, scope filter, ⚠ Secrets tab
 │       ├── DetailPanel/          # Variable editor with local undo (Ctrl+Z pre-stage)
 │       ├── PathEditor/           # Drag-and-drop list editor + path validation + %VAR% lint
 │       ├── ListEditor/           # Generic sortable list editor (comma/semicolon separator)
 │       ├── PathBanner/           # Banner shown when Envarly is not yet in PATH
-│       ├── StagedModal/          # Apply confirmation: per-entry Delta/Full diff for list values
+│       ├── StagedModal/          # Apply confirmation: per-entry Delta/Full diff + apply progress/log
 │       ├── NewVarModal/          # New variable creation dialog
-│       ├── SnapshotPanel/        # Snapshot list, create, restore
+│       ├── SnapshotPanel/        # Snapshot list, create, restore, compare
 │       ├── DiffPanel/            # External-change diff with selective apply
+│       ├── DiagnosticsPanel/     # Environment diagnostics banner
 │       ├── ImportExportPanel/    # File import / export UI
 │       └── LicensesPanel/        # OSS licenses: Envarly (MIT) + third-party (npm + Rust)
 ├── public/
@@ -283,15 +289,19 @@ envarly/
 │       ├── main.rs               # Entry point; CLI dispatch then GUI launch
 │       ├── lib.rs                # Tauri builder + command registration
 │       ├── cli.rs                # clap CLI (get / list / export)
-│       ├── commands.rs           # Tauri commands
-│       ├── env_store.rs          # Registry read/write + EnvBackend trait + MemBackend
-│       ├── export.rs             # JSON, .reg, and IaC format serialisation / parsing
+│       ├── commands/             # Tauri commands, one module per domain (env, snapshot, export, path, launch, update)
+│       ├── model.rs              # Shared domain types (EnvValue, EnvVar, EnvSnapshot, EnvChange, …)
+│       ├── env_store.rs          # EnvBackend trait + backend-agnostic business logic + MemBackend (tests)
+│       ├── env_backend.rs        # WinregBackend — the Windows registry implementation of EnvBackend
+│       ├── export/               # JSON, .reg, and IaC format serialisation / parsing, one module per format
 │       ├── path_manage.rs        # PATH status check + propose-add logic (install dir detection)
+│       ├── path_backend.rs       # Windows registry access for the PATH value
 │       ├── snapshot.rs           # Snapshot persistence (%LOCALAPPDATA%\Envarly)
 │       └── error.rs              # EnvarlyError (thiserror + Serialize)
+├── lp/                           # Astro landing page (published to GitHub Pages)
 ├── scripts/
-│   ├── sync-version.mjs          # Propagates package.json version to tauri.conf.json + Cargo.toml
-│   ├── check-version.mjs         # Verifies all three version fields match
+│   ├── sync-version.mjs          # Propagates package.json version to tauri.conf.json, Cargo.toml, Cargo.lock, lp/src/lib/lpContent.ts
+│   ├── check-version.mjs         # Verifies all version fields match
 │   └── gen-licenses.mjs          # Generates src/assets/oss-licenses.json
 ├── .github/workflows/
 │   ├── test.yml                  # Per-push test + version check
@@ -317,7 +327,11 @@ The baseline snapshot is captured on app mount. Every Refresh call re-reads the 
 
 ### Test isolation
 
-`env_store.rs` exposes an `EnvBackend` trait. The production `WinregBackend` is compiled only on Windows (`#[cfg(windows)]`). Tests use `MemBackend` — an in-memory `Mutex<HashMap>` that never touches the registry. `cargo test` runs on Linux in CI without any Windows-specific dependencies.
+`env_store.rs` defines the `EnvBackend` trait. The production implementation, `WinregBackend` (in `env_backend.rs`), is compiled only on Windows (`#[cfg(windows)]`). Tests use `MemBackend` — an in-memory `Mutex<HashMap>` defined alongside the trait — that never touches the registry. `cargo test` runs on Linux in CI without any Windows-specific dependencies.
+
+### Apply progress
+
+`apply_changes_with` (Rust) takes a per-change progress callback; the `apply_env_changes` Tauri command uses it to emit an `apply-progress` event for each variable as it's written, while keeping the existing atomic all-or-nothing rollback behavior unchanged. The frontend subscribes via `api.onApplyProgress` *before* calling `applyEnvChanges` — subscribing after would race a fast apply, since events emitted before a listener attaches are simply lost.
 
 ## License
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -27,7 +27,7 @@ If MSI testing shows a better direct-user experience for a specific release, upd
 
 Before tagging a release:
 
-- Confirm `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` have the same version.
+- Run `npm run check-version` to confirm `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `lp/src/lib/lpContent.ts` all have the same version.
 - Confirm the release workflow still uploads NSIS `.exe`, WiX `.msi`, portable `.zip`, and `SHA256SUMS.txt`.
 - Build locally if the change touches installer configuration:
 

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -117,6 +117,11 @@ export const enCopy: LandingCopy = {
       desc: 'Detects registry changes made by other processes while Envarly is open. Shows a diff with selective apply per entry.',
     },
     {
+      icon: '⏳',
+      title: 'Apply progress & log',
+      desc: 'A progress bar and per-variable log show exactly what happened while staged changes are written to the registry.',
+    },
+    {
       icon: '⇅',
       title: 'Import / Export',
       desc: 'Read and write .json and .reg formats, plus export to PowerShell, DSC, and Ansible-friendly files. Preview before any write.',
@@ -203,6 +208,11 @@ export const jaCopy: LandingCopy = {
       icon: '⇄',
       title: '外部変更の差分検出',
       desc: 'Envarly を開いている間に他プロセスがレジストリを変更した場合、差分を検出。項目ごとに受け入れる変更を選べます。',
+    },
+    {
+      icon: '⏳',
+      title: '適用の進捗とログ',
+      desc: 'ステージした変更をレジストリに書き込む間、進捗バーと変数ごとのログで何が起きているか確認できます。',
     },
     {
       icon: '⇅',


### PR DESCRIPTION
## Summary
- Document the two 1.3.0 features (apply progress/log, update check) in the README feature list and landing page (EN/JA)
- Rewrite the README's Project structure tree — it was stale after this cycle's env_store/env_backend/model.rs and export/commands module splits, and the new hooks/components (useAppInit, useApplyStaged, useUpdateCheck, stagingLogic, AppLoading, ErrorBoundary, etc.)
- Note Cargo.lock and lp/src/lib/lpContent.ts in the release checklist, matching the sync-version.mjs/check-version.mjs update from #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv