### PR TITLE
chore: prepare Scoop manifest

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -79,8 +79,27 @@ For WinGet:
 
 For Scoop:
 
-- Use the GitHub Release artifact URL and the matching SHA256 from `SHA256SUMS.txt`.
-- The portable ZIP is the best candidate if Scoop install behavior should avoid a traditional installer.
+- Manifest source of truth lives at [`scoop/envarly.json`](../scoop/envarly.json) in this repo.
+- Uses the portable ZIP (not the NSIS/MSI installer) — Scoop apps are expected to install without a traditional installer UI.
+- `checkver`/`autoupdate` point at GitHub Releases directly, so `scoop update envarly` on a consumer's machine picks up new tags automatically once the manifest is published in a bucket — but the manifest in *this* repo and the one in the bucket are two separate copies that must be kept in sync manually (see below).
+
+### Updating the Scoop manifest for a new release
+
+After tagging and publishing a release:
+
+1. Download `SHA256SUMS.txt` from the new release and copy the hash for `Envarly_<version>_x64-portable.zip`.
+2. In `scoop/envarly.json`, update `version`, `url` (the `v<version>` tag and filename), and `hash`.
+3. Validate the JSON (`node -e "JSON.parse(require('fs').readFileSync('scoop/envarly.json','utf8'))"`) — a syntax error here fails Scoop's bucket CI.
+4. If the manifest has already been submitted to a bucket (e.g. `ScoopInstaller/Extras`), copy the updated file there and open a PR — Scoop does not offer maintainer-side auto-publish the way `sync-version.mjs` does for our own files.
+
+### Install / uninstall / update behavior
+
+```powershell
+scoop bucket add extras   # if using the extras bucket
+scoop install envarly      # install
+scoop update envarly       # update to the latest manifest version
+scoop uninstall envarly    # uninstall — Scoop removes the shim/shortcut; app data under %LOCALAPPDATA%\Envarly is untouched
+```
 
 ## Release Notes Template
 

--- a/scoop/envarly.json
+++ b/scoop/envarly.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "1.3.0",
+    "description": "Windows environment variable manager — edit PATH with folder pickers, detect secrets, and preview changes before applying.",
+    "homepage": "https://github.com/iray-tno/envarly",
+    "license": "MIT",
+    "url": "https://github.com/iray-tno/envarly/releases/download/v1.3.0/Envarly_1.3.0_x64-portable.zip",
+    "hash": "08d39116868c5148026904417aeea1375ca3c9f319d41d06ebf214fa51a3bdb6",
+    "bin": "envarly.exe",
+    "shortcuts": [
+        [
+            "envarly.exe",
+            "Envarly"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/iray-tno/envarly"
+    },
+    "autoupdate": {
+        "url": "https://github.com/iray-tno/envarly/releases/download/v$version/Envarly_$version_x64-portable.zip"
+    }
+}


### PR DESCRIPTION
## Summary
Closes the "prepare" half of #73 — adds a Scoop manifest for Envarly, using the same GitHub Release artifacts and checksum process set up for WinGet (#71).

- `scoop/envarly.json` — manifest pointing at the portable ZIP (Scoop apps install without a traditional installer UI, so this uses the ZIP rather than the NSIS/MSI installer)
- `docs/distribution.md` — documents the update-on-release steps, and install/uninstall/update behavior

Not done yet, intentionally: actually submitting this to a bucket (e.g. `ScoopInstaller/Extras`) via PR to that third-party repo, and mentioning `scoop install envarly` in the README — per #73's acceptance criteria, the README mention should wait until the manifest is actually live in a bucket.

## Test plan
- [x] Manifest JSON validated (`node -e "JSON.parse(...)"`)
- [ ] `scoop install <path-to-manifest>` locally, confirm the app launches and the Start Menu shortcut works
- [ ] `scoop uninstall envarly`, confirm app data under `%LOCALAPPDATA%\Envarly` is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv