### PR TITLE
test: regression coverage for the startup-freeze fix

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,6 +1,12 @@
-import { isTauri } from "@tauri-apps/api/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api } from "./api";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api, withTimeout } from "./api";
+import type { ApplyProgressEvent } from "./types";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
 
 describe("api runtime detection", () => {
   beforeEach(() => {
@@ -11,5 +17,70 @@ describe("api runtime detection", () => {
     await expect(api.getEnvVars()).rejects.toThrow(
       "Tauri runtime unavailable. Start Envarly with `npm run dev`.",
     );
+  });
+});
+
+describe("withTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the real value if it arrives before the timeout", async () => {
+    const promise = withTimeout(Promise.resolve("real"), 3000, "fallback");
+    await expect(promise).resolves.toBe("real");
+  });
+
+  it("resolves with the fallback if the promise never settles", async () => {
+    const never = new Promise<string>(() => {});
+    const promise = withTimeout(never, 3000, "fallback");
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    await expect(promise).resolves.toBe("fallback");
+  });
+
+  it("resolves with the fallback if the promise rejects", async () => {
+    const promise = withTimeout(Promise.reject(new Error("boom")), 3000, "fallback");
+    await expect(promise).resolves.toBe("fallback");
+  });
+});
+
+describe("api.onApplyProgress", () => {
+  beforeEach(() => {
+    vi.mocked(isTauri).mockReturnValue(true);
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_launch_options") return { demo: false, demoFixture: null };
+      return undefined;
+    });
+  });
+
+  it("subscribes via listen and forwards event payloads to the callback", async () => {
+    const unlisten = vi.fn();
+    vi.mocked(listen).mockResolvedValue(unlisten);
+
+    const callback = vi.fn();
+    const unsubscribe = await api.onApplyProgress(callback);
+
+    expect(listen).toHaveBeenCalledWith("apply-progress", expect.any(Function));
+
+    const event: ApplyProgressEvent = {
+      index: 0,
+      total: 1,
+      name: "FOO",
+      scope: "User",
+      action: "set",
+      success: true,
+      error: null,
+    };
+    const [, handler] = vi.mocked(listen).mock.calls[0];
+    handler({ event: "apply-progress", id: 1, payload: event });
+    expect(callback).toHaveBeenCalledWith(event);
+
+    unsubscribe();
+    expect(unlisten).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -95,7 +95,7 @@ let apiPromise: Promise<EnvarlyApi> | null = null;
  * stuck IPC call can block every other command in the app behind `getApi()`. */
 const LAUNCH_OPTIONS_TIMEOUT_MS = 3000;
 
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
   return new Promise((resolve) => {
     const timer = setTimeout(() => resolve(fallback), ms);
     promise.then(

--- a/src/hooks/useApplyStaged.test.ts
+++ b/src/hooks/useApplyStaged.test.ts
@@ -106,6 +106,28 @@ describe("useApplyStaged", () => {
     expect(params.setDialog).toHaveBeenCalledWith(null);
   });
 
+  it("closes the dialog only after refresh and refreshPathStatus resolve", async () => {
+    const callOrder: string[] = [];
+    const params = makeParams({
+      refresh: vi.fn().mockImplementation(async () => {
+        callOrder.push("refresh");
+      }),
+      refreshPathStatus: vi.fn().mockImplementation(async () => {
+        callOrder.push("refreshPathStatus");
+      }),
+      setDialog: vi.fn().mockImplementation(() => {
+        callOrder.push("setDialog");
+      }),
+    });
+    const { result } = renderHook(() => useApplyStaged(params));
+
+    await act(async () => {
+      await result.current.handleApplyStaged(false);
+    });
+
+    expect(callOrder).toEqual(["refresh", "refreshPathStatus", "setDialog"]);
+  });
+
   it("keeps the modal open and exposes the error when apply fails", async () => {
     vi.mocked(api.applyEnvChanges).mockRejectedValue("Registry error: access denied");
     const params = makeParams();

--- a/src/hooks/useDiff.test.ts
+++ b/src/hooks/useDiff.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../api";
+import type { DiffEntry } from "../lib/diff";
+import { useDiff } from "./useDiff";
+
+vi.mock("../api", () => ({
+  api: {
+    getRegistrySnapshot: vi.fn(),
+    setEnvVar: vi.fn(),
+    deleteEnvVar: vi.fn(),
+  },
+}));
+
+describe("useDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.setEnvVar).mockResolvedValue(undefined);
+    vi.mocked(api.deleteEnvVar).mockResolvedValue(undefined);
+  });
+
+  it("closes the dialog only after refresh resolves", async () => {
+    const callOrder: string[] = [];
+    const refresh = vi.fn().mockImplementation(async () => {
+      callOrder.push("refresh");
+    });
+    const setDialog = vi.fn().mockImplementation(() => {
+      callOrder.push("setDialog");
+    });
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    await act(async () => {
+      await result.current.handleDiffApply([], []);
+    });
+
+    expect(callOrder).toEqual(["refresh", "setDialog"]);
+    expect(setDialog).toHaveBeenCalledWith(null);
+  });
+
+  it("reverts added entries by deleting them", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const setDialog = vi.fn();
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    const added: DiffEntry = { kind: "added", name: "NEW_VAR", scope: "User", value: "x", valueKind: "String" };
+    await act(async () => {
+      await result.current.handleDiffApply([], [added]);
+    });
+
+    expect(api.deleteEnvVar).toHaveBeenCalledWith("NEW_VAR", "User");
+  });
+
+  it("reverts removed entries by restoring the old value", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const setDialog = vi.fn();
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    const removed: DiffEntry = {
+      kind: "removed",
+      name: "OLD_VAR",
+      scope: "System",
+      value: "gone",
+      valueKind: "String",
+    };
+    await act(async () => {
+      await result.current.handleDiffApply([], [removed]);
+    });
+
+    expect(api.setEnvVar).toHaveBeenCalledWith("OLD_VAR", "gone", "String", "System");
+  });
+
+  it("keeps the dialog open and exposes the error when reverting fails", async () => {
+    vi.mocked(api.deleteEnvVar).mockRejectedValue(new Error("access denied"));
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const setDialog = vi.fn();
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    const added: DiffEntry = { kind: "added", name: "NEW_VAR", scope: "User", value: "x", valueKind: "String" };
+    await act(async () => {
+      await result.current.handleDiffApply([], [added]);
+    });
+
+    expect(setDialog).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(result.current.applyError).toBe("Error: access denied");
+  });
+
+  it("checkForExternalChanges populates diffEntries when the registry differs from baseline", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const setDialog = vi.fn();
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    result.current.baselineRef.current = { user: {}, system: {} };
+    vi.mocked(api.getRegistrySnapshot).mockResolvedValue({
+      user: { FOO: { value: "bar", kind: "String" } },
+      system: {},
+    });
+
+    await act(async () => {
+      await result.current.checkForExternalChanges();
+    });
+
+    expect(result.current.diffEntries).toEqual([
+      { kind: "added", name: "FOO", scope: "User", value: "bar", valueKind: "String" },
+    ]);
+    expect(setDialog).toHaveBeenCalledWith("changes");
+  });
+
+  it("handleDiffDismiss clears diff entries and error, and closes the dialog", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const setDialog = vi.fn();
+    const { result } = renderHook(() => useDiff(refresh, setDialog));
+
+    result.current.baselineRef.current = { user: {}, system: {} };
+    vi.mocked(api.getRegistrySnapshot).mockResolvedValue({
+      user: { FOO: { value: "bar", kind: "String" } },
+      system: {},
+    });
+    await act(async () => {
+      await result.current.checkForExternalChanges();
+    });
+    expect(result.current.diffEntries.length).toBe(1);
+
+    act(() => {
+      result.current.handleDiffDismiss();
+    });
+
+    expect(result.current.diffEntries).toEqual([]);
+    expect(result.current.applyError).toBeNull();
+    expect(setDialog).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/hooks/useUpdateCheck.test.ts
+++ b/src/hooks/useUpdateCheck.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../api";
+import { useUpdateCheck } from "./useUpdateCheck";
+
+vi.mock("../api", () => ({
+  api: {
+    checkForUpdate: vi.fn(),
+  },
+}));
+
+const STORAGE_KEY = "envarly.lastUpdateCheck";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("useUpdateCheck", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(api.checkForUpdate).mockReset();
+  });
+
+  it("checks for an update when never checked before", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue({
+      version: "9.9.9",
+      url: "https://example.com/release",
+    });
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({ version: "9.9.9", url: "https://example.com/release" });
+    expect(api.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the check time so it isn't repeated within 24 hours", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(null);
+
+    renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(api.checkForUpdate).toHaveBeenCalledTimes(1));
+    expect(Number(localStorage.getItem(STORAGE_KEY))).toBeGreaterThan(0);
+  });
+
+  it("does not check again if the last check was less than 24 hours ago", () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - DAY_MS / 2));
+
+    renderHook(() => useUpdateCheck());
+
+    expect(api.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("checks again if the last check was more than 24 hours ago", async () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - DAY_MS * 2));
+    vi.mocked(api.checkForUpdate).mockResolvedValue(null);
+
+    renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(api.checkForUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("stays null when there is no newer version", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(api.checkForUpdate).toHaveBeenCalledTimes(1));
+    expect(result.current).toBeNull();
+  });
+
+  it("does not throw when the update check fails", async () => {
+    vi.mocked(api.checkForUpdate).mockRejectedValue(new Error("network error"));
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(api.checkForUpdate).toHaveBeenCalledTimes(1));
+    expect(result.current).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes the test-coverage gap flagged after shipping v1.3.0's freeze fix — the actual mechanisms that prevent the app from freezing again had no tests guarding them.

- `withTimeout` (api.ts): exported for direct testing; covers real-value, never-settles (fake timers), and rejects cases
- `api.onApplyProgress`: verifies it subscribes via `listen()` and forwards event payloads to the callback
- `useUpdateCheck`: new test file — had zero coverage. Covers 24h rate limiting, success/null/error paths
- `useApplyStaged` / `useDiff`: added a regression test asserting the apply dialog only closes (`setDialog(null)`) after `refresh()` resolves — this is the exact premature-close ordering bug fixed earlier this cycle, previously unguarded

## Test plan
- [x] `vitest run --project=unit` — 255 tests, all pass
- [x] `tsc --noEmit` — clean
- [x] `biome lint src` — clean (pre-existing unrelated warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGshPF4YNUCzzUfcgd23Fv