### PR TITLE
chore: consolidate local draft folders under temp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,8 @@ src-tauri/gen/
 # Claude Code local settings (may contain local file paths)
 .claude/settings.local.json
 
-# Promo drafts (local only)
-promo/
-
-# WinGet submission drafts (submitted to microsoft/winget-pkgs)
-winget-manifests/
+# Local scratch/drafts (submission drafts, notes, anything not meant to be committed)
+temp/
 
 # Editor
 .vscode/*


### PR DESCRIPTION
## Summary
- Removed the one-off `promo/` and `winget-manifests/` gitignore entries in favor of the general `temp/` scratch folder
- No tracked files affected — both were already gitignored, local-only draft content

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>