### PR TITLE
feat(lp): add prev/next buttons to screenshot carousel

### DIFF
--- a/lp/src/components/LandingPage.astro
+++ b/lp/src/components/LandingPage.astro
@@ -100,6 +100,20 @@ const { copy } = Astro.props;
               loading="lazy"
             />
           </div>
+          <button
+            id="carousel-prev"
+            aria-label={copy.screenshots.prevLabel}
+            class="absolute left-2 top-1/2 -translate-y-1/2 flex items-center justify-center w-9 h-9 rounded-full bg-[var(--color-surface)]/80 border border-[var(--color-border)] text-[var(--color-text)] hover:border-[var(--color-accent)]/60 transition-colors backdrop-blur"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+          </button>
+          <button
+            id="carousel-next"
+            aria-label={copy.screenshots.nextLabel}
+            class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center w-9 h-9 rounded-full bg-[var(--color-surface)]/80 border border-[var(--color-border)] text-[var(--color-text)] hover:border-[var(--color-accent)]/60 transition-colors backdrop-blur"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6" /></svg>
+          </button>
         </div>
         <!-- Dots -->
         <div class="flex justify-center gap-2 mt-4">
@@ -111,6 +125,8 @@ const { copy } = Astro.props;
         {
           const track = document.getElementById('carousel-track');
           const dots = [document.getElementById('dot-0'), document.getElementById('dot-1')];
+          const prevBtn = document.getElementById('carousel-prev');
+          const nextBtn = document.getElementById('carousel-next');
           let current = 0;
           let timer: ReturnType<typeof setInterval>;
 
@@ -127,7 +143,15 @@ const { copy } = Astro.props;
             timer = setInterval(() => goTo((current + 1) % dots.length), 5000);
           }
 
-          dots.forEach((d, i) => d?.addEventListener('click', () => { clearInterval(timer); goTo(i); startAuto(); }));
+          function restart(i: number) {
+            clearInterval(timer);
+            goTo(i);
+            startAuto();
+          }
+
+          dots.forEach((d, i) => d?.addEventListener('click', () => restart(i)));
+          prevBtn?.addEventListener('click', () => restart((current - 1 + dots.length) % dots.length));
+          nextBtn?.addEventListener('click', () => restart((current + 1) % dots.length));
           startAuto();
         }
       </script>

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -29,6 +29,8 @@ export type LandingCopy = {
     applyModalAlt: string;
     firstLabel: string;
     secondLabel: string;
+    prevLabel: string;
+    nextLabel: string;
   };
   featuresHeading: string;
   featuresLead: string;
@@ -77,6 +79,8 @@ export const enCopy: LandingCopy = {
     applyModalAlt: 'Envarly — Apply confirmation modal with Full diff view for PATH entries',
     firstLabel: 'Screenshot 1',
     secondLabel: 'Screenshot 2',
+    prevLabel: 'Previous screenshot',
+    nextLabel: 'Next screenshot',
   },
   featuresHeading: 'Features',
   featuresLead: 'Everything you need to manage environment variables safely.',
@@ -170,6 +174,8 @@ export const jaCopy: LandingCopy = {
     applyModalAlt: 'Envarly — PATH エントリの詳細差分を表示する適用確認モーダル',
     firstLabel: 'スクリーンショット 1',
     secondLabel: 'スクリーンショット 2',
+    prevLabel: '前のスクリーンショット',
+    nextLabel: '次のスクリーンショット',
   },
   featuresHeading: '機能',
   featuresLead: '環境変数を安全に管理するために必要なものをひとまとめに。',


### PR DESCRIPTION
## Summary
- Added left/right arrow buttons to the landing page screenshot carousel so it can be navigated manually, not just via dots or auto-rotation
- Buttons wrap around (next from the last screenshot goes to the first, and vice versa) and reset the auto-rotate timer like the existing dot clicks do
- Added localized aria-labels (`prevLabel`/`nextLabel`) in both English and Japanese copy

## Test plan
- [ ] Run `astro dev` in `lp/`, confirm the arrow buttons appear centered vertically over the carousel and step through both screenshots in each direction
- [ ] Confirm clicking prev/next still resets/continues the 5s auto-rotate
- [ ] Check dark/light theme contrast on the buttons

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>