### PR TITLE
feat(lp): support swipe gestures on the screenshot carousel

### DIFF
--- a/lp/src/components/LandingPage.astro
+++ b/lp/src/components/LandingPage.astro
@@ -152,6 +152,21 @@ const { copy } = Astro.props;
           dots.forEach((d, i) => d?.addEventListener('click', () => restart(i)));
           prevBtn?.addEventListener('click', () => restart((current - 1 + dots.length) % dots.length));
           nextBtn?.addEventListener('click', () => restart((current + 1) % dots.length));
+
+          const SWIPE_THRESHOLD_PX = 40;
+          let touchStartX = 0;
+
+          track?.addEventListener('touchstart', (e) => {
+            touchStartX = e.touches[0].clientX;
+          }, { passive: true });
+
+          track?.addEventListener('touchend', (e) => {
+            const dx = e.changedTouches[0].clientX - touchStartX;
+            if (Math.abs(dx) < SWIPE_THRESHOLD_PX) return;
+            if (dx < 0) restart((current + 1) % dots.length);
+            else restart((current - 1 + dots.length) % dots.length);
+          }, { passive: true });
+
           startAuto();
         }
       </script>


### PR DESCRIPTION
## Summary
- Added touch swipe support to the landing page screenshot carousel, alongside the existing dots and arrow buttons
- Swiping past a 40px threshold moves to the next/previous screenshot (wraps around) and resets the auto-rotate timer, same as the other nav methods

## Test plan
- [ ] On a touch device (or browser touch emulation), swipe left/right over the carousel and confirm it advances/goes back correctly
- [ ] Confirm a small accidental touch (tap, or a swipe under the threshold) doesn't change the slide
- [ ] Confirm swipe still works alongside the arrow buttons and dots without conflicts

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>