### PR TITLE
feat: add a "Check command" diagnostic tool

### DIFF
--- a/src-tauri/src/commands/path.rs
+++ b/src-tauri/src/commands/path.rs
@@ -18,7 +18,7 @@ pub fn validate_paths(paths: Vec<String>) -> Vec<bool> {
 /// that Rust's Path::exists() (which uses GetFileAttributesExW) can produce
 /// under certain Windows filesystem filter drivers or security software.
 #[cfg(windows)]
-fn dir_exists(path: &str) -> bool {
+pub(crate) fn dir_exists(path: &str) -> bool {
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
     let attrs =
         unsafe { windows_sys::Win32::Storage::FileSystem::GetFileAttributesW(wide.as_ptr()) };
@@ -27,7 +27,7 @@ fn dir_exists(path: &str) -> bool {
 }
 
 #[cfg(not(windows))]
-fn dir_exists(path: &str) -> bool {
+pub(crate) fn dir_exists(path: &str) -> bool {
     std::path::Path::new(path).exists()
 }
 
@@ -93,6 +93,13 @@ pub fn get_path_proposal(scope: String) -> Result<Option<String>, EnvarlyError> 
         }
     };
     path_manage::propose_add(user)
+}
+
+/// Checks whether `input` (a command name or full exe path) resolves via the
+/// effective PATH, and whether it's shadowed by another same-named file.
+#[tauri::command]
+pub fn check_command(input: String) -> Result<path_manage::CheckCommandResult, EnvarlyError> {
+    path_manage::check_command(&input)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             commands::env::restart_as_admin,
             commands::path::get_path_status,
             commands::path::get_path_proposal,
+            commands::path::check_command,
             commands::launch::get_launch_options,
             commands::launch::read_demo_fixture,
             commands::update::check_for_update,

--- a/src-tauri/src/path_manage.rs
+++ b/src-tauri/src/path_manage.rs
@@ -38,6 +38,161 @@ pub fn compute_remove(current: &str, dir: &str) -> Option<String> {
     Some(after.join(";"))
 }
 
+// ── check_command: does a name/path resolve via the effective PATH? ───────
+
+const DEFAULT_PATHEXT: &str = ".COM;.EXE;.BAT;.CMD";
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandHit {
+    pub directory: String,
+    pub matched_file: String,
+    pub source: String, // "User" | "System"
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum FullPathStatus {
+    Active,
+    Shadowed {
+        #[serde(rename = "shadowedBy")]
+        shadowed_by: CommandHit,
+    },
+    NotOnEffectivePath,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckCommandResult {
+    pub input: String,
+    pub queried_name: String,
+    pub had_extension: bool,
+    pub hits: Vec<CommandHit>,
+    pub full_path_status: Option<FullPathStatus>,
+}
+
+struct NormalizedInput {
+    unquoted: String,
+    basename: String,
+    had_extension: bool,
+    full_dir: Option<String>,
+}
+
+fn normalize_input(raw: &str) -> NormalizedInput {
+    let trimmed = raw.trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(trimmed)
+        .to_string();
+
+    let (full_dir, basename) = match unquoted.rfind(['\\', '/']) {
+        Some(idx) => (
+            Some(unquoted[..idx].to_string()),
+            unquoted[idx + 1..].to_string(),
+        ),
+        None => (None, unquoted.clone()),
+    };
+
+    let had_extension = basename.rfind('.').is_some();
+
+    NormalizedInput {
+        unquoted,
+        basename,
+        had_extension,
+        full_dir,
+    }
+}
+
+fn split_path_entries<'a>(
+    raw: &'a str,
+    source: &'static str,
+) -> impl Iterator<Item = (&'a str, &'static str)> {
+    raw.split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(move |s| (s, source))
+}
+
+fn pathext_list(pathext_raw: &str) -> Vec<String> {
+    let list: Vec<String> = pathext_raw
+        .split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    if list.is_empty() {
+        DEFAULT_PATHEXT.split(';').map(str::to_string).collect()
+    } else {
+        list
+    }
+}
+
+fn normalize_dir_for_compare(dir: &str) -> String {
+    dir.trim_end_matches(['\\', '/']).to_lowercase()
+}
+
+/// Pure matching engine — no registry/filesystem access, everything injected,
+/// so it's fully unit-testable without touching the real PATH or disk.
+pub fn check_command_with(
+    raw_input: &str,
+    user_path_raw: &str,
+    system_path_raw: &str,
+    pathext_raw: &str,
+    expand_env: impl Fn(&str) -> String,
+    path_exists: impl Fn(&str) -> bool,
+) -> CheckCommandResult {
+    let normalized = normalize_input(raw_input);
+
+    let extensions: Vec<String> = if normalized.had_extension {
+        vec![String::new()]
+    } else {
+        pathext_list(pathext_raw)
+    };
+
+    let mut hits: Vec<CommandHit> = Vec::new();
+
+    for (dir, source) in split_path_entries(system_path_raw, "System")
+        .chain(split_path_entries(user_path_raw, "User"))
+    {
+        let expanded_dir = expand_env(dir);
+        let base = expanded_dir.trim_end_matches(['\\', '/']);
+        for ext in &extensions {
+            let candidate = format!("{base}\\{}{ext}", normalized.basename);
+            if path_exists(&candidate) {
+                hits.push(CommandHit {
+                    directory: expanded_dir.clone(),
+                    matched_file: format!("{}{ext}", normalized.basename),
+                    source: source.to_string(),
+                });
+                break;
+            }
+        }
+    }
+
+    let full_path_status = normalized.full_dir.as_deref().map(|input_dir| {
+        let input_dir_norm = normalize_dir_for_compare(input_dir);
+        match hits
+            .iter()
+            .position(|h| normalize_dir_for_compare(&h.directory) == input_dir_norm)
+        {
+            Some(0) => FullPathStatus::Active,
+            Some(_) => FullPathStatus::Shadowed {
+                shadowed_by: hits[0].clone(),
+            },
+            None => FullPathStatus::NotOnEffectivePath,
+        }
+    });
+
+    CheckCommandResult {
+        input: normalized.unquoted,
+        queried_name: normalized.basename,
+        had_extension: normalized.had_extension,
+        hits,
+        full_path_status,
+    }
+}
+
 // ── Public API ────────────────────────────────────────────────────────────
 
 /// The install directory (directory containing the running exe).
@@ -97,6 +252,24 @@ pub fn propose_add(user: bool) -> Result<Option<String>, EnvarlyError> {
     let key = open_path_key(user, false)?;
     let current = read_path_str(&key);
     Ok(compute_add(&current, &dir))
+}
+
+/// Checks whether `raw_input` (a command name or full exe path) would resolve
+/// via the effective PATH (User + System merged, System first), and whether
+/// it's shadowed by another same-named file earlier in the search order.
+#[cfg(windows)]
+pub fn check_command(raw_input: &str) -> Result<CheckCommandResult, EnvarlyError> {
+    let user_raw = read_path_str(&open_path_key(true, false)?);
+    let system_raw = read_path_str(&open_path_key(false, false)?);
+    let pathext_raw = std::env::var("PATHEXT").unwrap_or_default();
+    Ok(check_command_with(
+        raw_input,
+        &user_raw,
+        &system_raw,
+        &pathext_raw,
+        crate::commands::path::expand_env_vars,
+        crate::commands::path::dir_exists,
+    ))
 }
 
 /// Remove the install dir from User PATH and/or System PATH (if elevated).
@@ -193,5 +366,202 @@ mod tests {
     #[test]
     fn remove_is_case_insensitive() {
         assert_eq!(compute_remove(r"C:\FOO", r"C:\foo"), Some(String::new()));
+    }
+
+    // ── check_command_with ─────────────────────────────────────────────
+
+    fn fake_exists(existing: &[&str]) -> impl Fn(&str) -> bool {
+        let existing_lc: Vec<String> = existing.iter().map(|s| s.to_lowercase()).collect();
+        move |candidate: &str| existing_lc.contains(&candidate.to_lowercase())
+    }
+
+    fn no_expand(s: &str) -> String {
+        s.to_string()
+    }
+
+    const PATHEXT: &str = ".COM;.EXE;.BAT;.CMD";
+
+    #[test]
+    fn check_finds_bare_name_via_pathext() {
+        let exists = fake_exists(&[r"C:\Tools\node.exe"]);
+        let result = check_command_with("node", "", r"C:\Tools", PATHEXT, no_expand, exists);
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].directory, r"C:\Tools");
+        assert_eq!(result.hits[0].matched_file, "node.EXE");
+        assert_eq!(result.hits[0].source, "System");
+        assert!(result.full_path_status.is_none());
+    }
+
+    #[test]
+    fn check_collects_all_hits_system_first() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe", r"C:\User\node.exe"]);
+        let result = check_command_with("node", r"C:\User", r"C:\Sys", PATHEXT, no_expand, exists);
+        assert_eq!(result.hits.len(), 2);
+        assert_eq!(result.hits[0].directory, r"C:\Sys");
+        assert_eq!(result.hits[0].source, "System");
+        assert_eq!(result.hits[1].directory, r"C:\User");
+        assert_eq!(result.hits[1].source, "User");
+    }
+
+    #[test]
+    fn check_with_extension_skips_pathext_and_requires_exact_match() {
+        // Dir has foo.bat but not foo.exe — input "foo.exe" should not match it.
+        let exists = fake_exists(&[r"C:\Tools\foo.bat"]);
+        let result = check_command_with("foo.exe", "", r"C:\Tools", PATHEXT, no_expand, exists);
+        assert!(result.hits.is_empty());
+        assert!(result.had_extension);
+    }
+
+    #[test]
+    fn check_with_extension_matches_exact_file() {
+        let exists = fake_exists(&[r"C:\Tools\foo.exe"]);
+        let result = check_command_with("foo.exe", "", r"C:\Tools", PATHEXT, no_expand, exists);
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].matched_file, "foo.exe");
+    }
+
+    #[test]
+    fn check_unquotes_full_path_and_splits_on_backslash() {
+        let exists = fake_exists(&[r"C:\Tools\node.exe"]);
+        let result = check_command_with(
+            "\"C:\\Tools\\node.exe\"",
+            "",
+            r"C:\Tools",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert_eq!(result.input, r"C:\Tools\node.exe");
+        assert_eq!(result.queried_name, "node.exe");
+        assert!(matches!(
+            result.full_path_status,
+            Some(FullPathStatus::Active)
+        ));
+    }
+
+    #[test]
+    fn check_splits_full_path_on_forward_slash() {
+        let exists = fake_exists(&["C:/Tools/node.exe"]);
+        let result = check_command_with(
+            "C:/Tools/node.exe",
+            "",
+            "C:/Tools",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert_eq!(result.queried_name, "node.exe");
+        assert!(result.full_path_status.is_some());
+    }
+
+    #[test]
+    fn check_full_path_matching_first_hit_is_active() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe", r"C:\User\node.exe"]);
+        let result = check_command_with(
+            r"C:\Sys\node.exe",
+            r"C:\User",
+            r"C:\Sys",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert!(matches!(
+            result.full_path_status,
+            Some(FullPathStatus::Active)
+        ));
+    }
+
+    #[test]
+    fn check_full_path_matching_later_hit_is_shadowed() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe", r"C:\User\node.exe"]);
+        let result = check_command_with(
+            r"C:\User\node.exe",
+            r"C:\User",
+            r"C:\Sys",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        match result.full_path_status {
+            Some(FullPathStatus::Shadowed { shadowed_by }) => {
+                assert_eq!(shadowed_by.directory, r"C:\Sys");
+            }
+            other => panic!("expected Shadowed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_full_path_not_on_effective_path() {
+        // A different node.exe exists elsewhere on PATH, but not at the given path.
+        let exists = fake_exists(&[r"C:\Sys\node.exe"]);
+        let result = check_command_with(
+            r"C:\Elsewhere\node.exe",
+            "",
+            r"C:\Sys",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert_eq!(result.hits.len(), 1);
+        assert!(matches!(
+            result.full_path_status,
+            Some(FullPathStatus::NotOnEffectivePath)
+        ));
+    }
+
+    #[test]
+    fn check_empty_input_yields_no_hits_and_no_panic() {
+        let exists = fake_exists(&[]);
+        let result = check_command_with("", "", r"C:\Sys", PATHEXT, no_expand, exists);
+        assert!(result.hits.is_empty());
+        assert!(result.full_path_status.is_none());
+    }
+
+    #[test]
+    fn check_filters_empty_path_segments() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe"]);
+        let result = check_command_with("node", "", ";C:\\Sys;;", PATHEXT, no_expand, exists);
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].directory, r"C:\Sys");
+    }
+
+    #[test]
+    fn check_falls_back_to_default_pathext_when_missing() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe"]);
+        let result = check_command_with("node", "", r"C:\Sys", "", no_expand, exists);
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].matched_file, "node.EXE");
+    }
+
+    #[test]
+    fn check_nonexistent_dir_contributes_no_hits() {
+        let exists = fake_exists(&[r"C:\Real\node.exe"]);
+        let result = check_command_with(
+            "node",
+            "",
+            r"C:\DoesNotExist;C:\Real",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].directory, r"C:\Real");
+    }
+
+    #[test]
+    fn check_full_path_comparison_ignores_case_and_trailing_backslash() {
+        let exists = fake_exists(&[r"C:\Sys\node.exe"]);
+        let result = check_command_with(
+            r"c:\SYS\NODE.EXE",
+            "",
+            r"C:\Sys\",
+            PATHEXT,
+            no_expand,
+            exists,
+        );
+        assert!(matches!(
+            result.full_path_status,
+            Some(FullPathStatus::Active)
+        ));
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import type { DiagnosticAction, EnvironmentDiagnostic } from "./lib/environmentD
 import { stagedToDiff } from "./lib/stagedToDiff";
 import type { EnvVar } from "./types";
 
-type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | null;
+type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | "checkcommand" | null;
 
 export default function App() {
   const { t } = useI18n();
@@ -167,6 +167,7 @@ export default function App() {
           onDiscard={handleClearStaged}
           onShowChanges={() => setDialog("changes")}
           onImportExport={() => setDialog("importexport")}
+          onCheckCommand={() => setDialog("checkcommand")}
           onToggleSnapshots={() => setSnapshotsOpen((o) => !o)}
           onToggleTheme={toggleTheme}
           onLicenses={() => setDialog("licenses")}

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { createDemoApi, loadDemoFixture } from "./demo/createDemoApi";
 import type {
   ApplyProgressEvent,
+  CheckCommandResult,
   EnvChange,
   EnvSnapshot,
   EnvValueKind,
@@ -50,6 +51,7 @@ export interface EnvarlyApi {
     systemHasEntry: boolean;
   }>;
   getPathProposal: (scope: "User" | "System") => Promise<string | null>;
+  checkCommand: (input: string) => Promise<CheckCommandResult>;
   checkForUpdate: () => Promise<UpdateInfo | null>;
   /**
    * Subscribe to per-variable progress while `applyEnvChanges` runs. Resolves
@@ -84,6 +86,7 @@ const normalApi: EnvarlyApi = {
       "get_path_status",
     ),
   getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
+  checkCommand: (input) => invoke<CheckCommandResult>("check_command", { input }),
   checkForUpdate: () => invoke<UpdateInfo | null>("check_for_update"),
   onApplyProgress: async (callback) =>
     listen<ApplyProgressEvent>("apply-progress", (event) => callback(event.payload)),
@@ -148,6 +151,7 @@ export const api: EnvarlyApi = {
   parseImport: async (content, format) => (await getApi()).parseImport(content, format),
   getPathStatus: async () => (await getApi()).getPathStatus(),
   getPathProposal: async (scope) => (await getApi()).getPathProposal(scope),
+  checkCommand: async (input) => (await getApi()).checkCommand(input),
   checkForUpdate: async () => (await getApi()).checkForUpdate(),
   onApplyProgress: async (callback) => (await getApi()).onApplyProgress(callback),
 };

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -18,6 +18,7 @@ interface AppHeaderProps {
   onDiscard: () => void;
   onShowChanges: () => void;
   onImportExport: () => void;
+  onCheckCommand: () => void;
   onToggleSnapshots: () => void;
   onToggleTheme: () => void;
   onLicenses: () => void;
@@ -36,6 +37,7 @@ export function AppHeader({
   onDiscard,
   onShowChanges,
   onImportExport,
+  onCheckCommand,
   onToggleSnapshots,
   onToggleTheme,
   onLicenses,
@@ -87,6 +89,10 @@ export function AppHeader({
           onClick={onToggleSnapshots}
         >
           {t("header.snapshots")}
+        </Button>
+
+        <Button variant="ghost" size="sm" onClick={onCheckCommand}>
+          {t("header.check_command")}
         </Button>
       </div>
 

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -8,6 +8,7 @@ import type {
   EnvVar,
   VarScope,
 } from "../../types";
+import { CheckCommandPanel } from "../CheckCommandPanel/CheckCommandPanel";
 import { DiffPanel } from "../DiffPanel/DiffPanel";
 import { ImportExportPanel } from "../ImportExportPanel/ImportExportPanel";
 import { LicensesPanel } from "../LicensesPanel/LicensesPanel";
@@ -15,7 +16,7 @@ import { NewVarModal } from "../NewVarModal/NewVarModal";
 import { StagedModal } from "../StagedModal/StagedModal";
 import { Modal } from "../ui/Modal";
 
-type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | null;
+type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | "checkcommand" | null;
 
 interface Props {
   dialog: Dialog;
@@ -82,6 +83,15 @@ export function AppModals({
         size="xl"
       >
         <ImportExportPanel onStage={onStageImport} />
+      </Modal>
+
+      <Modal
+        open={dialog === "checkcommand"}
+        onClose={() => setDialog(null)}
+        title={t("modal.check_command")}
+        size="lg"
+      >
+        <CheckCommandPanel />
       </Modal>
 
       <Modal

--- a/src/components/CheckCommandPanel/CheckCommandPanel.stories.tsx
+++ b/src/components/CheckCommandPanel/CheckCommandPanel.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { api } from "../../api";
+import type { CheckCommandResult } from "../../types";
+import { CheckCommandPanel } from "./CheckCommandPanel";
+
+const meta = {
+  title: "Components/CheckCommandPanel",
+  component: CheckCommandPanel,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="w-[560px] h-[420px] bg-panel flex flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CheckCommandPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Locale-agnostic: the test environment defaults to Japanese, so play functions
+// must not match on translated text — use data-testid/data-status hooks instead.
+async function typeAndCheck(canvasElement: HTMLElement, query: string) {
+  const canvas = within(canvasElement);
+  const input = await canvas.findByTestId("check-command-input");
+  await userEvent.type(input, `${query}{Enter}`);
+}
+
+export const Empty: Story = {};
+
+export const SingleHitActive: Story = {
+  decorators: [
+    (Story) => {
+      api.checkCommand = async (): Promise<CheckCommandResult> => ({
+        input: "node",
+        queriedName: "node.EXE",
+        hadExtension: false,
+        hits: [
+          { directory: "C:\\Program Files\\nodejs", matchedFile: "node.EXE", source: "System" },
+        ],
+        fullPathStatus: null,
+      });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    await typeAndCheck(canvasElement, "node");
+    const canvas = within(canvasElement);
+    await waitFor(async () =>
+      expect(await canvas.findAllByTestId("check-command-hit")).toHaveLength(1),
+    );
+    const hits = canvas.getAllByTestId("check-command-hit");
+    expect(hits[0]).toHaveAttribute("data-status", "active");
+  },
+};
+
+export const ShadowedAcrossDirs: Story = {
+  decorators: [
+    (Story) => {
+      api.checkCommand = async (): Promise<CheckCommandResult> => ({
+        input: "node",
+        queriedName: "node.EXE",
+        hadExtension: false,
+        hits: [
+          { directory: "C:\\Windows\\System32", matchedFile: "node.EXE", source: "System" },
+          { directory: "C:\\Program Files\\nodejs", matchedFile: "node.EXE", source: "User" },
+          { directory: "C:\\Users\\dev\\.local\\bin", matchedFile: "node.EXE", source: "User" },
+        ],
+        fullPathStatus: null,
+      });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    await typeAndCheck(canvasElement, "node");
+    const canvas = within(canvasElement);
+    const hits = await waitFor(async () => {
+      const els = await canvas.findAllByTestId("check-command-hit");
+      expect(els).toHaveLength(3);
+      return els;
+    });
+    expect(hits[0]).toHaveAttribute("data-status", "active");
+    expect(hits[1]).toHaveAttribute("data-status", "shadowed");
+    expect(hits[2]).toHaveAttribute("data-status", "shadowed");
+  },
+};
+
+export const NotFound: Story = {
+  decorators: [
+    (Story) => {
+      api.checkCommand = async (): Promise<CheckCommandResult> => ({
+        input: "ghosttool",
+        queriedName: "ghosttool.EXE",
+        hadExtension: false,
+        hits: [],
+        fullPathStatus: null,
+      });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    await typeAndCheck(canvasElement, "ghosttool");
+    const canvas = within(canvasElement);
+    await waitFor(async () =>
+      expect(await canvas.findByTestId("check-command-not-found")).toBeVisible(),
+    );
+  },
+};
+
+export const FullPathNotOnEffectivePath: Story = {
+  decorators: [
+    (Story) => {
+      api.checkCommand = async (): Promise<CheckCommandResult> => ({
+        input: "C:\\OldTools\\node.exe",
+        queriedName: "node.exe",
+        hadExtension: true,
+        hits: [
+          { directory: "C:\\Program Files\\nodejs", matchedFile: "node.exe", source: "System" },
+        ],
+        fullPathStatus: { status: "notOnEffectivePath" },
+      });
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    await typeAndCheck(canvasElement, "C:\\OldTools\\node.exe");
+    const canvas = within(canvasElement);
+    const callout = await waitFor(async () =>
+      canvas.findByTestId("check-command-full-path-status"),
+    );
+    expect(callout).toHaveAttribute("data-status", "notOnEffectivePath");
+  },
+};

--- a/src/components/CheckCommandPanel/CheckCommandPanel.test.tsx
+++ b/src/components/CheckCommandPanel/CheckCommandPanel.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../api";
+import type { CheckCommandResult } from "../../types";
+import { CheckCommandPanel } from "./CheckCommandPanel";
+
+vi.mock("../../api");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function activeResult(): CheckCommandResult {
+  return {
+    input: "node",
+    queriedName: "node.EXE",
+    hadExtension: false,
+    hits: [{ directory: "C:\\Tools", matchedFile: "node.EXE", source: "System" }],
+    fullPathStatus: null,
+  };
+}
+
+function shadowedResult(): CheckCommandResult {
+  return {
+    input: "node",
+    queriedName: "node.EXE",
+    hadExtension: false,
+    hits: [
+      { directory: "C:\\Sys", matchedFile: "node.EXE", source: "System" },
+      { directory: "C:\\User", matchedFile: "node.EXE", source: "User" },
+    ],
+    fullPathStatus: null,
+  };
+}
+
+function notFoundResult(): CheckCommandResult {
+  return {
+    input: "ghost",
+    queriedName: "ghost.EXE",
+    hadExtension: false,
+    hits: [],
+    fullPathStatus: null,
+  };
+}
+
+describe("CheckCommandPanel", () => {
+  it("does not call api.checkCommand while typing", async () => {
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "node");
+    expect(api.checkCommand).not.toHaveBeenCalled();
+  });
+
+  it("calls api.checkCommand with the trimmed input on button click", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue(activeResult());
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "  node  ");
+    await user.click(screen.getByRole("button", { name: "Check" }));
+    expect(api.checkCommand).toHaveBeenCalledWith("node");
+  });
+
+  it("calls api.checkCommand on Enter", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue(activeResult());
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "node{Enter}");
+    expect(api.checkCommand).toHaveBeenCalledWith("node");
+  });
+
+  it("renders the active hit and no shadowed row for a single hit", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue(activeResult());
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "node{Enter}");
+    await waitFor(() => expect(screen.getByText("Active — runs")).toBeInTheDocument());
+    expect(screen.queryByText("Shadowed")).not.toBeInTheDocument();
+  });
+
+  it("renders one active row and one shadowed row when there are two hits", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue(shadowedResult());
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "node{Enter}");
+    await waitFor(() => expect(screen.getByText("Active — runs")).toBeInTheDocument());
+    expect(screen.getByText("Shadowed")).toBeInTheDocument();
+  });
+
+  it("renders a not-found message distinct from the shadowed/active states", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue(notFoundResult());
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "ghost{Enter}");
+    await waitFor(() =>
+      expect(screen.getByText("Not found anywhere on PATH.")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Active — runs")).not.toBeInTheDocument();
+  });
+
+  it("renders the full-path active message", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue({
+      ...activeResult(),
+      fullPathStatus: { status: "active" },
+    });
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "C:\\Tools\\node.exe{Enter}");
+    await waitFor(() =>
+      expect(screen.getByText("This exact file is the one that runs.")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders the full-path shadowed message with the shadowing location", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue({
+      ...shadowedResult(),
+      fullPathStatus: {
+        status: "shadowed",
+        shadowedBy: { directory: "C:\\Sys", matchedFile: "node.EXE", source: "System" },
+      },
+    });
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "C:\\User\\node.exe{Enter}");
+    await waitFor(() =>
+      expect(
+        screen.getByText("This file exists but is shadowed by C:\\Sys\\node.EXE."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders a distinct message for a full path not on the effective PATH", async () => {
+    vi.mocked(api.checkCommand).mockResolvedValue({
+      ...activeResult(),
+      fullPathStatus: { status: "notOnEffectivePath" },
+    });
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "C:\\Elsewhere\\node.exe{Enter}");
+    await waitFor(() =>
+      expect(screen.getByText(/isn't on the effective PATH/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("This exact file is the one that runs.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^This file exists but is shadowed/)).not.toBeInTheDocument();
+  });
+
+  it("surfaces an error when the check rejects", async () => {
+    vi.mocked(api.checkCommand).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    render(<CheckCommandPanel />);
+    await user.type(screen.getByPlaceholderText(/e.g. node/i), "node{Enter}");
+    await waitFor(() => expect(screen.getByText(/boom/)).toBeInTheDocument());
+  });
+});

--- a/src/components/CheckCommandPanel/CheckCommandPanel.tsx
+++ b/src/components/CheckCommandPanel/CheckCommandPanel.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { api } from "../../api";
+import { useI18n } from "../../hooks/useI18n";
+import type { CheckCommandResult, CommandHit } from "../../types";
+import { Badge } from "../ui/Badge";
+import { Button } from "../ui/Button";
+import { Icon } from "../ui/Icon";
+import { TextInput } from "../ui/TextInput";
+
+export function CheckCommandPanel() {
+  const { t } = useI18n();
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CheckCommandResult | null>(null);
+
+  const runCheck = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setResult(await api.checkCommand(trimmed));
+    } catch (e) {
+      setError(String(e));
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="px-5 py-3 border-b border-rim shrink-0 flex items-center gap-2">
+        <TextInput
+          label={t("check_command.input_label")}
+          labelHidden
+          placeholder={t("check_command.placeholder")}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") runCheck();
+          }}
+          data-testid="check-command-input"
+          className="flex-1"
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={runCheck}
+          disabled={loading || !input.trim()}
+          data-testid="check-command-submit"
+          className="shrink-0 whitespace-nowrap border border-transparent"
+        >
+          {loading ? t("check_command.checking") : t("check_command.check")}
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
+        {error && <p className="text-sm text-danger">{error}</p>}
+        {!error && !result && <p className="text-sm text-dim">{t("check_command.empty_state")}</p>}
+        {!error && result && <CheckCommandResultView result={result} />}
+      </div>
+    </div>
+  );
+}
+
+function CheckCommandResultView({ result }: { result: CheckCommandResult }) {
+  const { t } = useI18n();
+
+  if (result.hits.length === 0) {
+    return (
+      <div
+        data-testid="check-command-not-found"
+        className="flex items-center gap-2 text-sm text-danger"
+      >
+        <Icon name="x" size={16} />
+        <span>{t("check_command.not_found")}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ul className="flex flex-col gap-2">
+        {result.hits.map((hit, index) => (
+          <HitRow key={`${hit.source}:${hit.directory}`} hit={hit} isActive={index === 0} />
+        ))}
+      </ul>
+
+      {result.fullPathStatus && (
+        <div
+          data-testid="check-command-full-path-status"
+          data-status={result.fullPathStatus.status}
+          className={
+            "text-xs px-3 py-2 rounded border " +
+            (result.fullPathStatus.status === "active"
+              ? "border-success/40 bg-success/10 text-success"
+              : result.fullPathStatus.status === "shadowed"
+                ? "border-warn/40 bg-warn/10 text-warn"
+                : "border-rim bg-hover text-muted")
+          }
+        >
+          {result.fullPathStatus.status === "active" && t("check_command.full_path_active")}
+          {result.fullPathStatus.status === "shadowed" &&
+            t("check_command.full_path_shadowed", {
+              directory: result.fullPathStatus.shadowedBy.directory,
+              file: result.fullPathStatus.shadowedBy.matchedFile,
+            })}
+          {result.fullPathStatus.status === "notOnEffectivePath" &&
+            t("check_command.full_path_not_on_path", {
+              directory: result.hits[0].directory,
+              file: result.hits[0].matchedFile,
+              name: result.queriedName,
+            })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HitRow({ hit, isActive }: { hit: CommandHit; isActive: boolean }) {
+  const { t } = useI18n();
+  return (
+    <li
+      data-testid="check-command-hit"
+      data-status={isActive ? "active" : "shadowed"}
+      className="flex items-center gap-2 px-3 py-2 rounded border border-rim bg-panel text-sm"
+    >
+      <Icon
+        name={isActive ? "check" : "warning"}
+        size={16}
+        className={isActive ? "text-success shrink-0" : "text-warn shrink-0"}
+      />
+      <span className="font-mono text-xs text-fg break-all">
+        {hit.directory}\{hit.matchedFile}
+      </span>
+      <span className="ml-auto flex items-center gap-2 shrink-0">
+        <span className={isActive ? "text-xs text-success" : "text-xs text-warn"}>
+          {isActive ? t("check_command.active") : t("check_command.shadowed")}
+        </span>
+        <Badge variant={hit.source === "User" ? "user" : "system"}>{hit.source}</Badge>
+      </span>
+    </li>
+  );
+}

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -1,7 +1,14 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { EnvarlyApi, LaunchOptions } from "../api";
 import { inferEnvValueKind } from "../lib/envValueKind";
-import type { EnvSnapshot, EnvVar, SnapshotMeta, SnapshotValue, VarScope } from "../types";
+import type {
+  EnvSnapshot,
+  EnvVar,
+  FullPathStatus,
+  SnapshotMeta,
+  SnapshotValue,
+  VarScope,
+} from "../types";
 import bundledFixture from "./envarly-demo.json";
 
 interface DemoFixture {
@@ -190,6 +197,55 @@ export function createDemoApi(
         return null;
       }
       return [fixture.installDir, ...entries].join(";");
+    },
+    checkCommand: async (input) => {
+      const unquoted = input.trim().replace(/^"(.*)"$/, "$1");
+      const lastSep = Math.max(unquoted.lastIndexOf("\\"), unquoted.lastIndexOf("/"));
+      const basename = lastSep >= 0 ? unquoted.slice(lastSep + 1) : unquoted;
+      const fullDir = lastSep >= 0 ? unquoted.slice(0, lastSep) : null;
+      const hadExtension = basename.includes(".");
+      const nameOnly = (hadExtension ? basename.replace(/\.[^.]+$/, "") : basename).toLowerCase();
+
+      const dirsWithSource: Array<{ dir: string; source: "User" | "System" }> = [
+        ...(current.system.Path?.value.split(";").filter(Boolean) ?? []).map((dir) => ({
+          dir,
+          source: "System" as const,
+        })),
+        ...(current.user.Path?.value.split(";").filter(Boolean) ?? []).map((dir) => ({
+          dir,
+          source: "User" as const,
+        })),
+      ];
+
+      // Demo heuristic (no real filesystem access): a directory "contains" the
+      // command if its name hints at the tool, e.g. a "nodejs" dir matches "node".
+      const hits = dirsWithSource
+        .filter(({ dir }) => nameOnly && dir.toLowerCase().includes(nameOnly))
+        .map(({ dir, source }) => ({
+          directory: dir,
+          matchedFile: hadExtension ? basename : `${basename}.EXE`,
+          source,
+        }));
+
+      let fullPathStatus: FullPathStatus | null = null;
+      if (fullDir) {
+        const normalize = (d: string) => d.replace(/[\\/]+$/, "").toLowerCase();
+        const idx = hits.findIndex((h) => normalize(h.directory) === normalize(fullDir));
+        fullPathStatus =
+          idx === 0
+            ? { status: "active" }
+            : idx > 0
+              ? { status: "shadowed", shadowedBy: hits[0] }
+              : { status: "notOnEffectivePath" };
+      }
+
+      return {
+        input: unquoted,
+        queriedName: hadExtension ? basename : `${basename}.EXE`,
+        hadExtension,
+        hits,
+        fullPathStatus,
+      };
     },
     checkForUpdate: async () => null,
     onApplyProgress: async () => () => {},

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,6 +36,7 @@
     "external_changes_other": "{{count}} external changes",
     "import_export": "Import / Export",
     "snapshots": "Snapshots",
+    "check_command": "Check command",
     "run_as_admin": "Run as admin",
     "run_as_admin_title": "System variables are read-only. Restart as administrator to edit them.",
     "administrator": "Administrator",
@@ -141,7 +142,8 @@
     "apply_staged_other": "Apply {{count}} staged changes",
     "external_changes": "External changes detected ({{count}})",
     "new_var": "New variable",
-    "licenses": "Open Source Licenses"
+    "licenses": "Open Source Licenses",
+    "check_command": "Check Command"
   },
   "diff": {
     "title": "External changes detected",
@@ -246,6 +248,19 @@
     "heading": "Comparing snapshots",
     "no_diff": "These two snapshots are identical — no differences found.",
     "to_label": "→ {{label}}"
+  },
+  "check_command": {
+    "input_label": "Command or path",
+    "placeholder": "e.g. node, node.exe, or a full path",
+    "check": "Check",
+    "checking": "Checking…",
+    "empty_state": "Enter a command name or path and press Check.",
+    "not_found": "Not found anywhere on PATH.",
+    "active": "Active — runs",
+    "shadowed": "Shadowed",
+    "full_path_active": "This exact file is the one that runs.",
+    "full_path_shadowed": "This file exists but is shadowed by {{directory}}\\{{file}}.",
+    "full_path_not_on_path": "This file's directory isn't on the effective PATH — {{directory}}\\{{file}} runs instead when you type \"{{name}}\"."
   },
   "env_desc": {
     "categories": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -36,6 +36,7 @@
     "external_changes_other": "{{count}} 件の外部変更",
     "import_export": "インポート / エクスポート",
     "snapshots": "スナップショット",
+    "check_command": "コマンドを調べる",
     "run_as_admin": "管理者として実行",
     "run_as_admin_title": "システム変数は読み取り専用です。編集するには管理者として再起動してください。",
     "administrator": "管理者モード",
@@ -141,7 +142,8 @@
     "apply_staged_other": "{{count}} 件の変更を適用",
     "external_changes": "外部変更を検出 ({{count}} 件)",
     "new_var": "新しい変数",
-    "licenses": "オープンソースライセンス"
+    "licenses": "オープンソースライセンス",
+    "check_command": "コマンドを調べる"
   },
   "diff": {
     "title": "外部変更を検出",
@@ -246,6 +248,19 @@
     "heading": "スナップショットを比較",
     "no_diff": "この2つのスナップショットは同一です — 差分はありません。",
     "to_label": "→ {{label}}"
+  },
+  "check_command": {
+    "input_label": "コマンドまたはパス",
+    "placeholder": "例: node, node.exe, またはフルパス",
+    "check": "チェック",
+    "checking": "確認中…",
+    "empty_state": "コマンド名またはパスを入力してチェックを押してください。",
+    "not_found": "PATH のどこにも見つかりません。",
+    "active": "有効 — 実行される",
+    "shadowed": "シャドーイングされてます",
+    "full_path_active": "このファイルが実際に実行されるものです。",
+    "full_path_shadowed": "このファイルは存在しますが、{{directory}}\\{{file}} にシャドーイングされてます。",
+    "full_path_not_on_path": "このファイルのディレクトリは実効PATHに含まれてません — \"{{name}}\" と入力すると代わりに {{directory}}\\{{file}} が実行されます。"
   },
   "env_desc": {
     "categories": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,22 @@ export type EnvChange =
       name: string;
       scope: VarScope;
     };
+
+export interface CommandHit {
+  directory: string;
+  matchedFile: string;
+  source: "User" | "System";
+}
+
+export type FullPathStatus =
+  | { status: "active" }
+  | { status: "shadowed"; shadowedBy: CommandHit }
+  | { status: "notOnEffectivePath" };
+
+export interface CheckCommandResult {
+  input: string;
+  queriedName: string;
+  hadExtension: boolean;
+  hits: CommandHit[];
+  fullPathStatus: FullPathStatus | null;
+}


### PR DESCRIPTION
## Summary
- New header-level tool ("Check command", alongside Import/Export and Snapshots) that answers "why doesn't `foo` run from the command line" — enter a command name (`node`) or a full exe path (including quoted paths pasted via Explorer's "Copy as path"), and it scans the effective PATH (User + System merged, System first — matching real Windows precedence) for every directory containing a match.
- Detects **shadowing**: if a same-named file exists in more than one PATH directory, only the first one actually runs — the rest are flagged as shadowed.
- When a full path is given, cross-references it against the results: is *this exact file* the one that runs, is it shadowed by an earlier duplicate, or does its directory not appear on the effective PATH at all (a third, distinct state from plain "not found").
- PATHEXT-aware: a bare name like `node` tries `.COM;.EXE;.BAT;.CMD;...` in order per directory; a name with an extension is matched exactly.

## Implementation notes
- `check_command_with` in `path_manage.rs` is a pure, dependency-injected matching engine (file-existence check and env-var expansion are passed in), so the whole algorithm — including all the edge cases (empty input, stray `;;` in PATH, case/trailing-slash normalization, PATHEXT missing) — is unit tested without touching the registry or filesystem.
- Caught and fixed a real serde gotcha along the way: `#[serde(rename_all = "camelCase")]` on an enum doesn't automatically camelCase a struct-variant's field names — had to add an explicit `#[serde(rename = "shadowedBy")]`. Verified the exact JSON shape empirically before wiring up the frontend types.
- Storybook stories use `data-testid`/`data-status` hooks rather than matching translated text, since this project's Storybook test environment defaults to Japanese.
- Manually verified against the real PATH on the dev machine (not just Storybook/unit tests) — it correctly found `cmd`, correctly reported a nonexistent name as not found, and correctly cross-referenced a full path. It also surfaced a genuine (harmless) duplicate `system32` PATH entry that only differs by case.

## Test plan
- [x] `cargo test` — 86 Rust tests pass, including ~15 new table-driven cases for `check_command_with`
- [x] `npm test` — 279 unit tests pass, including 10 new tests for `CheckCommandPanel`
- [x] `npm run test:storybook` — 102 interaction tests pass, including 4 new stories (single hit, shadowed across dirs, not found, full-path-not-on-effective-path)
- [x] `cargo clippy` / `cargo fmt --check` clean
- [x] Manual smoke test in the built app (see above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>