### PR TITLE
chore: release v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 - **Admin elevation** — "Run as admin" button restarts the process elevated via UAC; system variables become editable; "Restart as admin →" inline hint appears in the detail panel when viewing a System variable without elevation
 - **CLI mode** — read-only subcommands (`get`, `list`, `export`) run from a terminal without launching the GUI
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
+- **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts
+- **Check command** — find out why a command isn't found: searches the effective PATH (User + System merged, PATHEXT-aware) for a name or exe path and flags shadowed duplicates
 
 ## Stack
 

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -2,7 +2,7 @@ export const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
-export const VERSION = '1.3.0';
+export const VERSION = '1.4.0';
 
 export type LandingCopy = {
   lang: 'en' | 'ja';
@@ -130,6 +130,16 @@ export const enCopy: LandingCopy = {
       title: 'Import / Export',
       desc: 'Read and write .json and .reg formats, plus export to PowerShell, DSC, and Ansible-friendly files. Preview before any write.',
     },
+    {
+      icon: '↔',
+      title: 'Resizable panels',
+      desc: 'Drag the sidebar and snapshots panel to the width you want. Sizes are remembered across restarts.',
+    },
+    {
+      icon: '🔎',
+      title: 'Check command',
+      desc: "Find out why a command isn't found — searches the effective PATH for a name or exe path and flags shadowed duplicates.",
+    },
   ],
   audience: {
     heading: 'Who is it for?',
@@ -224,6 +234,16 @@ export const jaCopy: LandingCopy = {
       icon: '⇅',
       title: 'インポート / エクスポート',
       desc: '.json と .reg 形式の読み書きに加えて、PowerShell、DSC、Ansible 向けの形式へエクスポートできます。書き込み前にプレビューできます。',
+    },
+    {
+      icon: '↔',
+      title: 'パネルの幅を変更',
+      desc: 'サイドバーとスナップショットパネルの幅をドラッグで調整できます。次回起動時も幅を記憶します。',
+    },
+    {
+      icon: '🔎',
+      title: 'コマンドを調べる',
+      desc: 'コマンドが見つからない理由を調査。実効PATHをコマンド名やexeパスで検索し、シャドーイングされた重複も検出します。',
     },
   ],
   audience: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envarly",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envarly",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/tauri.mjs dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.3.0"
+version = "1.4.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
## Summary
Version bump 1.3.0 → 1.4.0 (minor, per two new user-facing features since the last release).

Since v1.3.0:
- **feat:** resizable sidebar/snapshot panels (#137)
- **feat:** "Check command" PATH diagnostic tool (#138)
- chore: Scoop manifest prep, dependency updates, regression tests, gitignore cleanup

## Changes
- `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `lpContent.ts` version → 1.4.0 (via `npm version minor` / `sync-version.mjs`, verified with `npm run check-version`)
- Added feature bullets for the two new features to `README.md` and the landing page copy (en/ja)

## Next steps after merge
- Tag `v1.4.0` and push to trigger the release workflow
- Verify the release build artifacts
- Write release notes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>