### PR TITLE
feat: compact the header's staged-changes indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,7 +164,6 @@ export default function App() {
           theme={theme}
           onRefresh={handleRefresh}
           onApplyStaged={() => setDialog("staged")}
-          onDiscard={handleClearStaged}
           onShowChanges={() => setDialog("changes")}
           onImportExport={() => setDialog("importexport")}
           onCheckCommand={() => setDialog("checkcommand")}
@@ -237,6 +236,7 @@ export default function App() {
           stagedProgress={stagedProgress}
           stagedLog={stagedLog}
           onApplyStaged={handleApplyStaged}
+          onDiscardAll={handleClearStaged}
           diffEntries={diffEntries}
           applyBusy={applyBusy}
           applyError={applyError}

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -15,7 +15,6 @@ interface AppHeaderProps {
   theme: "dark" | "light";
   onRefresh: () => void;
   onApplyStaged: () => void;
-  onDiscard: () => void;
   onShowChanges: () => void;
   onImportExport: () => void;
   onCheckCommand: () => void;
@@ -34,7 +33,6 @@ export function AppHeader({
   theme,
   onRefresh,
   onApplyStaged,
-  onDiscard,
   onShowChanges,
   onImportExport,
   onCheckCommand,
@@ -63,14 +61,15 @@ export function AppHeader({
         </Button>
 
         {stagedCount > 0 && (
-          <>
-            <Button variant="primary" size="sm" onClick={onApplyStaged}>
-              {t("header.apply_staged", { count: stagedCount })}
-            </Button>
-            <Button variant="ghost" size="sm" onClick={onDiscard}>
-              {t("header.discard_all")}
-            </Button>
-          </>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onApplyStaged}
+            className="shrink-0"
+            title={t("header.apply_staged", { count: stagedCount })}
+          >
+            {t("header.staged_count", { count: stagedCount })}
+          </Button>
         )}
 
         {diffCount > 0 && (

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -28,6 +28,7 @@ interface Props {
   stagedProgress: { index: number; total: number } | null;
   stagedLog: ApplyProgressEvent[];
   onApplyStaged: (takeSnapshot: boolean) => Promise<void>;
+  onDiscardAll: () => void;
   diffEntries: DiffEntry[];
   applyBusy: boolean;
   applyError: string | null;
@@ -62,6 +63,7 @@ export function AppModals({
   stagedProgress,
   stagedLog,
   onApplyStaged,
+  onDiscardAll,
   diffEntries,
   applyBusy,
   applyError,
@@ -107,6 +109,7 @@ export function AppModals({
           progress={stagedProgress}
           log={stagedLog}
           onApply={onApplyStaged}
+          onDiscardAll={onDiscardAll}
           onClose={() => setDialog(null)}
         />
       </Modal>

--- a/src/components/StagedModal/StagedModal.tsx
+++ b/src/components/StagedModal/StagedModal.tsx
@@ -21,6 +21,7 @@ interface StagedModalProps {
   progress: { index: number; total: number } | null;
   log: ApplyProgressEvent[];
   onApply: (takeSnapshot: boolean) => void;
+  onDiscardAll: () => void;
   onClose: () => void;
 }
 
@@ -31,6 +32,7 @@ export function StagedModal({
   progress,
   log,
   onApply,
+  onDiscardAll,
   onClose,
 }: StagedModalProps) {
   const { t } = useI18n();
@@ -177,13 +179,27 @@ export function StagedModal({
             {error}
           </p>
         )}
-        <div className="flex gap-2 justify-end">
-          <Button variant="ghost" size="md" onClick={onClose} disabled={busy}>
-            {t("staged.cancel")}
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            variant="ghost"
+            size="md"
+            onClick={() => {
+              onDiscardAll();
+              onClose();
+            }}
+            disabled={busy}
+            className="text-danger"
+          >
+            {t("header.discard_all")}
           </Button>
-          <Button variant="primary" size="md" onClick={() => onApply(true)} disabled={busy}>
-            {busy ? t("staged.applying") : t("staged.apply", { count: diff.length })}
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="ghost" size="md" onClick={onClose} disabled={busy}>
+              {t("staged.cancel")}
+            </Button>
+            <Button variant="primary" size="md" onClick={() => onApply(true)} disabled={busy}>
+              {busy ? t("staged.applying") : t("staged.apply", { count: diff.length })}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,6 +31,8 @@
     "refresh": "Refresh",
     "apply_staged_one": "Apply {{count}} staged change",
     "apply_staged_other": "Apply {{count}} staged changes",
+    "staged_count_one": "{{count}} staged",
+    "staged_count_other": "{{count}} staged",
     "discard_all": "Discard all",
     "external_changes_one": "{{count}} external change",
     "external_changes_other": "{{count}} external changes",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -31,6 +31,8 @@
     "refresh": "更新",
     "apply_staged_one": "{{count}} 件の変更を適用",
     "apply_staged_other": "{{count}} 件の変更を適用",
+    "staged_count_one": "{{count}} 件ステージ済み",
+    "staged_count_other": "{{count}} 件ステージ済み",
     "discard_all": "すべて破棄",
     "external_changes_one": "{{count}} 件の外部変更",
     "external_changes_other": "{{count}} 件の外部変更",


### PR DESCRIPTION
## Summary
Step 1 of fixing header crowding when there are staged changes (see discussion). The header used to add two full-sentence buttons whenever changes were staged: "Apply N staged changes" and "Discard all" — but the "Apply" button only ever opened the staged-changes modal (the real apply/discard/cancel flow already lives there), so both got replaced with a single compact pill.

- Header: `stagedCount > 0` now renders one small "N staged" button instead of two full-text buttons
- `StagedModal`: added a "Discard all" button in the footer (left-aligned, opposite Cancel/Apply), wired to the same `handleClearStaged` the header used to call directly
- New i18n keys: `header.staged_count_one`/`staged_count_other` (en/ja)

## Verified but not fixed here
Screenshotted `AppHeader`'s `WithStagedChanges` story at 1200/900/700px via Playwright. The new compact pill holds up fine at every width. But the *rest* of the header (Import/Export, Snapshots, Check command, Run as admin) still wraps badly at ~900px and narrower — individual buttons collapse into vertical single-character text columns. That's a separate, larger fix (likely an overflow "…" menu for lower-priority items) tracked as a follow-up, not addressed in this PR.

## Test plan
- [x] `npm test` — 279 tests pass
- [x] `npm run test:storybook` — 102 tests pass
- [x] `npm run tauri build` succeeds
- [x] Manually screenshotted the `WithStagedChanges` Storybook story at 3 widths to confirm the new pill doesn't break

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>