### PR TITLE
feat: edit environment variables for other user accounts (#62)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,4 +39,8 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security_Cryptography",
   "Win32_System_Console",
   "Win32_Storage_FileSystem",
+  "Win32_System_Registry",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_NetworkManagement_NetManagement",
 ] }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -134,6 +134,7 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
                         let tag = match v.scope {
                             VarScope::User => "user",
                             VarScope::System => "sys ",
+                            VarScope::OtherUser => "other",
                         };
                         println!("[{}] {}={}", tag, v.name, v.value);
                     }

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -75,6 +75,7 @@ pub async fn export_custom(
     let mut snapshot = EnvSnapshot {
         user: HashMap::new(),
         system: HashMap::new(),
+        other_user: None,
     };
     for v in &vars {
         match v.scope.as_str() {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod launch;
 pub mod path;
 pub mod snapshot;
 pub mod update;
+pub mod users;

--- a/src-tauri/src/commands/path.rs
+++ b/src-tauri/src/commands/path.rs
@@ -87,19 +87,17 @@ pub fn get_path_status() -> path_manage::PathStatus {
 
 /// Returns the proposed new PATH value (with envarly added) for the given scope,
 /// or None if the install directory is already present.
-/// scope: "User" | "System"
+/// scope: "User" | "System" | "OtherUser"
 #[tauri::command]
 pub fn get_path_proposal(scope: String) -> Result<Option<String>, EnvarlyError> {
-    let user = match scope.as_str() {
-        "User" => true,
-        "System" => false,
-        other => {
-            return Err(EnvarlyError::InvalidInput(format!(
-                "invalid scope: {other:?}"
-            )))
-        }
-    };
-    path_manage::propose_add(user)
+    match scope.as_str() {
+        "User" => path_manage::propose_add(true),
+        "System" => path_manage::propose_add(false),
+        "OtherUser" => path_manage::propose_add_for_other_user(),
+        other => Err(EnvarlyError::InvalidInput(format!(
+            "invalid scope: {other:?}"
+        ))),
+    }
 }
 
 /// Checks whether `input` (a command name or full exe path) resolves via the

--- a/src-tauri/src/commands/users.rs
+++ b/src-tauri/src/commands/users.rs
@@ -1,0 +1,20 @@
+use crate::error::EnvarlyError;
+use crate::user_hive::{self, LocalAccount};
+
+#[tauri::command]
+pub fn list_local_accounts() -> Result<Vec<LocalAccount>, EnvarlyError> {
+    user_hive::list_local_accounts()
+}
+
+/// Switch the active other-user account. `None` deselects (unloading any
+/// hive Envarly itself loaded). The frontend should re-fetch vars/snapshot
+/// after this resolves — it doesn't change any other command's signature.
+#[tauri::command]
+pub fn select_account(sid: Option<String>) -> Result<Option<LocalAccount>, EnvarlyError> {
+    user_hive::select_account(sid.as_deref())
+}
+
+#[tauri::command]
+pub fn get_selected_account() -> Option<LocalAccount> {
+    user_hive::selected_account()
+}

--- a/src-tauri/src/env_backend.rs
+++ b/src-tauri/src/env_backend.rs
@@ -61,6 +61,18 @@ impl EnvBackend for WinregBackend {
     fn broadcast_changes(&self) {
         broadcast_settings_change();
     }
+
+    fn read_other_user(&self) -> Result<Option<HashMap<String, EnvValue>>, EnvarlyError> {
+        crate::user_hive::read_other_user_vars()
+    }
+
+    fn write_other_user(&self, name: &str, value: &EnvValue) -> Result<(), EnvarlyError> {
+        crate::user_hive::write_other_user_var(name, value)
+    }
+
+    fn delete_other_user(&self, name: &str) -> Result<(), EnvarlyError> {
+        crate::user_hive::delete_other_user_var(name)
+    }
 }
 
 pub fn read_unsupported_values() -> Result<Vec<UnsupportedEnvValue>, EnvarlyError> {
@@ -73,6 +85,7 @@ pub fn read_unsupported_values() -> Result<Vec<UnsupportedEnvValue>, EnvarlyErro
         let scope_order = |scope: &VarScope| match scope {
             VarScope::User => 0,
             VarScope::System => 1,
+            VarScope::OtherUser => 2,
         };
         scope_order(&a.scope)
             .cmp(&scope_order(&b.scope))
@@ -81,7 +94,7 @@ pub fn read_unsupported_values() -> Result<Vec<UnsupportedEnvValue>, EnvarlyErro
     Ok(values)
 }
 
-fn iter_string_values(key: &RegKey) -> impl Iterator<Item = (String, EnvValue)> + '_ {
+pub(crate) fn iter_string_values(key: &RegKey) -> impl Iterator<Item = (String, EnvValue)> + '_ {
     key.enum_values().filter_map(|v| {
         let (name, val) = v.ok()?;
         let kind = match val.vtype {
@@ -110,7 +123,7 @@ fn unsupported_values(
     })
 }
 
-fn to_reg_value(value: &EnvValue) -> Result<RegValue<'_>, EnvarlyError> {
+pub(crate) fn to_reg_value(value: &EnvValue) -> Result<RegValue<'_>, EnvarlyError> {
     let kind = value.kind.ok_or_else(|| {
         EnvarlyError::InvalidInput("registry type must be resolved before writing".into())
     })?;

--- a/src-tauri/src/env_store.rs
+++ b/src-tauri/src/env_store.rs
@@ -23,6 +23,27 @@ pub trait EnvBackend: Send + Sync {
     fn delete_system(&self, name: &str) -> Result<(), EnvarlyError>;
     fn is_elevated(&self) -> bool;
     fn broadcast_changes(&self) {}
+
+    /// The currently-selected other-user account's variables, if any. Returns
+    /// `Ok(None)` (not an error) when no other-user account is selected, so
+    /// existing callers (snapshot/apply/rollback) can call this unconditionally
+    /// without changing behavior for the common case.
+    fn read_other_user(&self) -> Result<Option<HashMap<String, EnvValue>>, EnvarlyError> {
+        Ok(None)
+    }
+    /// Only ever called for `VarScope::OtherUser`, which the frontend can only
+    /// send when it has an account selected — hitting the default (no active
+    /// hive) here is a genuine error, unlike `read_other_user`.
+    fn write_other_user(&self, _name: &str, _value: &EnvValue) -> Result<(), EnvarlyError> {
+        Err(EnvarlyError::InvalidInput(
+            "no other-user account selected".into(),
+        ))
+    }
+    fn delete_other_user(&self, _name: &str) -> Result<(), EnvarlyError> {
+        Err(EnvarlyError::InvalidInput(
+            "no other-user account selected".into(),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -33,6 +54,8 @@ pub trait EnvBackend: Send + Sync {
 pub struct MemBackend {
     pub user: std::sync::Mutex<HashMap<String, EnvValue>>,
     pub system: std::sync::Mutex<HashMap<String, EnvValue>>,
+    /// `None` means "no other-user account selected" (the common case).
+    pub other_user: std::sync::Mutex<Option<HashMap<String, EnvValue>>>,
     pub elevated: bool,
 }
 
@@ -42,6 +65,7 @@ impl MemBackend {
         Self {
             user: std::sync::Mutex::new(HashMap::new()),
             system: std::sync::Mutex::new(HashMap::new()),
+            other_user: std::sync::Mutex::new(None),
             elevated: true,
         }
     }
@@ -56,6 +80,25 @@ impl MemBackend {
                 )
             })
             .collect();
+        self
+    }
+
+    /// Selects an other-user account with the given starting variables (mirrors
+    /// `user_hive::select_account` making a hive active for real).
+    pub fn with_other_user(
+        self,
+        vars: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Self {
+        *self.other_user.lock().unwrap() = Some(
+            vars.into_iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_string(),
+                        EnvValue::typed(v.to_string(), EnvValueKind::String),
+                    )
+                })
+                .collect(),
+        );
         self
     }
 
@@ -119,6 +162,34 @@ impl EnvBackend for MemBackend {
         self.elevated
     }
     // broadcast_changes: uses default no-op
+
+    fn read_other_user(&self) -> Result<Option<HashMap<String, EnvValue>>, EnvarlyError> {
+        Ok(self.other_user.lock().unwrap().clone())
+    }
+
+    fn write_other_user(&self, name: &str, value: &EnvValue) -> Result<(), EnvarlyError> {
+        let mut guard = self.other_user.lock().unwrap();
+        let Some(map) = guard.as_mut() else {
+            return Err(EnvarlyError::InvalidInput(
+                "no other-user account selected".into(),
+            ));
+        };
+        map.insert(name.to_string(), value.clone());
+        Ok(())
+    }
+
+    fn delete_other_user(&self, name: &str) -> Result<(), EnvarlyError> {
+        let mut guard = self.other_user.lock().unwrap();
+        let Some(map) = guard.as_mut() else {
+            return Err(EnvarlyError::InvalidInput(
+                "no other-user account selected".into(),
+            ));
+        };
+        map.remove(name).ok_or_else(|| {
+            EnvarlyError::Registry(std::io::Error::from(std::io::ErrorKind::NotFound))
+        })?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -128,7 +199,15 @@ impl EnvBackend for MemBackend {
 pub fn read_all_with(backend: &dyn EnvBackend) -> Result<Vec<EnvVar>, EnvarlyError> {
     let mut vars: Vec<EnvVar> = Vec::new();
 
-    for (name, env_value) in backend.read_user()? {
+    // "Switch mode": when another account is active, its variables take the
+    // place of the real current user's — the two are never shown together.
+    let other_user = backend.read_other_user()?;
+    let (personal_vars, personal_scope) = match &other_user {
+        Some(vars) => (vars.clone(), VarScope::OtherUser),
+        None => (backend.read_user()?, VarScope::User),
+    };
+
+    for (name, env_value) in personal_vars {
         let value_kind = env_value.kind.ok_or_else(|| {
             EnvarlyError::InvalidInput(format!("registry value {name:?} has no type"))
         })?;
@@ -136,7 +215,7 @@ pub fn read_all_with(backend: &dyn EnvBackend) -> Result<Vec<EnvVar>, EnvarlyErr
         vars.push(EnvVar {
             name,
             value: env_value.value,
-            scope: VarScope::User,
+            scope: personal_scope.clone(),
             value_kind,
             list_separator,
         });
@@ -163,6 +242,7 @@ pub fn read_snapshot_with(backend: &dyn EnvBackend) -> Result<EnvSnapshot, Envar
     Ok(EnvSnapshot {
         user: backend.read_user()?,
         system: backend.read_system()?,
+        other_user: backend.read_other_user()?,
     })
 }
 
@@ -177,10 +257,12 @@ pub fn write_var_with(
     match scope {
         VarScope::User => backend.write_user(name, &env_value)?,
         VarScope::System => backend.write_system(name, &env_value)?,
+        VarScope::OtherUser => backend.write_other_user(name, &env_value)?,
     }
     let written = match scope {
         VarScope::User => backend.read_user()?,
         VarScope::System => backend.read_system()?,
+        VarScope::OtherUser => backend.read_other_user()?.unwrap_or_default(),
     };
     if written.get(name) != Some(&env_value) {
         return Err(EnvarlyError::InvalidInput(format!(
@@ -199,6 +281,7 @@ pub fn delete_var_with(
     match scope {
         VarScope::User => backend.delete_user(name)?,
         VarScope::System => backend.delete_system(name)?,
+        VarScope::OtherUser => backend.delete_other_user(name)?,
     }
     backend.broadcast_changes();
     Ok(())
@@ -224,12 +307,14 @@ pub fn apply_changes_with(
                 match scope {
                     VarScope::User => backend.write_user(name, &env_value),
                     VarScope::System => backend.write_system(name, &env_value),
+                    VarScope::OtherUser => backend.write_other_user(name, &env_value),
                 }
                 .and_then(|()| verify_value(backend, name, scope, Some(&env_value)))
             }
             EnvChange::Delete { name, scope } => match scope {
                 VarScope::User => backend.delete_user(name),
                 VarScope::System => backend.delete_system(name),
+                VarScope::OtherUser => backend.delete_other_user(name),
             }
             .and_then(|()| verify_value(backend, name, scope, None)),
         };
@@ -261,6 +346,7 @@ fn verify_value(
     let values = match scope {
         VarScope::User => backend.read_user()?,
         VarScope::System => backend.read_system()?,
+        VarScope::OtherUser => backend.read_other_user()?.unwrap_or_default(),
     };
     if values.get(name) == expected {
         Ok(())
@@ -286,7 +372,18 @@ fn restore_snapshot_with(
         &snapshot.system,
         |name, value| backend.write_system(name, value),
         |name| backend.delete_system(name),
-    )
+    )?;
+    if let Some(other_baseline) = &snapshot.other_user {
+        if let Some(current_other) = backend.read_other_user()? {
+            restore_scope(
+                current_other,
+                other_baseline,
+                |name, value| backend.write_other_user(name, value),
+                |name| backend.delete_other_user(name),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn restore_scope(
@@ -616,5 +713,115 @@ mod tests {
         .unwrap();
 
         assert_eq!(seen, vec![(0, 2, true), (1, 2, true)]);
+    }
+
+    // --- VarScope::OtherUser dispatch ---
+
+    #[test]
+    fn no_other_user_selected_keeps_existing_behavior() {
+        let b = backend().with_user([("MY_VAR", "hello")]);
+        let vars = read_all_with(&b).unwrap();
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].scope, VarScope::User);
+    }
+
+    #[test]
+    fn other_user_selected_replaces_user_scope_in_switch_mode() {
+        let b = MemBackend::new()
+            .with_user([("MINE", "should not appear")])
+            .with_other_user([("THEIRS", "hello")]);
+        *b.system.lock().unwrap() = [(
+            "SYS".to_string(),
+            EnvValue::typed("world".to_string(), EnvValueKind::String),
+        )]
+        .into();
+        let vars = read_all_with(&b).unwrap();
+        let scopes: Vec<(&str, &VarScope)> =
+            vars.iter().map(|v| (v.name.as_str(), &v.scope)).collect();
+        assert_eq!(
+            scopes,
+            vec![("SYS", &VarScope::System), ("THEIRS", &VarScope::OtherUser)]
+        );
+    }
+
+    #[test]
+    fn write_and_read_other_user_var() {
+        let b = MemBackend::new().with_other_user([]);
+        write_var_with(
+            &b,
+            "MY_VAR",
+            "hello",
+            EnvValueKind::String,
+            &VarScope::OtherUser,
+        )
+        .unwrap();
+        let snap = read_snapshot_with(&b).unwrap();
+        assert_eq!(
+            snap.other_user
+                .unwrap()
+                .get("MY_VAR")
+                .map(|v| v.value.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn write_other_user_var_without_selection_returns_error() {
+        let b = MemBackend::new(); // no with_other_user() call — nothing selected
+        let err = write_var_with(
+            &b,
+            "MY_VAR",
+            "hello",
+            EnvValueKind::String,
+            &VarScope::OtherUser,
+        )
+        .unwrap_err();
+        assert!(matches!(err, EnvarlyError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn delete_existing_other_user_var() {
+        let b = MemBackend::new().with_other_user([("TO_DELETE", "v")]);
+        delete_var_with(&b, "TO_DELETE", &VarScope::OtherUser).unwrap();
+        let snap = read_snapshot_with(&b).unwrap();
+        assert!(!snap.other_user.unwrap().contains_key("TO_DELETE"));
+    }
+
+    #[test]
+    fn snapshot_omits_other_user_when_none_selected() {
+        let b = backend().with_user([("MY_VAR", "hello")]);
+        let snap = read_snapshot_with(&b).unwrap();
+        assert!(snap.other_user.is_none());
+    }
+
+    #[test]
+    fn apply_rolls_back_other_user_scope_after_failure() {
+        let b = MemBackend::new()
+            .with_other_user([("KEEP", "original")])
+            .with_elevated(false); // System write below will fail, triggering rollback
+        let result = apply_changes_with(
+            &b,
+            &[
+                EnvChange::Set {
+                    name: "KEEP".into(),
+                    value: "changed".into(),
+                    value_kind: EnvValueKind::String,
+                    scope: VarScope::OtherUser,
+                },
+                EnvChange::Set {
+                    name: "DENIED".into(),
+                    value: "value".into(),
+                    value_kind: EnvValueKind::String,
+                    scope: VarScope::System,
+                },
+            ],
+            |_, _, _, _| {},
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            read_snapshot_with(&b).unwrap().other_user.unwrap()["KEEP"].value,
+            "original"
+        );
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -14,6 +14,9 @@ pub enum EnvarlyError {
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
+
+    #[error("Could not access that account: {0}")]
+    OtherUserAccount(String),
 }
 
 // Tauri commands must return serializable errors

--- a/src-tauri/src/export/ansible.rs
+++ b/src-tauri/src/export/ansible.rs
@@ -63,6 +63,7 @@ mod tests {
                 ("OS".to_string(), string("Windows_NT")),
             ]
             .into(),
+            other_user: None,
         }
     }
 

--- a/src-tauri/src/export/dsc.rs
+++ b/src-tauri/src/export/dsc.rs
@@ -106,6 +106,7 @@ mod tests {
                 ("OS".to_string(), string("Windows_NT")),
             ]
             .into(),
+            other_user: None,
         }
     }
 

--- a/src-tauri/src/export/json.rs
+++ b/src-tauri/src/export/json.rs
@@ -55,6 +55,7 @@ pub fn parse_json(content: &str) -> Result<EnvSnapshot, EnvarlyError> {
     Ok(EnvSnapshot {
         user: as_map("user"),
         system: as_map("system"),
+        other_user: None,
     })
 }
 
@@ -86,6 +87,7 @@ mod tests {
                 ("OS".to_string(), string("Windows_NT")),
             ]
             .into(),
+            other_user: None,
         }
     }
 

--- a/src-tauri/src/export/powershell.rs
+++ b/src-tauri/src/export/powershell.rs
@@ -76,6 +76,7 @@ mod tests {
                 ("OS".to_string(), string("Windows_NT")),
             ]
             .into(),
+            other_user: None,
         }
     }
 

--- a/src-tauri/src/export/reg.rs
+++ b/src-tauri/src/export/reg.rs
@@ -111,7 +111,11 @@ pub fn parse_reg(content: &str) -> Result<EnvSnapshot, EnvarlyError> {
         }
     }
 
-    Ok(EnvSnapshot { user, system })
+    Ok(EnvSnapshot {
+        user,
+        system,
+        other_user: None,
+    })
 }
 
 fn reg_logical_lines(content: &str) -> Vec<String> {
@@ -216,6 +220,7 @@ mod tests {
                 ("OS".to_string(), string("Windows_NT")),
             ]
             .into(),
+            other_user: None,
         }
     }
 
@@ -240,6 +245,7 @@ mod tests {
         let snap = EnvSnapshot {
             user: [("X".to_string(), string("C:\\foo\\bar"))].into(),
             system: Default::default(),
+            other_user: None,
         };
         let parsed = parse_reg(&to_reg(&snap, ExportScope::User)).unwrap();
         assert_eq!(parsed.user["X"].value, "C:\\foo\\bar");
@@ -250,6 +256,7 @@ mod tests {
         let snap = EnvSnapshot {
             user: [("X".to_string(), string(r#"say "hello""#))].into(),
             system: Default::default(),
+            other_user: None,
         };
         let parsed = parse_reg(&to_reg(&snap, ExportScope::User)).unwrap();
         assert_eq!(parsed.user["X"].value, r#"say "hello""#);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ mod path_backend;
 mod path_manage;
 #[cfg(windows)]
 mod snapshot;
+#[cfg(windows)]
+mod user_hive;
 
 /// If CLI subcommand args are present, execute them and exit the process.
 /// Returns normally (unit) when there are no subcommand args, so the caller can launch the GUI.
@@ -60,7 +62,17 @@ pub fn run() {
             commands::launch::get_launch_options,
             commands::launch::read_demo_fixture,
             commands::update::check_for_update,
+            commands::users::list_local_accounts,
+            commands::users::select_account,
+            commands::users::get_selected_account,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running envarly");
+        .build(tauri::generate_context!())
+        .expect("error while running envarly")
+        .run(|_app_handle, event| {
+            // Make sure a crash-free shutdown never leaves an other-user
+            // hive loaded, even if the frontend never explicitly deselected.
+            if let tauri::RunEvent::Exit = event {
+                user_hive::unload_active_hive();
+            }
+        });
 }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 pub enum VarScope {
     User,
     System,
+    /// Another local account's per-user scope, selected via `select_account`.
+    OtherUser,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -50,6 +52,11 @@ pub struct EnvVar {
 pub struct EnvSnapshot {
     pub user: HashMap<String, EnvValue>,
     pub system: HashMap<String, EnvValue>,
+    /// Present only when an other-user account was active when this snapshot
+    /// was taken. `#[serde(default)]` keeps pre-existing on-disk snapshots
+    /// (without this field) readable.
+    #[serde(default)]
+    pub other_user: Option<HashMap<String, EnvValue>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/src-tauri/src/path_backend.rs
+++ b/src-tauri/src/path_backend.rs
@@ -63,3 +63,13 @@ pub(crate) fn write_path_str(key: &RegKey, value: &str) -> Result<(), EnvarlyErr
     )
     .map_err(EnvarlyError::Registry)
 }
+
+/// Read-only PATH access for the currently-selected other-user account, kept
+/// separate from `open_path_key` (HKCU/HKLM) by design — see `user_hive`'s
+/// module doc for why the two are never unified. `Ok(None)` means no account
+/// is active. Writing "Path" for that account goes through the generic
+/// `VarScope::OtherUser` dispatch in `env_store.rs` like any other variable —
+/// there's no separate write path here.
+pub(crate) fn read_other_user_path() -> Result<Option<String>, EnvarlyError> {
+    crate::user_hive::with_active_environment_key(false, |key| Ok(read_path_str(key)))
+}

--- a/src-tauri/src/path_manage.rs
+++ b/src-tauri/src/path_manage.rs
@@ -209,6 +209,14 @@ pub struct PathStatus {
     pub install_dir: String,
     pub user_has_entry: bool,
     pub system_has_entry: bool,
+    /// `None` when no other-user account is currently selected.
+    pub other_user_has_entry: Option<bool>,
+}
+
+fn has_entry(current: &str, dir_lc: &str) -> bool {
+    current
+        .split(';')
+        .any(|p| p.trim().to_lowercase() == dir_lc)
 }
 
 /// Read whether the install dir is currently in User / System PATH.
@@ -220,25 +228,23 @@ pub fn path_status() -> PathStatus {
     let dir_lc = dir.to_lowercase();
 
     let user_has = open_path_key(true, false)
-        .map(|k| {
-            read_path_str(&k)
-                .split(';')
-                .any(|p| p.trim().to_lowercase() == dir_lc)
-        })
+        .map(|k| has_entry(&read_path_str(&k), &dir_lc))
         .unwrap_or(false);
 
     let sys_has = open_path_key(false, false)
-        .map(|k| {
-            read_path_str(&k)
-                .split(';')
-                .any(|p| p.trim().to_lowercase() == dir_lc)
-        })
+        .map(|k| has_entry(&read_path_str(&k), &dir_lc))
         .unwrap_or(false);
+
+    let other_user_has = crate::path_backend::read_other_user_path()
+        .ok()
+        .flatten()
+        .map(|current| has_entry(&current, &dir_lc));
 
     PathStatus {
         install_dir: dir,
         user_has_entry: user_has,
         system_has_entry: sys_has,
+        other_user_has_entry: other_user_has,
     }
 }
 
@@ -251,6 +257,17 @@ pub fn propose_add(user: bool) -> Result<Option<String>, EnvarlyError> {
         .unwrap_or_default();
     let key = open_path_key(user, false)?;
     let current = read_path_str(&key);
+    Ok(compute_add(&current, &dir))
+}
+
+/// Same as `propose_add`, but for the currently-selected other-user account.
+#[cfg(windows)]
+pub fn propose_add_for_other_user() -> Result<Option<String>, EnvarlyError> {
+    let dir = install_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let current = crate::path_backend::read_other_user_path()?
+        .ok_or_else(|| EnvarlyError::OtherUserAccount("no other-user account selected".into()))?;
     Ok(compute_add(&current, &dir))
 }
 

--- a/src-tauri/src/snapshot.rs
+++ b/src-tauri/src/snapshot.rs
@@ -93,6 +93,7 @@ impl From<LegacySnapshotMeta> for SnapshotMeta {
             snapshot: EnvSnapshot {
                 user: unresolved(legacy.snapshot.user),
                 system: unresolved(legacy.snapshot.system),
+                other_user: None,
             },
         }
     }
@@ -206,6 +207,7 @@ mod tests {
                 ),
             )]),
             system: HashMap::new(),
+            other_user: None,
         }
     }
 

--- a/src-tauri/src/user_hive.rs
+++ b/src-tauri/src/user_hive.rs
@@ -1,0 +1,437 @@
+//! Loading and enumerating other local accounts' registry hives (`HKEY_USERS`).
+//!
+//! This is a deliberately separate, additive module from `env_backend.rs`:
+//! the existing HKCU/HKLM read-write code paths must not change behavior at
+//! all when no other-user account is selected, and the new Win32 surface
+//! here (RegLoadKey/RegUnLoadKey, privilege enabling, account enumeration)
+//! is inherently riskier, so it stays isolated rather than unified with it.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use winreg::enums::*;
+use winreg::RegKey;
+
+use crate::error::EnvarlyError;
+use crate::model::EnvValue;
+
+const PROFILE_LIST_KEY: &str = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList";
+const WELL_KNOWN_SIDS: &[&str] = &["S-1-5-18", "S-1-5-19", "S-1-5-20"];
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalAccount {
+    pub sid: String,
+    pub username: String,
+    pub has_profile: bool,
+    pub currently_logged_in: bool,
+}
+
+struct ActiveHive {
+    account: LocalAccount,
+    guard: HiveGuard,
+}
+
+static ACTIVE_HIVE: Mutex<Option<ActiveHive>> = Mutex::new(None);
+
+/// Enumerate local Windows accounts, excluding the current user and
+/// well-known non-interactive service SIDs. Only `has_profile` accounts can
+/// actually have their variables loaded (an account that has never logged
+/// in has no `NTUSER.DAT` to load).
+pub fn list_local_accounts() -> Result<Vec<LocalAccount>, EnvarlyError> {
+    let current_sid = current_user_sid()?;
+    let mut accounts = Vec::new();
+    for username in net_user_enum()? {
+        let Ok(sid) = lookup_account_sid(&username) else {
+            continue; // can't resolve a SID for this account; skip it
+        };
+        if sid == current_sid || WELL_KNOWN_SIDS.contains(&sid.as_str()) {
+            continue;
+        }
+        accounts.push(LocalAccount {
+            has_profile: profile_image_path(&sid).is_some(),
+            currently_logged_in: hkey_users_subkey_exists(&sid),
+            sid,
+            username,
+        });
+    }
+    accounts.sort_by_key(|a| a.username.to_lowercase());
+    Ok(accounts)
+}
+
+/// Switch the active other-user hive. `None` deselects (unloading whatever
+/// hive Envarly itself loaded). Replacing an already-active selection
+/// unloads the previous one first.
+pub fn select_account(sid: Option<&str>) -> Result<Option<LocalAccount>, EnvarlyError> {
+    let mut active = ACTIVE_HIVE.lock().unwrap();
+    *active = None; // drop first: unloads whatever hive we owned, if any
+
+    let Some(sid) = sid else {
+        return Ok(None);
+    };
+
+    let account = list_local_accounts()?
+        .into_iter()
+        .find(|a| a.sid == sid)
+        .ok_or_else(|| EnvarlyError::OtherUserAccount(format!("unknown account {sid:?}")))?;
+    if !account.has_profile {
+        return Err(EnvarlyError::OtherUserAccount(format!(
+            "{} has no profile on this machine yet",
+            account.username
+        )));
+    }
+
+    let guard = HiveGuard::load(&account.sid)?;
+    let result = account.clone();
+    *active = Some(ActiveHive { account, guard });
+    Ok(Some(result))
+}
+
+pub fn selected_account() -> Option<LocalAccount> {
+    ACTIVE_HIVE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|a| a.account.clone())
+}
+
+/// Run `f` against the currently active hive's `Environment` key, if any.
+/// Returns `Ok(None)` when nothing is selected — callers use this to make
+/// other-user reads a no-op rather than an error when there's no context.
+pub fn with_active_environment_key<T>(
+    write: bool,
+    f: impl FnOnce(&RegKey) -> Result<T, EnvarlyError>,
+) -> Result<Option<T>, EnvarlyError> {
+    let active = ACTIVE_HIVE.lock().unwrap();
+    let Some(active) = active.as_ref() else {
+        return Ok(None);
+    };
+    let flags = if write { KEY_SET_VALUE } else { KEY_READ };
+    let key = active
+        .guard
+        .root
+        .open_subkey_with_flags("Environment", flags)?;
+    f(&key).map(Some)
+}
+
+pub fn read_other_user_vars() -> Result<Option<HashMap<String, EnvValue>>, EnvarlyError> {
+    with_active_environment_key(false, |key| {
+        Ok(crate::env_backend::iter_string_values(key).collect())
+    })
+}
+
+pub fn write_other_user_var(name: &str, value: &EnvValue) -> Result<(), EnvarlyError> {
+    with_active_environment_key(true, |key| {
+        key.set_raw_value(name, &crate::env_backend::to_reg_value(value)?)?;
+        Ok(())
+    })?
+    .ok_or_else(|| EnvarlyError::OtherUserAccount("no other-user account selected".into()))
+}
+
+pub fn delete_other_user_var(name: &str) -> Result<(), EnvarlyError> {
+    with_active_environment_key(true, |key| {
+        key.delete_value(name)?;
+        Ok(())
+    })?
+    .ok_or_else(|| EnvarlyError::OtherUserAccount("no other-user account selected".into()))
+}
+
+/// RAII guard around a loaded (or already-loaded) `HKEY_USERS\<sid>` hive.
+/// Unloads it on drop, but only if this guard is the one that loaded it —
+/// an already-logged-in account's hive is left alone (some other process,
+/// namely the logon session, owns its lifetime).
+struct HiveGuard {
+    root: RegKey,
+    owns_load: bool,
+    sid: String,
+}
+
+impl HiveGuard {
+    fn load(sid: &str) -> Result<Self, EnvarlyError> {
+        if hkey_users_subkey_exists(sid) {
+            let root = RegKey::predef(HKEY_USERS).open_subkey(sid)?;
+            return Ok(Self {
+                root,
+                owns_load: false,
+                sid: sid.to_string(),
+            });
+        }
+
+        let profile_path = profile_image_path(sid)
+            .ok_or_else(|| EnvarlyError::OtherUserAccount(format!("no profile found for {sid}")))?;
+        let ntuser_dat = format!("{profile_path}\\NTUSER.DAT");
+        ensure_backup_restore_privileges()?;
+        reg_load_key(sid, &ntuser_dat)?;
+
+        let root = RegKey::predef(HKEY_USERS).open_subkey(sid)?;
+        Ok(Self {
+            root,
+            owns_load: true,
+            sid: sid.to_string(),
+        })
+    }
+}
+
+impl Drop for HiveGuard {
+    fn drop(&mut self) {
+        if self.owns_load {
+            if let Err(err) = reg_unload_key(&self.sid) {
+                eprintln!("envarly: failed to unload hive for {}: {err}", self.sid);
+            }
+        }
+    }
+}
+
+/// Unload whatever other-user hive Envarly currently owns, if any. Called on
+/// app exit so a crash-free shutdown never leaves a hive loaded.
+pub fn unload_active_hive() {
+    *ACTIVE_HIVE.lock().unwrap() = None;
+}
+
+fn hkey_users_subkey_exists(sid: &str) -> bool {
+    RegKey::predef(HKEY_USERS).open_subkey(sid).is_ok()
+}
+
+fn profile_image_path(sid: &str) -> Option<String> {
+    let key = RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey(format!("{PROFILE_LIST_KEY}\\{sid}"))
+        .ok()?;
+    key.get_value("ProfileImagePath").ok()
+}
+
+// ---------------------------------------------------------------------------
+// Raw Win32 calls
+// ---------------------------------------------------------------------------
+
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+fn current_user_sid() -> Result<String, EnvarlyError> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let mut needed = 0u32;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+        let mut buf = vec![0u8; needed as usize];
+        let ok = GetTokenInformation(
+            token,
+            TokenUser,
+            buf.as_mut_ptr() as *mut _,
+            needed,
+            &mut needed,
+        );
+        CloseHandle(token);
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+        sid_to_string(token_user.User.Sid)
+    }
+}
+
+fn sid_to_string(sid: *mut core::ffi::c_void) -> Result<String, EnvarlyError> {
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+
+    unsafe {
+        let mut ptr: *mut u16 = std::ptr::null_mut();
+        if ConvertSidToStringSidW(sid, &mut ptr) == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let s = pwstr_to_string(ptr);
+        LocalFree(ptr as *mut _);
+        Ok(s)
+    }
+}
+
+unsafe fn pwstr_to_string(ptr: *const u16) -> String {
+    let mut len = 0usize;
+    while *ptr.add(len) != 0 {
+        len += 1;
+    }
+    String::from_utf16_lossy(std::slice::from_raw_parts(ptr, len))
+}
+
+fn net_user_enum() -> Result<Vec<String>, EnvarlyError> {
+    use windows_sys::Win32::NetworkManagement::NetManagement::{
+        NetApiBufferFree, NetUserEnum, FILTER_NORMAL_ACCOUNT, MAX_PREFERRED_LENGTH, USER_INFO_0,
+    };
+
+    unsafe {
+        let mut buf: *mut u8 = std::ptr::null_mut();
+        let mut entries_read = 0u32;
+        let mut total_entries = 0u32;
+        let mut resume_handle = 0u32;
+        let status = NetUserEnum(
+            std::ptr::null(),
+            0,
+            FILTER_NORMAL_ACCOUNT,
+            &mut buf,
+            MAX_PREFERRED_LENGTH,
+            &mut entries_read,
+            &mut total_entries,
+            &mut resume_handle,
+        );
+        if status != 0 {
+            return Err(std::io::Error::from_raw_os_error(status as i32).into());
+        }
+        let entries = std::slice::from_raw_parts(buf as *const USER_INFO_0, entries_read as usize);
+        let names = entries
+            .iter()
+            .map(|entry| pwstr_to_string(entry.usri0_name))
+            .collect();
+        NetApiBufferFree(buf as *mut _);
+        Ok(names)
+    }
+}
+
+fn lookup_account_sid(username: &str) -> Result<String, EnvarlyError> {
+    use windows_sys::Win32::Security::LookupAccountNameW;
+
+    let wide_name = wide(username);
+    unsafe {
+        let mut sid_size = 0u32;
+        let mut domain_size = 0u32;
+        let mut use_ = 0i32;
+        LookupAccountNameW(
+            std::ptr::null(),
+            wide_name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut sid_size,
+            std::ptr::null_mut(),
+            &mut domain_size,
+            &mut use_,
+        );
+        let mut sid_buf = vec![0u8; sid_size as usize];
+        let mut domain_buf = vec![0u16; domain_size as usize];
+        let ok = LookupAccountNameW(
+            std::ptr::null(),
+            wide_name.as_ptr(),
+            sid_buf.as_mut_ptr() as *mut _,
+            &mut sid_size,
+            domain_buf.as_mut_ptr(),
+            &mut domain_size,
+            &mut use_,
+        );
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        sid_to_string(sid_buf.as_mut_ptr() as *mut _)
+    }
+}
+
+fn ensure_backup_restore_privileges() -> Result<(), EnvarlyError> {
+    use windows_sys::Win32::Foundation::{CloseHandle, LUID};
+    use windows_sys::Win32::Security::{
+        AdjustTokenPrivileges, LookupPrivilegeValueW, LUID_AND_ATTRIBUTES, SE_PRIVILEGE_ENABLED,
+        TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &mut token) == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+
+        for name in ["SeBackupPrivilege", "SeRestorePrivilege"] {
+            let mut luid: LUID = std::mem::zeroed();
+            if LookupPrivilegeValueW(std::ptr::null(), wide(name).as_ptr(), &mut luid) == 0 {
+                CloseHandle(token);
+                return Err(std::io::Error::last_os_error().into());
+            }
+            let privs = TOKEN_PRIVILEGES {
+                PrivilegeCount: 1,
+                Privileges: [LUID_AND_ATTRIBUTES {
+                    Luid: luid,
+                    Attributes: SE_PRIVILEGE_ENABLED,
+                }],
+            };
+            if AdjustTokenPrivileges(
+                token,
+                0,
+                &privs,
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ) == 0
+            {
+                CloseHandle(token);
+                return Err(std::io::Error::last_os_error().into());
+            }
+        }
+        CloseHandle(token);
+    }
+    Ok(())
+}
+
+fn reg_load_key(sid: &str, file_path: &str) -> Result<(), EnvarlyError> {
+    use windows_sys::Win32::System::Registry::RegLoadKeyW;
+
+    let hku = RegKey::predef(HKEY_USERS).raw_handle();
+    let status = unsafe { RegLoadKeyW(hku, wide(sid).as_ptr(), wide(file_path).as_ptr()) };
+    if status != 0 {
+        return Err(EnvarlyError::OtherUserAccount(format!(
+            "could not load profile hive ({}): {}",
+            file_path,
+            std::io::Error::from_raw_os_error(status as i32)
+        )));
+    }
+    Ok(())
+}
+
+fn reg_unload_key(sid: &str) -> Result<(), EnvarlyError> {
+    use windows_sys::Win32::System::Registry::RegUnLoadKeyW;
+
+    let hku = RegKey::predef(HKEY_USERS).raw_handle();
+    let status = unsafe { RegUnLoadKeyW(hku, wide(sid).as_ptr()) };
+    if status != 0 {
+        return Err(std::io::Error::from_raw_os_error(status as i32).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod manual_smoke_tests {
+    use super::*;
+
+    /// Not run in CI (depends on this machine's actual local accounts) — run
+    /// explicitly with `cargo test -- --ignored --nocapture` to manually
+    /// verify the real Win32 calls (NetUserEnum/LookupAccountNameW/SID
+    /// resolution/ProfileList lookup/HKEY_USERS enumeration) against the
+    /// current machine as part of Phase 1 verification.
+    #[test]
+    #[ignore]
+    fn list_and_select_real_accounts() {
+        let accounts = list_local_accounts().expect("list_local_accounts should not error");
+        println!("current_user_sid = {:?}", current_user_sid());
+        for account in &accounts {
+            println!("{account:?}");
+        }
+
+        let Some(candidate) = accounts.iter().find(|a| a.has_profile) else {
+            println!("no other account with a profile on this machine — nothing further to test");
+            return;
+        };
+
+        println!("selecting {candidate:?}");
+        let selected = select_account(Some(&candidate.sid)).expect("select_account failed");
+        println!("selected = {selected:?}");
+        assert_eq!(selected.as_ref().map(|a| &a.sid), Some(&candidate.sid));
+
+        let vars = read_other_user_vars().expect("read_other_user_vars failed");
+        println!("vars = {vars:?}");
+        assert!(vars.is_some());
+
+        select_account(None).expect("deselect failed");
+        assert!(selected_account().is_none());
+        println!("deselected cleanly");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { useTheme } from "./hooks/useTheme";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import type { DiagnosticAction, EnvironmentDiagnostic } from "./lib/environmentDiagnostics";
 import { stagedToDiff } from "./lib/stagedToDiff";
-import type { EnvVar } from "./types";
+import type { EnvVar, VarScope } from "./types";
 
 type Dialog = "importexport" | "changes" | "staged" | "licenses" | "newvar" | "checkcommand" | null;
 
@@ -57,6 +57,7 @@ export default function App() {
   const {
     userPathInEnv,
     systemPathInEnv,
+    otherUserPathInEnv,
     pathBannerDismissed,
     refreshPathStatus,
     handleStageAddToPath,
@@ -91,6 +92,20 @@ export default function App() {
     },
   });
   const personalScope = selectedAccount ? "OtherUser" : "User";
+
+  // While an account is selected, its PATH takes priority over the real
+  // current user's — same "switch mode" rule as the sidebar's personal scope.
+  const pathBannerScope: VarScope | null = selectedAccount
+    ? otherUserPathInEnv === false
+      ? "OtherUser"
+      : null
+    : elevated
+      ? !systemPathInEnv
+        ? "System"
+        : null
+      : !userPathInEnv
+        ? "User"
+        : null;
 
   useKeyboardShortcuts(undo, redo, localUndoRef);
 
@@ -189,10 +204,14 @@ export default function App() {
           accountSwitchDisabled={staged.size > 0}
         />
 
-        {(elevated ? !systemPathInEnv : !userPathInEnv) && !pathBannerDismissed && (
+        {pathBannerScope && !pathBannerDismissed && (
           <PathBanner
-            scope={elevated ? "System" : "User"}
-            onStageAddToPath={() => handleStageAddToPath(elevated ? "System" : "User")}
+            scopeLabel={
+              pathBannerScope === "OtherUser"
+                ? (selectedAccount?.username ?? pathBannerScope)
+                : pathBannerScope
+            }
+            onStageAddToPath={() => handleStageAddToPath(pathBannerScope)}
             onDismiss={handleDismissPathBanner}
           />
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Sidebar } from "./components/Sidebar/Sidebar";
 import { SnapshotPanelDock } from "./components/SnapshotPanel/SnapshotPanelDock";
 import { ThemeContext } from "./context/ThemeContext";
 import { useUndo } from "./contexts/UndoContext";
+import { useAccountSwitch } from "./hooks/useAccountSwitch";
 import { useAppInit } from "./hooks/useAppInit";
 import { useApplyStaged } from "./hooks/useApplyStaged";
 import { useDiagnostics } from "./hooks/useDiagnostics";
@@ -79,6 +80,17 @@ export default function App() {
     refresh,
     checkForExternalChanges,
   });
+
+  const { accounts, selectedAccount, handleSelectAccount } = useAccountSwitch({
+    elevated,
+    hasStagedChanges: staged.size > 0,
+    refresh: async () => {
+      await refresh();
+      await checkForExternalChanges();
+      await refreshPathStatus();
+    },
+  });
+  const personalScope = selectedAccount ? "OtherUser" : "User";
 
   useKeyboardShortcuts(undo, redo, localUndoRef);
 
@@ -171,6 +183,10 @@ export default function App() {
           onToggleTheme={toggleTheme}
           onLicenses={() => setDialog("licenses")}
           updateInfo={updateInfo}
+          accounts={accounts}
+          selectedAccount={selectedAccount}
+          onSelectAccount={handleSelectAccount}
+          accountSwitchDisabled={staged.size > 0}
         />
 
         {(elevated ? !systemPathInEnv : !userPathInEnv) && !pathBannerDismissed && (
@@ -201,6 +217,8 @@ export default function App() {
             onCreateNew={() => setDialog("newvar")}
             loading={loading}
             staged={staged}
+            personalScope={personalScope}
+            personalScopeLabel={selectedAccount?.username}
           />
 
           <div className="flex flex-1 overflow-hidden">
@@ -245,6 +263,8 @@ export default function App() {
           onStageImport={handleStageImport}
           effectiveVars={effectiveVars}
           elevated={elevated}
+          personalScope={personalScope}
+          personalScopeLabel={selectedAccount?.username}
           onNewVarStage={handleNewVarStage}
         />
       </div>

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ import type {
   EnvSnapshot,
   EnvValueKind,
   EnvVar,
+  LocalAccount,
   SnapshotMeta,
   UnsupportedEnvValue,
   UpdateInfo,
@@ -53,6 +54,13 @@ export interface EnvarlyApi {
   getPathProposal: (scope: "User" | "System") => Promise<string | null>;
   checkCommand: (input: string) => Promise<CheckCommandResult>;
   checkForUpdate: () => Promise<UpdateInfo | null>;
+  /** Local accounts (other than the current one) that can be selected for
+   * editing when running elevated. */
+  listLocalAccounts: () => Promise<LocalAccount[]>;
+  /** Switch the active other-user account; `null` deselects. Callers must
+   * re-fetch vars/snapshot/path-status afterward — this alone doesn't. */
+  selectAccount: (sid: string | null) => Promise<LocalAccount | null>;
+  getSelectedAccount: () => Promise<LocalAccount | null>;
   /**
    * Subscribe to per-variable progress while `applyEnvChanges` runs. Resolves
    * once the listener is actually registered — callers must await this before
@@ -88,6 +96,9 @@ const normalApi: EnvarlyApi = {
   getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
   checkCommand: (input) => invoke<CheckCommandResult>("check_command", { input }),
   checkForUpdate: () => invoke<UpdateInfo | null>("check_for_update"),
+  listLocalAccounts: () => invoke<LocalAccount[]>("list_local_accounts"),
+  selectAccount: (sid) => invoke<LocalAccount | null>("select_account", { sid }),
+  getSelectedAccount: () => invoke<LocalAccount | null>("get_selected_account"),
   onApplyProgress: async (callback) =>
     listen<ApplyProgressEvent>("apply-progress", (event) => callback(event.payload)),
 };
@@ -153,5 +164,8 @@ export const api: EnvarlyApi = {
   getPathProposal: async (scope) => (await getApi()).getPathProposal(scope),
   checkCommand: async (input) => (await getApi()).checkCommand(input),
   checkForUpdate: async () => (await getApi()).checkForUpdate(),
+  listLocalAccounts: async () => (await getApi()).listLocalAccounts(),
+  selectAccount: async (sid) => (await getApi()).selectAccount(sid),
+  getSelectedAccount: async () => (await getApi()).getSelectedAccount(),
   onApplyProgress: async (callback) => (await getApi()).onApplyProgress(callback),
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -50,8 +50,10 @@ export interface EnvarlyApi {
     installDir: string;
     userHasEntry: boolean;
     systemHasEntry: boolean;
+    /** `null` when no other-user account is selected. */
+    otherUserHasEntry: boolean | null;
   }>;
-  getPathProposal: (scope: "User" | "System") => Promise<string | null>;
+  getPathProposal: (scope: VarScope) => Promise<string | null>;
   checkCommand: (input: string) => Promise<CheckCommandResult>;
   checkForUpdate: () => Promise<UpdateInfo | null>;
   /** Local accounts (other than the current one) that can be selected for
@@ -90,9 +92,12 @@ const normalApi: EnvarlyApi = {
   exportCustomVars: (vars, format) => invoke<string | null>("export_custom", { vars, format }),
   parseImport: (content, format) => invoke<EnvSnapshot>("parse_import", { content, format }),
   getPathStatus: () =>
-    invoke<{ installDir: string; userHasEntry: boolean; systemHasEntry: boolean }>(
-      "get_path_status",
-    ),
+    invoke<{
+      installDir: string;
+      userHasEntry: boolean;
+      systemHasEntry: boolean;
+      otherUserHasEntry: boolean | null;
+    }>("get_path_status"),
   getPathProposal: (scope) => invoke<string | null>("get_path_proposal", { scope }),
   checkCommand: (input) => invoke<CheckCommandResult>("check_command", { input }),
   checkForUpdate: () => invoke<UpdateInfo | null>("check_for_update"),

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -14,6 +14,10 @@ const meta: Meta<typeof AppHeader> = {
     snapshotsOpen: false,
     theme: "dark",
     updateInfo: null,
+    accounts: [],
+    selectedAccount: null,
+    onSelectAccount: () => {},
+    accountSwitchDisabled: false,
   },
   argTypes: {
     loading: { control: "boolean" },
@@ -52,6 +56,22 @@ export const Loading: Story = {
 
 export const UpdateAvailable: Story = {
   args: { updateInfo: { version: "1.3.0", url: "https://github.com/iray-tno/envarly/releases" } },
+};
+
+export const WithAccounts: Story = {
+  args: {
+    elevated: true,
+    accounts: [
+      { sid: "S-1-5-21-1", username: "alice", hasProfile: true, currentlyLoggedIn: true },
+      { sid: "S-1-5-21-2", username: "bob", hasProfile: true, currentlyLoggedIn: false },
+    ],
+    selectedAccount: {
+      sid: "S-1-5-21-1",
+      username: "alice",
+      hasProfile: true,
+      currentlyLoggedIn: true,
+    },
+  },
 };
 
 /** Forces the header below the lg (1024px) breakpoint, where GitHub/Language/

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,7 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { api } from "../../api";
 import { useI18n } from "../../hooks/useI18n";
-import type { UpdateInfo } from "../../types";
+import type { LocalAccount, UpdateInfo } from "../../types";
 import { Button } from "../ui/Button";
 import { Dropdown } from "../ui/Dropdown";
 import { Icon } from "../ui/Icon";
@@ -24,6 +24,10 @@ interface AppHeaderProps {
   onToggleTheme: () => void;
   onLicenses: () => void;
   updateInfo: UpdateInfo | null;
+  accounts: LocalAccount[];
+  selectedAccount: LocalAccount | null;
+  onSelectAccount: (sid: string | null) => void;
+  accountSwitchDisabled: boolean;
 }
 
 export function AppHeader({
@@ -42,8 +46,16 @@ export function AppHeader({
   onToggleTheme,
   onLicenses,
   updateInfo,
+  accounts,
+  selectedAccount,
+  onSelectAccount,
+  accountSwitchDisabled,
 }: AppHeaderProps) {
   const { t, language, setLanguage } = useI18n();
+  const accountOptions = [
+    { value: "", label: t("account_picker.my_variables") },
+    ...accounts.map((a) => ({ value: a.sid, label: a.username })),
+  ];
   const languageOptions = [
     { value: "en", label: "English" },
     { value: "ja", label: "日本語" },
@@ -131,6 +143,18 @@ export function AppHeader({
           </Button>
         )}
         <div className="hidden @5xl:flex items-center gap-2">
+          {accounts.length > 0 && (
+            <Select
+              aria-label={t("account_picker.aria_label")}
+              value={selectedAccount?.sid ?? ""}
+              onValueChange={(v) => onSelectAccount(v || null)}
+              options={accountOptions}
+              density="compact"
+              className="text-xs"
+              disabled={accountSwitchDisabled}
+              title={accountSwitchDisabled ? t("account_picker.disabled_hint") : undefined}
+            />
+          )}
           <div className="flex items-center gap-1 text-xs text-dim">
             <Icon name="globe" size={14} className="text-dim" />
             <Select
@@ -179,6 +203,21 @@ export function AppHeader({
               />
             )}
           >
+            {accounts.length > 0 && (
+              <div className="flex items-center gap-2 px-2 py-1.5">
+                <Select
+                  aria-label={t("account_picker.aria_label")}
+                  value={selectedAccount?.sid ?? ""}
+                  onValueChange={(v) => onSelectAccount(v || null)}
+                  options={accountOptions}
+                  density="compact"
+                  containerClassName="flex-1"
+                  className="w-full"
+                  disabled={accountSwitchDisabled}
+                  title={accountSwitchDisabled ? t("account_picker.disabled_hint") : undefined}
+                />
+              </div>
+            )}
             <div className="flex items-center gap-2 px-2 py-1.5">
               <Icon name="globe" size={14} className="text-dim shrink-0" />
               <Select

--- a/src/components/AppModals/AppModals.tsx
+++ b/src/components/AppModals/AppModals.tsx
@@ -45,6 +45,8 @@ interface Props {
   ) => void;
   effectiveVars: EnvVar[];
   elevated: boolean;
+  personalScope: VarScope;
+  personalScopeLabel?: string;
   onNewVarStage: (
     name: string,
     scope: VarScope,
@@ -72,6 +74,8 @@ export function AppModals({
   onStageImport,
   effectiveVars,
   elevated,
+  personalScope,
+  personalScopeLabel,
   onNewVarStage,
 }: Props) {
   const { t } = useI18n();
@@ -140,6 +144,8 @@ export function AppModals({
         <NewVarModal
           vars={effectiveVars}
           elevated={elevated}
+          personalScope={personalScope}
+          personalScopeLabel={personalScopeLabel}
           onStage={onNewVarStage}
           onClose={() => setDialog(null)}
         />

--- a/src/components/DetailPanel/DetailHeader.tsx
+++ b/src/components/DetailPanel/DetailHeader.tsx
@@ -1,11 +1,12 @@
 import { api } from "../../api";
 import { useI18n } from "../../hooks/useI18n";
+import type { VarScope } from "../../types";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
 
 interface Props {
   name: string;
-  scope: "User" | "System";
+  scope: VarScope;
   readOnly: boolean;
   isStagedSet: boolean;
   isStagedDelete: boolean;
@@ -36,7 +37,11 @@ export function DetailHeader({
     <div className="flex items-center gap-3 px-6 h-[60px] border-b border-rim-subtle shrink-0">
       <div className="flex items-center gap-2 flex-1 min-w-0">
         <h2 className="font-mono font-semibold text-base text-fg truncate">{name}</h2>
-        <Badge variant={scope === "User" ? "user" : "system"}>{scope}</Badge>
+        <Badge
+          variant={scope === "User" ? "user" : scope === "System" ? "system" : "otherUser"}
+        >
+          {scope}
+        </Badge>
         {readOnly && (
           <>
             <Badge variant="readonly">{t("detail.readonly_badge")}</Badge>

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -90,8 +90,10 @@ export function DetailPanel({
       .forEach((v) => {
         lookup.set(v.name.toUpperCase(), v.value);
       });
+    // "User" or "OtherUser" — whichever personal scope is currently active
+    // (switch mode never shows both at once).
     allVars
-      .filter((v) => v.scope === "User")
+      .filter((v) => v.scope === "User" || v.scope === "OtherUser")
       .forEach((v) => {
         lookup.set(v.name.toUpperCase(), v.value);
       });
@@ -157,9 +159,16 @@ export function DetailPanel({
   const readOnly = variable.scope === "System" && !elevated;
   const description = lookupEnvDescription(variable.name);
   const isPathVar = variable.name.toUpperCase() === "PATH";
-  const pathInEnvForScope = variable.scope === "System" ? systemPathInEnv : userPathInEnv;
+  // PATH tooling doesn't support the OtherUser scope yet (a separate,
+  // deferred follow-up) — treat it as "already present" so the hint never
+  // offers an action that would target the wrong hive.
+  const pathInEnvForScope =
+    variable.scope === "System" ? systemPathInEnv : variable.scope === "User" ? userPathInEnv : true;
   const showAddToPathHint =
-    isPathVar && !pathInEnvForScope && !isStagedDelete && (variable.scope === "User" || elevated);
+    isPathVar &&
+    !pathInEnvForScope &&
+    !isStagedDelete &&
+    (variable.scope === "User" || (variable.scope === "System" && elevated));
 
   const editorLabel =
     effectiveSeparator === ";"

--- a/src/components/NewVarModal/NewVarModal.stories.tsx
+++ b/src/components/NewVarModal/NewVarModal.stories.tsx
@@ -9,6 +9,7 @@ const meta: Meta<typeof NewVarModal> = {
   args: {
     vars: [],
     elevated: false,
+    personalScope: "User",
     onStage: fn(),
     onClose: fn(),
   },
@@ -36,5 +37,13 @@ export const WithExistingVar: Story = {
         listSeparator: null,
       },
     ],
+  },
+};
+
+export const OtherUserSelected: Story = {
+  args: {
+    elevated: true,
+    personalScope: "OtherUser",
+    personalScopeLabel: "alice",
   },
 };

--- a/src/components/NewVarModal/NewVarModal.tsx
+++ b/src/components/NewVarModal/NewVarModal.tsx
@@ -10,14 +10,24 @@ import { Select } from "../ui/Select";
 interface NewVarModalProps {
   vars: EnvVar[];
   elevated: boolean;
+  /** "User" normally; "OtherUser" while another account is selected. */
+  personalScope: VarScope;
+  personalScopeLabel?: string;
   onStage: (name: string, scope: VarScope, value: string, valueKind: EnvValueKindSelection) => void;
   onClose: () => void;
 }
 
-export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalProps) {
+export function NewVarModal({
+  vars,
+  elevated,
+  personalScope,
+  personalScopeLabel,
+  onStage,
+  onClose,
+}: NewVarModalProps) {
   const { t } = useI18n();
   const [name, setName] = useState("");
-  const [scope, setScope] = useState<VarScope>("User");
+  const [scope, setScope] = useState<VarScope>(personalScope);
   const [value, setValue] = useState("");
   const [valueKind, setValueKind] = useState<EnvValueKindSelection>("Auto");
   const nameInputRef = useRef<HTMLInputElement>(null);
@@ -101,7 +111,10 @@ export function NewVarModal({ vars, elevated, onStage, onClose }: NewVarModalPro
         <SegmentedControl
           aria-label="Variable scope"
           options={[
-            { value: "User" as VarScope, label: "User" },
+            {
+              value: personalScope,
+              label: personalScope === "OtherUser" ? (personalScopeLabel ?? personalScope) : "User",
+            },
             {
               value: "System" as VarScope,
               label: elevated ? "System" : t("new_var.system_admin"),

--- a/src/components/PathBanner/PathBanner.stories.tsx
+++ b/src/components/PathBanner/PathBanner.stories.tsx
@@ -5,13 +5,11 @@ const meta: Meta<typeof PathBanner> = {
   title: "Components/PathBanner",
   component: PathBanner,
   tags: ["autodocs"],
-  args: { scope: "User" },
-  argTypes: {
-    scope: { control: "radio", options: ["User", "System"] },
-  },
+  args: { scopeLabel: "User" },
 };
 export default meta;
 type Story = StoryObj<typeof PathBanner>;
 
-export const UserScope: Story = { args: { scope: "User" } };
-export const SystemScope: Story = { args: { scope: "System" } };
+export const UserScope: Story = { args: { scopeLabel: "User" } };
+export const SystemScope: Story = { args: { scopeLabel: "System" } };
+export const OtherUserScope: Story = { args: { scopeLabel: "alice" } };

--- a/src/components/PathBanner/PathBanner.tsx
+++ b/src/components/PathBanner/PathBanner.tsx
@@ -2,22 +2,24 @@ import { useI18n } from "../../hooks/useI18n";
 import { Button } from "../ui/Button";
 
 interface PathBannerProps {
-  scope: "User" | "System";
+  /** Display label for the scope: "User", "System", or (while another
+   * account is selected) that account's username. */
+  scopeLabel: string;
   onStageAddToPath: () => void;
   onDismiss: () => void;
 }
 
-export function PathBanner({ scope, onStageAddToPath, onDismiss }: PathBannerProps) {
+export function PathBanner({ scopeLabel, onStageAddToPath, onDismiss }: PathBannerProps) {
   const { t } = useI18n();
 
   return (
     <div className="flex items-center gap-3 px-5 py-2 bg-accent/10 border-b border-accent/30 text-sm shrink-0">
       <span className="text-fg flex-1">
-        {t("path_banner.prefix", { scope })} <span className="font-mono text-fg">envarly</span>{" "}
-        {t("path_banner.suffix")}
+        {t("path_banner.prefix", { scope: scopeLabel })}{" "}
+        <span className="font-mono text-fg">envarly</span> {t("path_banner.suffix")}
       </span>
       <Button variant="secondary" size="sm" icon="plus" onClick={onStageAddToPath}>
-        {t("path_banner.add", { scope })}
+        {t("path_banner.add", { scope: scopeLabel })}
       </Button>
       <Button variant="ghost" size="sm" onClick={onDismiss}>
         {t("path_banner.dismiss")}

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -80,6 +80,7 @@ export const Default: Story = {
         onCreateNew={() => {}}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />
     );
   },
@@ -96,6 +97,7 @@ export const WithStagedChanges: Story = {
         onCreateNew={() => {}}
         loading={false}
         staged={withStaged}
+        personalScope="User"
       />
     );
   },
@@ -109,6 +111,7 @@ export const Loading: Story = {
     onCreateNew: () => {},
     loading: true,
     staged: noStaged,
+    personalScope: "User",
   },
 };
 
@@ -120,6 +123,7 @@ export const Empty: Story = {
     onCreateNew: () => {},
     loading: false,
     staged: noStaged,
+    personalScope: "User",
   },
 };
 
@@ -137,6 +141,7 @@ export const Narrow: Story = {
         onCreateNew={() => {}}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />
     );
   },

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -31,6 +31,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     for (const v of vars) {
@@ -48,6 +49,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     await user.type(screen.getByPlaceholderText("Search variables..."), "JAVA");
@@ -65,6 +67,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     await user.click(screen.getByRole("radio", { name: /^user/i }));
@@ -83,6 +86,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     await user.click(screen.getByText("JAVA_HOME"));
@@ -98,6 +102,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={true}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     expect(screen.getByText("Loading…")).toBeInTheDocument();
@@ -113,6 +118,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     await user.type(screen.getByPlaceholderText("Search variables..."), "ZZZNOMATCH");
@@ -128,6 +134,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     // All=4, User=2, System=2 — no secret chip when secretCount=0
@@ -153,6 +160,7 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     // "GitHub" service badge should appear next to MY_KEY
@@ -174,11 +182,33 @@ describe("Sidebar", () => {
         onCreateNew={vi.fn()}
         loading={false}
         staged={noStaged}
+        personalScope="User"
       />,
     );
     await user.click(screen.getByRole("button", { name: /secrets/i }));
     expect(screen.getByText("AWS_SECRET_ACCESS_KEY")).toBeInTheDocument();
     expect(screen.getByText("GITHUB_TOKEN")).toBeInTheDocument();
     expect(screen.queryByText("JAVA_HOME")).not.toBeInTheDocument();
+  });
+
+  it("swaps the personal-scope tab to the selected account while in switch mode", () => {
+    const otherUserVars: EnvVar[] = [
+      { name: "THEIR_VAR", value: "v", scope: "OtherUser", listSeparator: null },
+      makeVar("WINDIR", "System"),
+    ];
+    render(
+      <Sidebar
+        vars={otherUserVars}
+        selected={null}
+        onSelect={vi.fn()}
+        onCreateNew={vi.fn()}
+        loading={false}
+        staged={noStaged}
+        personalScope="OtherUser"
+        personalScopeLabel="alice"
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /alice/i })).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: /^user/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -27,14 +27,33 @@ interface Props {
   onCreateNew: () => void;
   loading: boolean;
   staged: Map<string, StagedChange>;
+  /** "User" normally; "OtherUser" while another account is selected — the
+   * personal-scope tab swaps to show that account's variables instead of
+   * the current user's (switch mode, never both at once). */
+  personalScope: "User" | "OtherUser";
+  /** Display label for the personal-scope tab when it's "OtherUser" (e.g.
+   * the selected account's username). Ignored when personalScope is "User". */
+  personalScopeLabel?: string;
 }
 
-const SCOPES = ["All", "User", "System"] as const;
-type ScopeFilter = (typeof SCOPES)[number];
+type ScopeFilter = "All" | VarScope;
 type SortOrder = "name-asc" | "name-desc" | "scope" | "staged";
 
-export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged }: Props) {
+export function Sidebar({
+  vars,
+  selected,
+  onSelect,
+  onCreateNew,
+  loading,
+  staged,
+  personalScope,
+  personalScopeLabel,
+}: Props) {
   const { t } = useI18n();
+  const scopeTabs = useMemo(
+    () => ["All", personalScope, "System"] as const,
+    [personalScope],
+  );
   const { width, isDragging, handleProps } = useResizableWidth({ ...SIDEBAR_WIDTH, side: "left" });
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>("All");
@@ -84,16 +103,13 @@ export function Sidebar({ vars, selected, onSelect, onCreateNew, loading, staged
     }
   }, [filtered, sortBy, staged]);
 
-  const counts: Record<VarScope, number> = {
-    User: vars.filter((v) => v.scope === "User").length,
-    System: vars.filter((v) => v.scope === "System").length,
-  };
+  const countFor = (scope: VarScope) => vars.filter((v) => v.scope === scope).length;
   const secretCount = vars.filter((v) => resolveSecret(v.name, v.value) !== null).length;
 
-  const scopeOptions = SCOPES.map((s) => ({
+  const scopeOptions = scopeTabs.map((s) => ({
     value: s,
-    label: s,
-    count: s === "All" ? vars.length : counts[s as VarScope],
+    label: s === "OtherUser" ? (personalScopeLabel ?? s) : s,
+    count: s === "All" ? vars.length : countFor(s),
   }));
   const sortOptions = [
     { value: "name-asc", label: t("sidebar.sort_name_asc") },

--- a/src/components/Sidebar/SidebarRow.tsx
+++ b/src/components/Sidebar/SidebarRow.tsx
@@ -89,7 +89,9 @@ export function SidebarRow({
       <span
         className={cn(
           "text-[10px] font-semibold w-4 h-4 rounded flex items-center justify-center shrink-0 mr-4",
-          v.scope === "User" ? "bg-accent/15 text-accent" : "bg-violet/15 text-violet",
+          v.scope === "User" && "bg-accent/15 text-accent",
+          v.scope === "System" && "bg-violet/15 text-violet",
+          v.scope === "OtherUser" && "bg-warn/15 text-warn",
         )}
       >
         {v.scope[0]}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react";
 import { cn } from "../../lib/cn";
 
-type Variant = "user" | "system" | "warn" | "muted" | "readonly";
+type Variant = "user" | "system" | "otherUser" | "warn" | "muted" | "readonly";
 
 const variantCls: Record<Variant, string> = {
   user: "bg-accent/15 text-accent",
   system: "bg-violet/15 text-violet",
+  otherUser: "bg-warn/15 text-warn",
   warn: "bg-warn/15 text-warn",
   muted: "bg-hover text-dim",
   readonly: "border border-rim text-dim",

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -69,6 +69,7 @@ function normalizeSnapshot(snapshot: {
   return {
     user: normalizeValues(snapshot.user),
     system: normalizeValues(snapshot.system),
+    otherUser: null,
   };
 }
 
@@ -248,6 +249,10 @@ export function createDemoApi(
       };
     },
     checkForUpdate: async () => null,
+    // Demo mode has no other-user accounts to switch between.
+    listLocalAccounts: async () => [],
+    selectAccount: async () => null,
+    getSelectedAccount: async () => null,
     onApplyProgress: async () => () => {},
   };
 }

--- a/src/demo/createDemoApi.ts
+++ b/src/demo/createDemoApi.ts
@@ -190,6 +190,7 @@ export function createDemoApi(
       installDir: fixture.installDir,
       userHasEntry: fixture.pathStatus.userHasEntry,
       systemHasEntry: fixture.pathStatus.systemHasEntry,
+      otherUserHasEntry: null, // demo mode has no other-user accounts
     }),
     getPathProposal: async (scope) => {
       const path = scopedRecord(current, scope).Path?.value ?? "";

--- a/src/hooks/stagingLogic.ts
+++ b/src/hooks/stagingLogic.ts
@@ -198,10 +198,14 @@ export function computeStageSnapshot(
   for (const [name, value] of Object.entries(snap.system)) {
     stageValue(name, "System", value);
   }
+  for (const [name, value] of Object.entries(snap.otherUser ?? {})) {
+    stageValue(name, "OtherUser", value);
+  }
 
   // Stage deletes for registry vars not present in the snapshot
   for (const v of registryVars) {
-    const inSnap = v.scope === "User" ? snap.user : snap.system;
+    const inSnap =
+      v.scope === "User" ? snap.user : v.scope === "System" ? snap.system : (snap.otherUser ?? {});
     if (!(v.name in inSnap)) {
       const k = stagedKey(v.name, v.scope);
       next.set(k, {

--- a/src/hooks/useAccountSwitch.ts
+++ b/src/hooks/useAccountSwitch.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../api";
+import type { LocalAccount } from "../types";
+
+interface Params {
+  elevated: boolean;
+  /** Switching accounts while changes are staged would leave them pointing at
+   * a hive that's no longer active, so callers should block the switch (e.g.
+   * disable the picker) while this is true rather than silently discarding. */
+  hasStagedChanges: boolean;
+  /** Re-fetch vars, diff baseline, and PATH status for the new context. */
+  refresh: () => Promise<void>;
+}
+
+export function useAccountSwitch({ elevated, hasStagedChanges, refresh }: Params) {
+  const [accounts, setAccounts] = useState<LocalAccount[]>([]);
+  const [selectedAccount, setSelectedAccount] = useState<LocalAccount | null>(null);
+
+  useEffect(() => {
+    if (!elevated) {
+      setAccounts([]);
+      return;
+    }
+    let cancelled = false;
+    api
+      .listLocalAccounts()
+      .then((list) => {
+        if (!cancelled) setAccounts(list);
+      })
+      .catch(() => {
+        if (!cancelled) setAccounts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [elevated]);
+
+  const handleSelectAccount = useCallback(
+    async (sid: string | null) => {
+      if (hasStagedChanges) return;
+      const account = await api.selectAccount(sid);
+      setSelectedAccount(account);
+      await refresh();
+    },
+    [hasStagedChanges, refresh],
+  );
+
+  return { accounts, selectedAccount, handleSelectAccount };
+}

--- a/src/hooks/usePathStatus.ts
+++ b/src/hooks/usePathStatus.ts
@@ -7,9 +7,11 @@ import { stagedKey } from "./useStaged";
 interface UsePathStatusResult {
   userPathInEnv: boolean;
   systemPathInEnv: boolean;
+  /** `null` when no other-user account is selected. */
+  otherUserPathInEnv: boolean | null;
   pathBannerDismissed: boolean;
   refreshPathStatus: () => Promise<void>;
-  handleStageAddToPath: (scope: "User" | "System") => Promise<void>;
+  handleStageAddToPath: (scope: VarScope) => Promise<void>;
   handleDismissPathBanner: () => void;
   setActualUserPathInEnv: (v: boolean) => void;
   setActualSystemPathInEnv: (v: boolean) => void;
@@ -21,23 +23,29 @@ export function usePathStatus(
 ): UsePathStatusResult {
   const [actualUserPathInEnv, setActualUserPathInEnv] = useState(true);
   const [actualSystemPathInEnv, setActualSystemPathInEnv] = useState(true);
+  const [actualOtherUserPathInEnv, setActualOtherUserPathInEnv] = useState<boolean | null>(null);
   const [pathBannerDismissed, setPathBannerDismissed] = useState(
     () => localStorage.getItem("envarly.pathBannerDismissed") === "1",
   );
 
   const userPathInEnv = actualUserPathInEnv || staged.has(stagedKey("Path", "User"));
   const systemPathInEnv = actualSystemPathInEnv || staged.has(stagedKey("Path", "System"));
+  const otherUserPathInEnv =
+    actualOtherUserPathInEnv === null
+      ? null
+      : actualOtherUserPathInEnv || staged.has(stagedKey("Path", "OtherUser"));
 
   const refreshPathStatus = useCallback(async () => {
     try {
       const ps = await api.getPathStatus();
       setActualUserPathInEnv(ps.userHasEntry);
       setActualSystemPathInEnv(ps.systemHasEntry);
+      setActualOtherUserPathInEnv(ps.otherUserHasEntry);
     } catch {}
   }, []);
 
   const handleStageAddToPath = useCallback(
-    async (scope: "User" | "System") => {
+    async (scope: VarScope) => {
       try {
         const proposed = await api.getPathProposal(scope);
         if (proposed === null) return;
@@ -57,6 +65,7 @@ export function usePathStatus(
   return {
     userPathInEnv,
     systemPathInEnv,
+    otherUserPathInEnv,
     pathBannerDismissed,
     refreshPathStatus,
     handleStageAddToPath,

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -29,13 +29,21 @@ function snapshotValue(value: SnapshotValue | string): SnapshotValue {
   return typeof value === "string" ? { value, kind: null } : value;
 }
 
+function recordFor(snapshot: EnvSnapshot, scope: VarScope): Record<string, SnapshotValue> {
+  if (scope === "User") return snapshot.user;
+  if (scope === "System") return snapshot.system;
+  return snapshot.otherUser ?? {};
+}
+
+const SCOPES: readonly VarScope[] = ["User", "System", "OtherUser"];
+
 /** Compare two snapshots and return a sorted list of differences. */
 export function computeDiff(baseline: EnvSnapshot, current: EnvSnapshot): DiffEntry[] {
   const entries: DiffEntry[] = [];
 
-  for (const scope of ["User", "System"] as const) {
-    const old = scope === "User" ? baseline.user : baseline.system;
-    const cur = scope === "User" ? current.user : current.system;
+  for (const scope of SCOPES) {
+    const old = recordFor(baseline, scope);
+    const cur = recordFor(current, scope);
 
     for (const name of Object.keys(cur)) {
       if (!(name in old)) {
@@ -94,9 +102,17 @@ export function snapshotsEqual(a: EnvSnapshot, b: EnvSnapshot): boolean {
 export function applyAccepted(baseline: EnvSnapshot, accepted: DiffEntry[]): EnvSnapshot {
   const user = { ...baseline.user };
   const system = { ...baseline.system };
+  const otherUser = baseline.otherUser ? { ...baseline.otherUser } : null;
+
+  const targetFor = (scope: VarScope) => {
+    if (scope === "User") return user;
+    if (scope === "System") return system;
+    return otherUser;
+  };
 
   for (const entry of accepted) {
-    const target = entry.scope === "User" ? user : system;
+    const target = targetFor(entry.scope);
+    if (!target) continue; // no other-user baseline bucket to merge into
     if (entry.kind === "added") {
       target[entry.name] = { value: entry.value, kind: entry.valueKind };
     } else if (entry.kind === "removed") {
@@ -106,5 +122,5 @@ export function applyAccepted(baseline: EnvSnapshot, accepted: DiffEntry[]): Env
     }
   }
 
-  return { user, system };
+  return { user, system, otherUser };
 }

--- a/src/lib/environmentDiagnostics.ts
+++ b/src/lib/environmentDiagnostics.ts
@@ -104,9 +104,11 @@ export async function diagnoseEnvironment(
       .filter((variable) => variable.scope === "System")
       .map((variable) => variable.name.toUpperCase()),
   );
+  // "User" or "OtherUser" — whichever personal scope is currently loaded
+  // (switch mode never shows both at once).
   const userNames = new Set(
     vars
-      .filter((variable) => variable.scope === "User")
+      .filter((variable) => variable.scope === "User" || variable.scope === "OtherUser")
       .map((variable) => variable.name.toUpperCase()),
   );
   const pathChecks: Array<{

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,6 +85,11 @@
     "meta_original": "Original",
     "confirm_delete": "Stage \"{{name}}\" for deletion from {{scope}} environment?"
   },
+  "account_picker": {
+    "aria_label": "Account",
+    "my_variables": "My variables",
+    "disabled_hint": "Apply or discard staged changes before switching accounts"
+  },
   "sidebar": {
     "search_placeholder": "Search variables...",
     "secret_one": "{{count}} secret",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -85,6 +85,11 @@
     "meta_original": "元の値",
     "confirm_delete": "{{scope}} 環境の \"{{name}}\" を削除としてステージしますか？"
   },
+  "account_picker": {
+    "aria_label": "アカウント",
+    "my_variables": "自分の変数",
+    "disabled_hint": "アカウントを切り替える前に、ステージ済みの変更を適用または破棄してください"
+  },
   "sidebar": {
     "search_placeholder": "変数を検索...",
     "secret_one": "{{count}} 件の機密情報",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type VarScope = "User" | "System";
+export type VarScope = "User" | "System" | "OtherUser";
 export type EnvValueKind = "String" | "ExpandString";
 export type EnvValueKindSelection = "Auto" | EnvValueKind;
 
@@ -26,6 +26,17 @@ export interface UnsupportedEnvValue {
 export interface EnvSnapshot {
   user: Record<string, SnapshotValue>;
   system: Record<string, SnapshotValue>;
+  /** Present only when an other-user account was active when this was taken. */
+  otherUser: Record<string, SnapshotValue> | null;
+}
+
+/** A local Windows account, other than the current one, that can be selected
+ * for editing when running elevated. */
+export interface LocalAccount {
+  sid: string;
+  username: string;
+  hasProfile: boolean;
+  currentlyLoggedIn: boolean;
 }
 
 export interface SnapshotMeta {


### PR DESCRIPTION
## Summary

Implements #62 — when running elevated, view/edit another local Windows account's environment variables, including PATH tooling.

Shipped as three separate commits, each independently buildable/testable:

1. **Backend foundation** — a new `user_hive` module: enumerates local accounts (`NetUserEnum`), resolves SIDs, loads/unloads other accounts' registry hives (`RegLoadKeyW`/`RegUnLoadKeyW` + `SeBackupPrivilege`/`SeRestorePrivilege`), and a third `VarScope::OtherUser` that dispatches through **additive** `EnvBackend` trait methods with default `Err`/`None` implementations. The existing HKCU/HKLM read-write paths are untouched — every new dispatch arm is opt-in and only reachable once an account is actually selected. This was an explicit design constraint: prioritize safety/isolation over unifying with the existing (battle-tested) User/System code, even though HKCU is architecturally just `HKEY_USERS\<current SID>`.
2. **Switch-mode UI** — an account picker in the header (visible only when elevated and other accounts exist). Selecting an account swaps the sidebar's personal-scope list for that account's variables; System stays visible; the two are never shown together. Covers the scope filter tabs, new-variable scope choice, badge color, `%VAR%` expansion lookups, the diagnostics user/system relationship check, and diff/snapshot staging. Switching is blocked (not silently discarded) while there are staged changes.
3. **PATH tooling** — extends the PATH banner and "add envarly to PATH" proposal to the selected account, via a separate read-only helper (`path_backend::read_other_user_path`) rather than folding a third case into the existing bool-based `open_path_key`. Writing "Path" for the other-user scope already goes through the generic dispatch from commit 1 — no new write path needed. `check_command` is intentionally untouched, since it diagnoses the real running process's PATH resolution, unrelated to whichever account is on screen.

## Known gap

This dev machine only has built-in accounts with no profile (Administrator, Guest, DefaultAccount, WDAGUtilityAccount) — account enumeration and the "already logged in" hive-access path were verified live (see the `#[ignore]`d `user_hive::manual_smoke_tests::list_and_select_real_accounts` test, run with `cargo test -- --ignored --nocapture`), but the actual `RegLoadKeyW`/`RegUnLoadKeyW` path for an account that is **not** currently logged in was never exercised against a real profile. Please test on a machine with a second real (previously logged-in but not currently active) account before relying on this in production.

## Test plan

- [x] `cargo test` — 94 passed, 1 ignored (manual smoke test)
- [x] `cargo fmt --check` / `cargo clippy` — clean
- [x] `npm test` — 289 unit tests pass
- [x] `npm run test:storybook` — 108 tests pass
- [x] `tsc --noEmit` / `npm run lint` — clean
- [x] `npm run tauri build` — release build + MSI/NSIS bundles succeed
- [ ] Manual verification of `RegLoadKeyW` against a real not-currently-logged-in account (see "Known gap" above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)