### PR TITLE
chore: automate WinGet manifest submission on release

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,33 @@
+name: WinGet Submit
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Submit WinGet manifest update
+    runs-on: windows-latest
+    if: "!github.event.release.prerelease"
+    steps:
+      - name: Determine version and installer URL
+        id: vars
+        shell: pwsh
+        run: |
+          $version = "${{ github.event.release.tag_name }}" -replace '^v', ''
+          $url = "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/Envarly_${version}_x64_en-US.msi"
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "url=$url" >> $env:GITHUB_OUTPUT
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Update and submit WinGet manifest
+        shell: pwsh
+        run: |
+          .\wingetcreate.exe update Envarly.Envarly `
+            --version ${{ steps.vars.outputs.version }} `
+            --urls "${{ steps.vars.outputs.url }}" `
+            --submit `
+            --token ${{ secrets.WINGET_TOKEN }}

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -73,9 +73,10 @@ Adjust paths and filenames to match the artifacts produced by the release workfl
 
 For WinGet:
 
-- Prefer the MSI artifact first if the release checklist passes for install, upgrade, uninstall, and silent modes.
-- Use the GitHub Release artifact URL and the matching SHA256 from `SHA256SUMS.txt`.
-- Fall back to the EXE installer only if MSI behavior is worse for that release.
+- Package identifier: `Envarly.Envarly`, submitted as a single `wix` (MSI) installer — see the [`.github/workflows/winget.yml`](../.github/workflows/winget.yml) workflow.
+- Automated: publishing a non-prerelease GitHub Release triggers this workflow, which runs `wingetcreate update` against the release's MSI asset and opens the PR against `microsoft/winget-pkgs` directly. Nothing to do manually unless the workflow fails (check the Actions log — a missing/renamed MSI asset or an expired `WINGET_TOKEN` are the likely causes).
+- Requires a repo secret `WINGET_TOKEN`: a GitHub PAT (classic, `public_repo` scope) belonging to the account that will own the fork/PR against `microsoft/winget-pkgs`. Rotate it there if submissions start failing with an auth error.
+- If MSI behavior is ever worse than the EXE installer for a release, switch the installer type manually with `wingetcreate update Envarly.Envarly --version <version> --urls <exe-url> --submit --token <token>` for that one release, then let the automated workflow resume next time.
 
 For Scoop:
 


### PR DESCRIPTION
## Summary

Automates what was previously a manual step for the 1.2.1 release: submitting an updated manifest to `microsoft/winget-pkgs` whenever a new version ships.

- New workflow `.github/workflows/winget.yml`, triggered on `release: published` (skipped for prereleases).
- Runs Microsoft's official `wingetcreate update` against the release's MSI asset (`Envarly_<version>_x64_en-US.msi`), which diffs against the last submitted manifest (`Envarly.Envarly`, confirmed via the existing 1.2.1 submission — single `wix`/MSI installer, x64) and opens the PR directly.
- `docs/distribution.md` updated to describe the automation and the required secret.

## Setup required before this can run

Add a repo secret **`WINGET_TOKEN`**: a GitHub PAT (classic, `public_repo` scope) belonging to whichever account should own the fork of `microsoft/winget-pkgs` and the resulting PR. Without it, the workflow will fail at the `wingetcreate update --submit` step — visible in the Actions log, not a silent failure.

## Test plan

- [x] YAML syntax validated
- [ ] First real run against the next tagged release (can't dry-run against a fake release safely — recommend watching the Actions log on the next release to confirm `wingetcreate` finds the MSI asset and opens the PR successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)