### PR TITLE
fix: surface account-switch failures instead of swallowing them

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ export default function App() {
     checkForExternalChanges,
   });
 
-  const { accounts, selectedAccount, handleSelectAccount } = useAccountSwitch({
+  const { accounts, selectedAccount, handleSelectAccount, accountSwitchError } = useAccountSwitch({
     elevated,
     hasStagedChanges: staged.size > 0,
     refresh: async () => {
@@ -225,6 +225,12 @@ export default function App() {
         {error && (
           <div className="px-4 py-2 bg-danger/15 border-b border-danger text-danger text-sm shrink-0">
             {t("app.registry_error", { error })}
+          </div>
+        )}
+
+        {accountSwitchError && (
+          <div className="px-4 py-2 bg-danger/15 border-b border-danger text-danger text-sm shrink-0">
+            {t("app.account_switch_error", { error: accountSwitchError })}
           </div>
         )}
 

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -52,9 +52,12 @@ export function AppHeader({
   accountSwitchDisabled,
 }: AppHeaderProps) {
   const { t, language, setLanguage } = useI18n();
+  // Accounts without a profile have no Environment key to load — offering
+  // them here would be a guaranteed-to-fail dead end.
+  const selectableAccounts = accounts.filter((a) => a.hasProfile);
   const accountOptions = [
     { value: "", label: t("account_picker.my_variables") },
-    ...accounts.map((a) => ({ value: a.sid, label: a.username })),
+    ...selectableAccounts.map((a) => ({ value: a.sid, label: a.username })),
   ];
   const languageOptions = [
     { value: "en", label: "English" },
@@ -143,7 +146,7 @@ export function AppHeader({
           </Button>
         )}
         <div className="hidden @5xl:flex items-center gap-2">
-          {accounts.length > 0 && (
+          {selectableAccounts.length > 0 && (
             <Select
               aria-label={t("account_picker.aria_label")}
               value={selectedAccount?.sid ?? ""}
@@ -203,7 +206,7 @@ export function AppHeader({
               />
             )}
           >
-            {accounts.length > 0 && (
+            {selectableAccounts.length > 0 && (
               <div className="flex items-center gap-2 px-2 py-1.5">
                 <Select
                   aria-label={t("account_picker.aria_label")}

--- a/src/hooks/useAccountSwitch.ts
+++ b/src/hooks/useAccountSwitch.ts
@@ -15,6 +15,7 @@ interface Params {
 export function useAccountSwitch({ elevated, hasStagedChanges, refresh }: Params) {
   const [accounts, setAccounts] = useState<LocalAccount[]>([]);
   const [selectedAccount, setSelectedAccount] = useState<LocalAccount | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!elevated) {
@@ -38,12 +39,17 @@ export function useAccountSwitch({ elevated, hasStagedChanges, refresh }: Params
   const handleSelectAccount = useCallback(
     async (sid: string | null) => {
       if (hasStagedChanges) return;
-      const account = await api.selectAccount(sid);
-      setSelectedAccount(account);
-      await refresh();
+      setError(null);
+      try {
+        const account = await api.selectAccount(sid);
+        setSelectedAccount(account);
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     },
     [hasStagedChanges, refresh],
   );
 
-  return { accounts, selectedAccount, handleSelectAccount };
+  return { accounts, selectedAccount, handleSelectAccount, accountSwitchError: error };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "app": {
     "registry_error": "Registry error: {{error}}",
+    "account_switch_error": "Couldn't switch account: {{error}}",
     "loading": "Loading…"
   },
   "diagnostics": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,6 +1,7 @@
 {
   "app": {
     "registry_error": "レジストリエラー: {{error}}",
+    "account_switch_error": "アカウントを切り替えられませんでした: {{error}}",
     "loading": "読み込み中…"
   },
   "diagnostics": {


### PR DESCRIPTION
## Summary

Fixes the bug you hit after merging #148: picking an account in the header did nothing, no matter what was selected.

Two real problems, both fixed:

1. **Errors were silently swallowed.** `handleSelectAccount` never caught the promise from `api.selectAccount()`, so any failure (e.g. `RegLoadKeyW` failing, or an invalid selection) just vanished — the UI never updated and nothing was shown. Now the error is caught and surfaced as a banner under the header, same style as the existing registry-error banner.
2. **Profile-less accounts were offered as if selectable.** Built-in accounts like Administrator/Guest/DefaultAccount that have never logged in have no `Environment` registry key at all, so selecting them was guaranteed to fail server-side. The picker now only lists accounts with `hasProfile: true`.

If a machine only has profile-less built-in accounts (no other real logged-in-before user), the picker now correctly doesn't appear at all — that's expected, not a bug.

## Test plan

- [x] `tsc --noEmit` / `npm run lint` — clean
- [x] `npm test` — 289 unit tests pass
- [x] Confirmed against real hardware: the previously-silent failure now surfaces an error message, and profile-less accounts no longer appear in the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)