### PR TITLE
feat: allow manually triggering the WinGet submission workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -3,19 +3,31 @@ name: WinGet Submit
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to submit, e.g. 1.4.0 (must match an existing vX.Y.Z release tag with an MSI asset)"
+        required: true
+        type: string
 
 jobs:
   winget:
     name: Submit WinGet manifest update
     runs-on: windows-latest
-    if: "!github.event.release.prerelease"
+    if: "github.event_name == 'workflow_dispatch' || !github.event.release.prerelease"
     steps:
       - name: Determine version and installer URL
         id: vars
         shell: pwsh
         run: |
-          $version = "${{ github.event.release.tag_name }}" -replace '^v', ''
-          $url = "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/Envarly_${version}_x64_en-US.msi"
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $version = "${{ inputs.version }}"
+            $tag = "v$version"
+          } else {
+            $tag = "${{ github.event.release.tag_name }}"
+            $version = $tag -replace '^v', ''
+          }
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/Envarly_${version}_x64_en-US.msi"
           "version=$version" >> $env:GITHUB_OUTPUT
           "url=$url" >> $env:GITHUB_OUTPUT
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -75,6 +75,7 @@ For WinGet:
 
 - Package identifier: `Envarly.Envarly`, submitted as a single `wix` (MSI) installer — see the [`.github/workflows/winget.yml`](../.github/workflows/winget.yml) workflow.
 - Automated: publishing a non-prerelease GitHub Release triggers this workflow, which runs `wingetcreate update` against the release's MSI asset and opens the PR against `microsoft/winget-pkgs` directly. Nothing to do manually unless the workflow fails (check the Actions log — a missing/renamed MSI asset or an expired `WINGET_TOKEN` are the likely causes).
+- Can also be run manually (e.g. to submit a version that was released before this automation existed) via `workflow_dispatch`: `gh workflow run winget.yml -f version=1.4.0`, or from the Actions tab in GitHub's UI.
 - Requires a repo secret `WINGET_TOKEN`: a GitHub PAT (classic, `public_repo` scope) belonging to the account that will own the fork/PR against `microsoft/winget-pkgs`. Rotate it there if submissions start failing with an auth error.
 - If MSI behavior is ever worse than the EXE installer for a release, switch the installer type manually with `wingetcreate update Envarly.Envarly --version <version> --urls <exe-url> --submit --token <token>` for that one release, then let the automated workflow resume next time.
 


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` input to `.github/workflows/winget.yml` so a version can be submitted on demand — needed for 1.4.0, which was released before the automation in #149 existed and so never got a WinGet submission.

Usage once merged (and `WINGET_TOKEN` is set):

```
gh workflow run winget.yml -f version=1.4.0
```

or via the Actions tab → "WinGet Submit" → "Run workflow".

🤖 Generated with [Claude Code](https://claude.com/claude-code)