### PR TITLE
refactor: replace contextual comments with self-explanatory documentation

### DIFF
--- a/src-tauri/src/commands/path.rs
+++ b/src-tauri/src/commands/path.rs
@@ -166,6 +166,7 @@ mod tests {
 
     #[test]
     fn validate_paths_existing() {
+        // C:\Windows only reliably exists when this actually runs on Windows.
         let results = validate_paths(vec!["C:\\Windows".to_string()]);
         if cfg!(target_os = "windows") {
             assert_eq!(results, vec![true]);

--- a/src-tauri/src/commands/path.rs
+++ b/src-tauri/src/commands/path.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn expand_continues_after_unknown_var() {
-        // Regression: unknown var must not stop expansion of subsequent known vars
+        // Unknown variables are preserved while continuing expansion of subsequent variables
         std::env::set_var("_TEST_EXPAND_KNOWN", "found");
         let result = expand_env_vars("%_UNKNOWN_ZZZ_%\\%_TEST_EXPAND_KNOWN%");
         assert_eq!(result, "%_UNKNOWN_ZZZ_%\\found");
@@ -166,9 +166,7 @@ mod tests {
 
     #[test]
     fn validate_paths_existing() {
-        // System32 should always exist on Windows CI
         let results = validate_paths(vec!["C:\\Windows".to_string()]);
-        // On non-Windows CI this might be false; guard the assertion
         if cfg!(target_os = "windows") {
             assert_eq!(results, vec![true]);
         }

--- a/src-tauri/src/user_hive.rs
+++ b/src-tauri/src/user_hive.rs
@@ -402,11 +402,8 @@ fn reg_unload_key(sid: &str) -> Result<(), EnvarlyError> {
 mod manual_smoke_tests {
     use super::*;
 
-    /// Not run in CI (depends on this machine's actual local accounts) — run
-    /// explicitly with `cargo test -- --ignored --nocapture` to manually
-    /// verify the real Win32 calls (NetUserEnum/LookupAccountNameW/SID
-    /// resolution/ProfileList lookup/HKEY_USERS enumeration) against the
-    /// current machine as part of Phase 1 verification.
+    /// Smoke test for local account enumeration and Win32 registry hive operations.
+    /// Ignored in CI; run explicitly on a Windows host using `cargo test -- --ignored --nocapture`.
     #[test]
     #[ignore]
     fn list_and_select_real_accounts() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,8 +93,8 @@ export default function App() {
   });
   const personalScope = selectedAccount ? "OtherUser" : "User";
 
-  // While an account is selected, its PATH takes priority over the real
-  // current user's — same "switch mode" rule as the sidebar's personal scope.
+  // When another account is selected, its PATH status takes priority for banner hints,
+  // following the same active scope resolution as the sidebar personal scope.
   const pathBannerScope: VarScope | null = selectedAccount
     ? otherUserPathInEnv === false
       ? "OtherUser"

--- a/src/components/CheckCommandPanel/CheckCommandPanel.stories.tsx
+++ b/src/components/CheckCommandPanel/CheckCommandPanel.stories.tsx
@@ -20,8 +20,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Locale-agnostic: the test environment defaults to Japanese, so play functions
-// must not match on translated text — use data-testid/data-status hooks instead.
+// Query elements using data-testid and data-status attributes to remain locale-independent.
 async function typeAndCheck(canvasElement: HTMLElement, query: string) {
   const canvas = within(canvasElement);
   const input = await canvas.findByTestId("check-command-input");

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -159,9 +159,8 @@ export function DetailPanel({
   const readOnly = variable.scope === "System" && !elevated;
   const description = lookupEnvDescription(variable.name);
   const isPathVar = variable.name.toUpperCase() === "PATH";
-  // PATH tooling doesn't support the OtherUser scope yet (a separate,
-  // deferred follow-up) — treat it as "already present" so the hint never
-  // offers an action that would target the wrong hive.
+  // PATH management actions target User or System scopes. For OtherUser variables,
+  // treat PATH status as already present to suppress adding Envarly's install directory.
   const pathInEnvForScope =
     variable.scope === "System" ? systemPathInEnv : variable.scope === "User" ? userPathInEnv : true;
   const showAddToPathHint =

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -159,8 +159,8 @@ export function DetailPanel({
   const readOnly = variable.scope === "System" && !elevated;
   const description = lookupEnvDescription(variable.name);
   const isPathVar = variable.name.toUpperCase() === "PATH";
-  // PATH management actions target User or System scopes. For OtherUser variables,
-  // treat PATH status as already present to suppress adding Envarly's install directory.
+  // OtherUser has no PATH tooling of its own yet — treat it as already present
+  // so the hint never offers an action that would write to the wrong hive.
   const pathInEnvForScope =
     variable.scope === "System" ? systemPathInEnv : variable.scope === "User" ? userPathInEnv : true;
   const showAddToPathHint =

--- a/src/components/DiffPanel/DiffPanel.test.tsx
+++ b/src/components/DiffPanel/DiffPanel.test.tsx
@@ -53,7 +53,7 @@ describe("DiffPanel", () => {
     const user = userEvent.setup();
     render(<DiffPanel entries={entries} onApply={onApply} onDismiss={vi.fn()} />);
     const checkboxes = screen.getAllByRole("checkbox");
-    await user.click(checkboxes[0]); // uncheck NEW_VAR
+    await user.click(checkboxes[0]); // Uncheck the added entry
     await user.click(screen.getByRole("button", { name: /apply/i }));
     expect(onApply).toHaveBeenCalledWith([removed, changed], [added]);
   });
@@ -71,7 +71,7 @@ describe("DiffPanel", () => {
   it("Select all re-checks all entries", async () => {
     const user = userEvent.setup();
     render(<DiffPanel entries={entries} onApply={vi.fn()} onDismiss={vi.fn()} />);
-    // uncheck first
+    // Uncheck an entry before selecting all
     await user.click(screen.getAllByRole("checkbox")[0]);
     await user.click(screen.getByRole("button", { name: "Select all" }));
     const checkboxes = screen.getAllByRole("checkbox");

--- a/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
+++ b/src/components/ImportExportPanel/ImportExportPanel.stories.tsx
@@ -118,7 +118,7 @@ export const SecretWarning: Story = {
     const canvas = within(canvasElement);
     const exportButton = await canvas.findByRole("button", { name: /\.json/i });
     exportButton.click();
-    // "GitHub" (the secret service name) isn't translated, so it's a safe locale-agnostic anchor.
+    // Service names (such as "GitHub") remain unlocalized, serving as reliable test anchors.
     await canvas.findByText(/github/i);
   },
 };

--- a/src/components/ImportExportPanel/ImportExportPanel.test.tsx
+++ b/src/components/ImportExportPanel/ImportExportPanel.test.tsx
@@ -63,7 +63,6 @@ describe("ImportExportPanel — Export tab", () => {
   });
 
   it("exports directly without confirmation when no secrets in scope", async () => {
-    // Default mock: JAVA_HOME, MY_VAR, WINDIR — none are secrets
     const user = userEvent.setup();
     render(<ImportExportPanel onStage={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: /export all/i }));
@@ -114,7 +113,6 @@ describe("ImportExportPanel — Export tab", () => {
   });
 
   it("shows success status after export", async () => {
-    // No secrets in default mock → direct export
     const user = userEvent.setup();
     render(<ImportExportPanel onStage={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: /export all/i }));
@@ -128,7 +126,6 @@ describe("ImportExportPanel — Export tab", () => {
     render(<ImportExportPanel onStage={vi.fn()} />);
     await user.click(screen.getByRole("radio", { name: "Custom…" }));
     await waitFor(() => expect(screen.getByText("JAVA_HOME")).toBeInTheDocument());
-    // Test data (JAVA_HOME) has no secrets → no confirmation step
     await user.click(screen.getByRole("button", { name: /export \d+ selected/i }));
     await waitFor(() => expect(api.exportCustomVars).toHaveBeenCalled());
   });

--- a/src/components/PathEditor/PathEditor.tsx
+++ b/src/components/PathEditor/PathEditor.tsx
@@ -32,24 +32,22 @@ export function PathEditor({
   onBeforeReorder,
 }: Props) {
   const [entries, setEntries] = useState<ListEntry[]>([]);
-  // Lint runs against lintedValue, which only updates on blur or when rawValue changes while not focused.
+  // Linting operates on `lintedValue`, updated on blur or when external changes occur while unfocused.
   const [lintedValue, setLintedValue] = useState(rawValue);
   const hasFocusRef = useRef(false);
 
-  // Sync lintedValue when rawValue changes externally (e.g. variable switch) while not focused.
+  // Synchronize `lintedValue` when `rawValue` changes externally (e.g., switching variables).
   useEffect(() => {
     if (!hasFocusRef.current) setLintedValue(rawValue);
   }, [rawValue]);
 
-  // Parse rawValue → entries. Guard prevents reset when the change originated here.
+  // Parse `rawValue` into entry objects, preserving item identity across undo operations.
   useEffect(() => {
     setEntries((prev) => {
       const current = prev.map((e) => e.value).join(";");
       if (current === rawValue) return prev;
       const parts = rawValue.split(";").filter((p) => p.trim().length > 0);
-      // Reuse existing entry IDs to preserve DOM nodes and focus across undo operations.
-      // 1. Value match  — handles drag undo (same values, reordered).
-      // 2. Index match  — handles text-edit undo (same position, different value).
+      // Re-use stable IDs by matching previous values (for reordering) or indices (for text updates).
       const pool = prev.map((e, i) => ({ e, i, used: false }));
       return parts.map((value, i) => {
         const byVal = pool.find((p) => !p.used && p.e.value === value);
@@ -67,7 +65,7 @@ export function PathEditor({
     });
   }, [rawValue]);
 
-  // Validate paths when new entries appear with exists === null.
+  // Asynchronously validate filesystem existence for unverified path entries.
   useEffect(() => {
     if (skipPathValidation || entries.length === 0) return;
     if (entries.every((e) => e.exists !== null && e.exists !== undefined)) return;

--- a/src/hooks/stagingLogic.ts
+++ b/src/hooks/stagingLogic.ts
@@ -31,7 +31,8 @@ export type StagedChange =
       newValue: null;
     });
 
-export type StagedKey = string; // `${VarScope}:${name}`
+/** Compound key format: `${VarScope}:${name}` */
+export type StagedKey = string;
 
 type RegistryByKey = Map<StagedKey, EnvVar>;
 type StagedMap = Map<StagedKey, StagedChange>;

--- a/src/hooks/useLocalHistory.test.ts
+++ b/src/hooks/useLocalHistory.test.ts
@@ -118,10 +118,11 @@ describe("useLocalHistory", () => {
       result.current.reset("z");
     });
     expect(result.current.value).toBe("z");
-    expect(result.current.dirty).toBe(true);
+    expect(result.current.dirty).toBe(true); // "z" differs from the original value "a"
     act(() => {
       result.current.discard();
     });
+    // reset cleared the "b" checkpoint, so discard falls back to the original value
     expect(result.current.value).toBe("a");
   });
 

--- a/src/hooks/useLocalHistory.test.ts
+++ b/src/hooks/useLocalHistory.test.ts
@@ -49,7 +49,7 @@ describe("useLocalHistory", () => {
     });
     act(() => {
       result.current.onChange("c");
-    }); // text edit after checkpoint
+    });
     act(() => {
       result.current.discard();
     });
@@ -65,10 +65,10 @@ describe("useLocalHistory", () => {
     });
     act(() => {
       result.current.discard();
-    }); // back to checkpoint (b == top, pop it)
+    });
     act(() => {
       result.current.discard();
-    }); // back to original
+    });
     expect(result.current.value).toBe("a");
     expect(result.current.dirty).toBe(false);
   });
@@ -77,14 +77,14 @@ describe("useLocalHistory", () => {
     const { result } = renderHook(() => useLocalHistory("a"));
     act(() => {
       result.current.onChange("b");
-    }); // text edit
+    });
     act(() => {
       result.current.onBeforeStructuralChange();
       result.current.onChange("c");
     });
     act(() => {
       result.current.discard();
-    }); // current === checkpoint c → pop, go to b
+    });
     expect(result.current.value).toBe("b");
   });
 
@@ -96,14 +96,14 @@ describe("useLocalHistory", () => {
     });
     act(() => {
       result.current.onBeforeStructuralChange();
-      result.current.onChange("c"); // pre-op value b == top checkpoint → skip duplicate
+      result.current.onChange("c");
     });
     act(() => {
       result.current.discard();
-    }); // c → b (top checkpoint)
+    });
     act(() => {
       result.current.discard();
-    }); // b → a (original)
+    });
     expect(result.current.value).toBe("a");
     expect(result.current.dirty).toBe(false);
   });
@@ -118,8 +118,7 @@ describe("useLocalHistory", () => {
       result.current.reset("z");
     });
     expect(result.current.value).toBe("z");
-    expect(result.current.dirty).toBe(true); // z !== originalValue (a)
-    // history cleared: discard goes to original, not b
+    expect(result.current.dirty).toBe(true);
     act(() => {
       result.current.discard();
     });
@@ -147,7 +146,6 @@ describe("useLocalHistory", () => {
     rerender({ v: "x" });
     expect(result.current.value).toBe("x");
     expect(result.current.dirty).toBe(false);
-    // history cleared: discard should stay at x (no checkpoints)
     act(() => {
       result.current.discard();
     });

--- a/src/hooks/useUndoStack.test.ts
+++ b/src/hooks/useUndoStack.test.ts
@@ -95,13 +95,13 @@ describe("useUndoStack", () => {
     });
     act(() => {
       result.current.undo();
-    }); // u2 (most recent first)
+    });
     act(() => {
       result.current.undo();
-    }); // u1
+    });
     act(() => {
       result.current.redo();
-    }); // r1 (oldest first)
+    });
     expect(log).toEqual(["u2", "u1", "r1"]);
   });
 


### PR DESCRIPTION
## Overview
Refactors code comments across both the React frontend and Rust backend to replace contextual/provisional/history-referencing comments with clean, self-explanatory, domain-focused documentation.

Re-submission of #155, which was reverted (`main` force-pushed back to before its merge) because its `Co-Authored-By: Antigravity <antigravity@google.com>` trailers happened to match a real, unrelated GitHub user's verified email, linking them as a co-author. Content is otherwise identical to #155 plus its follow-up fix commit — only the co-author email changed, to `noreply@google.com`.

## Key Changes
- **Backend (Rust)**:
  - `src-tauri/src/commands/path.rs`: Clarified path variable expansion test comments.
  - `src-tauri/src/user_hive.rs`: Updated manual smoke test documentation to be timeless.
- **Frontend (TypeScript/React)**:
  - `src/components/DetailPanel/DetailPanel.tsx`: Clarified PATH hint scope logic rationale.
  - `src/components/PathEditor/PathEditor.tsx`: Improved state synchronization and entry tracking comments.
  - `src/hooks/stagingLogic.ts`: Enhanced type documentation with JSDoc comments.
  - `src/App.tsx`: Clarified PATH banner scope resolution precedence.
  - Storybook stories and unit test files: Removed redundant inline step annotations in favor of clean assertions and descriptive comments.
- Follow-up fix (carried over from #155): restored a few spots where the cleanup traded a genuinely useful "why" for a restatement of "what" (DetailPanel.tsx's deferred-OtherUser-support rationale, path.rs's target_os guard rationale, useLocalHistory.test.ts's reset/discard rationale).

## Verification
- All Vitest unit tests and Storybook tests passed (`npm test`).
- All Cargo Rust unit tests passed (`cargo test`).
- Confirmed file content is byte-for-byte identical to #155 (diffed against the original branch) — only commit trailers changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)