### PR TITLE
feat(lp): add WinGet install command, split features into tiers

### DIFF
--- a/lp/src/components/LandingPage.astro
+++ b/lp/src/components/LandingPage.astro
@@ -5,6 +5,7 @@ import {
   RELEASE_URL,
   REPORTS_URL,
   STORYBOOK_URL,
+  WINGET_COMMAND,
   type LandingCopy,
 } from '../lib/lpContent';
 
@@ -78,6 +79,37 @@ const { copy } = Astro.props;
           {copy.hero.github}
         </a>
       </div>
+
+      <!-- WinGet install -->
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-2 mb-16 -mt-8 text-sm">
+        <span class="text-[var(--color-muted)]">{copy.install.label}</span>
+        <div class="flex items-center gap-1 pl-3 pr-1 py-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+          <code id="winget-command" class="font-mono text-xs text-[var(--color-text)]">{WINGET_COMMAND}</code>
+          <button
+            id="winget-copy"
+            type="button"
+            class="px-2 py-1 rounded-md text-xs text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)]/40 transition-colors"
+            data-copy-label={copy.install.copy}
+            data-copied-label={copy.install.copied}
+          >
+            {copy.install.copy}
+          </button>
+        </div>
+      </div>
+      <script define:vars={{ command: WINGET_COMMAND }}>
+        {
+          const button = document.getElementById('winget-copy');
+          button?.addEventListener('click', async () => {
+            await navigator.clipboard.writeText(command);
+            const copied = button.dataset.copiedLabel ?? 'Copied!';
+            const original = button.dataset.copyLabel ?? button.textContent ?? '';
+            button.textContent = copied;
+            setTimeout(() => {
+              button.textContent = original;
+            }, 1500);
+          });
+        }
+      </script>
 
       <!-- Screenshot carousel -->
       <div class="mx-auto">
@@ -177,12 +209,25 @@ const { copy } = Astro.props;
       <h2 class="text-2xl font-bold text-[var(--color-text)] text-center mb-3">{copy.featuresHeading}</h2>
       <p class="text-[var(--color-muted)] text-center mb-12">{copy.featuresLead}</p>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-14">
         {copy.features.map((f) => (
           <div class="p-5 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-accent)]/40 transition-colors">
             <div class="text-2xl mb-3">{f.icon}</div>
             <h3 class="text-sm font-semibold text-[var(--color-text)] mb-2">{f.title}</h3>
             <p class="text-xs text-[var(--color-muted)] leading-relaxed">{f.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      <p class="text-xs text-[var(--color-muted)] text-center mb-5 uppercase tracking-widest">{copy.otherFeaturesHeading}</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3">
+        {copy.otherFeatures.map((f) => (
+          <div class="flex items-start gap-3 py-2">
+            <div class="text-base shrink-0 mt-0.5">{f.icon}</div>
+            <div>
+              <h3 class="text-xs font-semibold text-[var(--color-text)] mb-0.5">{f.title}</h3>
+              <p class="text-xs text-[var(--color-muted)] leading-relaxed">{f.desc}</p>
+            </div>
           </div>
         ))}
       </div>

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -3,6 +3,7 @@ export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest'
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
 export const VERSION = '1.4.0';
+export const WINGET_COMMAND = 'winget install Envarly.Envarly';
 
 export type LandingCopy = {
   lang: 'en' | 'ja';
@@ -24,6 +25,11 @@ export type LandingCopy = {
     download: string;
     github: string;
   };
+  install: {
+    label: string;
+    copy: string;
+    copied: string;
+  };
   screenshots: {
     pathEditorAlt: string;
     applyModalAlt: string;
@@ -35,6 +41,12 @@ export type LandingCopy = {
   featuresHeading: string;
   featuresLead: string;
   features: Array<{
+    icon: string;
+    title: string;
+    desc: string;
+  }>;
+  otherFeaturesHeading: string;
+  otherFeatures: Array<{
     icon: string;
     title: string;
     desc: string;
@@ -74,6 +86,11 @@ export const enCopy: LandingCopy = {
     download: `Download v${VERSION} for Windows`,
     github: 'View on GitHub →',
   },
+  install: {
+    label: 'Or install with WinGet:',
+    copy: 'Copy',
+    copied: 'Copied!',
+  },
   screenshots: {
     pathEditorAlt: 'Envarly — PATH editor with per-entry validation and staged change',
     applyModalAlt: 'Envarly — Apply confirmation modal with Full diff view for PATH entries',
@@ -88,13 +105,26 @@ export const enCopy: LandingCopy = {
     {
       icon: '⠿',
       title: 'Practical PATH editor',
-      desc: 'Reorder PATH entries, switch between list and plain text, move through rows with the keyboard, and choose folders without leaving the editor.',
+      desc: 'Reorder entries, validate each one with a live ✓ / ✗ existence check, switch between list and plain text, move through rows with the keyboard, and choose folders — all without leaving the editor.',
     },
     {
-      icon: '✓',
-      title: 'Path validation',
-      desc: 'Each entry in PATH-style variables gets a live ✓ / ✗ existence check so broken paths are caught before you apply.',
+      icon: '⚿',
+      title: 'Secret detection',
+      desc: 'Name-based heuristics and value-pattern matching across 35+ token formats — GitHub, AWS, Anthropic, Stripe, npm, and more.',
     },
+    {
+      icon: '⇄',
+      title: 'Diff detection',
+      desc: 'Detects registry changes made by other processes while Envarly is open. Shows a diff with selective apply per entry.',
+    },
+    {
+      icon: '📸',
+      title: 'Snapshots & demo mode',
+      desc: 'Save named snapshots of your full environment, encrypted with DPAPI. Demo mode opens realistic sample data for screenshots and walkthroughs without touching your registry.',
+    },
+  ],
+  otherFeaturesHeading: 'Also included',
+  otherFeatures: [
     {
       icon: '⚠',
       title: 'Environment guidance',
@@ -104,21 +134,6 @@ export const enCopy: LandingCopy = {
       icon: '↩',
       title: 'Local undo before staging',
       desc: 'Multi-step Ctrl+Z in the detail panel before staging. Drag reorders and text edits are independent undo steps.',
-    },
-    {
-      icon: '⚿',
-      title: 'Secret detection',
-      desc: 'Name-based heuristics and value-pattern matching across 35+ token formats — GitHub, AWS, Anthropic, Stripe, npm, and more.',
-    },
-    {
-      icon: '📸',
-      title: 'Snapshots & demo mode',
-      desc: 'Save named snapshots of your full environment, encrypted with DPAPI. Demo mode opens realistic sample data for screenshots and walkthroughs without touching your registry.',
-    },
-    {
-      icon: '⇄',
-      title: 'Diff detection',
-      desc: 'Detects registry changes made by other processes while Envarly is open. Shows a diff with selective apply per entry.',
     },
     {
       icon: '⏳',
@@ -179,6 +194,11 @@ export const jaCopy: LandingCopy = {
     download: `Windows 版 v${VERSION} をダウンロード`,
     github: 'GitHub で見る →',
   },
+  install: {
+    label: 'または WinGet でインストール:',
+    copy: 'コピー',
+    copied: 'コピーしました！',
+  },
   screenshots: {
     pathEditorAlt: 'Envarly — エントリごとの検証とステージ済み変更を表示する PATH エディター',
     applyModalAlt: 'Envarly — PATH エントリの詳細差分を表示する適用確認モーダル',
@@ -193,13 +213,26 @@ export const jaCopy: LandingCopy = {
     {
       icon: '⠿',
       title: '実用的な PATH エディター',
-      desc: 'PATH エントリの並べ替え、リスト表示とプレーンテキストの切り替え、キーボードでの行移動、フォルダ選択に対応しています。',
+      desc: 'エントリの並べ替え、ライブの ✓ / ✗ 存在チェックによる検証、リスト表示とプレーンテキストの切り替え、キーボードでの行移動、フォルダ選択まで、すべてエディターを離れずに行えます。',
     },
     {
-      icon: '✓',
-      title: 'パス検証',
-      desc: 'PATH 系の各エントリに対して存在チェックを行い、壊れたパスを適用前に見つけられます。',
+      icon: '⚿',
+      title: 'シークレット検出',
+      desc: '変数名のヒューリスティックと値のパターン照合で、GitHub、AWS、Anthropic、Stripe、npm など 35 種類以上のトークン形式を検出します。',
     },
+    {
+      icon: '⇄',
+      title: '外部変更の差分検出',
+      desc: 'Envarly を開いている間に他プロセスがレジストリを変更した場合、差分を検出。項目ごとに受け入れる変更を選べます。',
+    },
+    {
+      icon: '📸',
+      title: 'スナップショットとデモモード',
+      desc: '環境変数全体の名前付きスナップショットを DPAPI で暗号化して保存。デモモードでは、実際のレジストリに触れずにサンプルデータで動作を確認できます。',
+    },
+  ],
+  otherFeaturesHeading: 'そのほかの機能',
+  otherFeatures: [
     {
       icon: '⚠',
       title: '環境変数の説明とガイド',
@@ -209,21 +242,6 @@ export const jaCopy: LandingCopy = {
       icon: '↩',
       title: 'ステージ前のローカル Undo',
       desc: '詳細パネルでステージする前に Ctrl+Z を複数段階使えます。ドラッグでの並べ替えとテキスト編集を別の Undo として扱います。',
-    },
-    {
-      icon: '⚿',
-      title: 'シークレット検出',
-      desc: '変数名のヒューリスティックと値のパターン照合で、GitHub、AWS、Anthropic、Stripe、npm など 35 種類以上のトークン形式を検出します。',
-    },
-    {
-      icon: '📸',
-      title: 'スナップショットとデモモード',
-      desc: '環境変数全体の名前付きスナップショットを DPAPI で暗号化して保存。デモモードでは、実際のレジストリに触れずにサンプルデータで動作を確認できます。',
-    },
-    {
-      icon: '⇄',
-      title: '外部変更の差分検出',
-      desc: 'Envarly を開いている間に他プロセスがレジストリを変更した場合、差分を検出。項目ごとに受け入れる変更を選べます。',
     },
     {
       icon: '⏳',


### PR DESCRIPTION
## Summary

Two changes to the landing page:

1. **WinGet install command**: adds `winget install Envarly.Envarly` with a copy-to-clipboard button under the hero CTAs, now that the submission automation (#149/#152/#153) is live. Scoop isn't included since it hasn't been submitted to a bucket yet.
2. **Feature tiers**: the features grid had 11 items with equal visual weight, mixing headline capabilities with smaller supporting ones — nothing signaled what actually differentiates Envarly at a glance. Split into:
   - A 4-item core grid: Practical PATH editor (now also covering the path-validation checkmarks it absorbed from the old standalone "Path validation" card), Secret detection, Diff detection, Snapshots & demo mode.
   - A denser "Also included" list for the remaining 6: Environment guidance, Local undo, Apply progress & log, Import/Export, Resizable panels, Check command.

Both EN and JA copy updated.

## Test plan

- [x] `astro build` succeeds for both `/` and `/ja/`
- [x] Manually verified both pages render correctly via Playwright screenshots (install block, 4-item core grid, compact "Also included"/"そのほかの機能" list)
- [x] Verified the copy button actually copies `winget install Envarly.Envarly` to the clipboard and shows "Copied!"/"コピーしました！" feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)