### PR TITLE
fix(lp): sync meta description with the reorganized feature tiers, fix stale metadata

### DIFF
--- a/lp/src/layouts/Base.astro
+++ b/lp/src/layouts/Base.astro
@@ -1,21 +1,22 @@
 ---
 import '../styles/global.css';
+import { VERSION } from '../lib/lpContent';
 
 interface Props {
-  title?: string;
-  description?: string;
-  ogDescription?: string;
+  title: string;
+  description: string;
+  ogDescription: string;
   ogImage?: string;
-  lang?: 'en' | 'ja';
-  canonicalPath?: string;
+  lang: 'en' | 'ja';
+  canonicalPath: string;
 }
 
 const {
-  title = 'Envarly — Windows Environment Variable Manager',
-  description = 'Windows environment variable manager — edit PATH, detect secrets, and preview changes before applying. Free & open source on Windows 10 and 11.',
-  ogDescription = 'Windows environment variable manager — edit PATH, detect secrets, and preview changes before applying. Free & open source.',
+  title,
+  description,
+  ogDescription,
   ogImage = '/envarly/og-image.png',
-  lang = 'en',
+  lang,
   canonicalPath,
 } = Astro.props;
 
@@ -33,7 +34,7 @@ const jsonLd = {
   description,
   url: canonicalURL.toString(),
   downloadUrl: 'https://github.com/iray-tno/envarly/releases/latest',
-  softwareVersion: '1.1.0',
+  softwareVersion: VERSION,
   license: 'https://opensource.org/licenses/MIT',
   author: { '@type': 'Person', name: 'iray-tno' },
   inLanguage: lang,

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -69,8 +69,8 @@ export type LandingCopy = {
 export const enCopy: LandingCopy = {
   lang: 'en',
   title: 'Envarly — Windows Environment Variable Manager',
-  description: 'Windows environment variable manager — edit PATH with folder pickers, detect secrets, and preview changes before applying. Free & open source on Windows 10 and 11.',
-  ogDescription: 'Windows environment variable manager — edit PATH with folder pickers, detect secrets, and preview changes before applying. Free & open source.',
+  description: 'Edit Windows environment variables safely — PATH editing with folder pickers, secret detection, change previews, and encrypted snapshots. Free & open source.',
+  ogDescription: 'Edit Windows environment variables safely — PATH editing with folder pickers, secret detection, change previews, and encrypted snapshots. Free & open source.',
   canonicalPath: '/envarly/',
   alternatePath: '/envarly/ja/',
   alternateLabel: '日本語',
@@ -177,8 +177,8 @@ export const enCopy: LandingCopy = {
 export const jaCopy: LandingCopy = {
   lang: 'ja',
   title: 'Envarly — Windows 環境変数マネージャー',
-  description: 'Windows の環境変数を安全に編集できるマネージャー。フォルダ選択付きの PATH 編集、シークレット検出、変更前プレビューに対応。Windows 10 / 11 向けの無料オープンソースアプリです。',
-  ogDescription: 'Windows の環境変数を安全に編集。フォルダ選択付きの PATH 編集、シークレット検出、変更前プレビューに対応した無料オープンソースアプリ。',
+  description: 'Windows の環境変数を安全に編集 — フォルダ選択付きの PATH 編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。無料のオープンソースアプリです。',
+  ogDescription: 'Windows の環境変数を安全に編集 — フォルダ選択付きの PATH 編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。無料のオープンソースアプリです。',
   canonicalPath: '/envarly/ja/',
   alternatePath: '/envarly/',
   alternateLabel: 'English',


### PR DESCRIPTION
## Summary

Three related issues found while reviewing the meta description per your ask:

1. **Description didn't mention snapshots** (one of the four core features from the recent features-tier reorg in #157), and the EN variant was 163 chars — over the ~155-160 char point where Google typically truncates search snippets. Tightened both EN/JA to mention all four core features (PATH editor, secret detection, change previews, encrypted snapshots), and unified `description`/`ogDescription` to the same text since there was no longer a meaningful length difference between them (EN: 157 chars, JA: 88 chars).
2. **`Base.astro` had its own hardcoded default `description`/`ogDescription`** that had drifted out of sync with `lpContent.ts`'s actual copy — dead text, since `LandingPage.astro` always passes both explicitly. Made them required props instead of defaults, so this can't silently drift again.
3. **JSON-LD's `softwareVersion` was hardcoded to `'1.1.0'`** (actual: 1.4.0). Now imports `VERSION` from `lpContent.ts`, which `sync-version.mjs` already keeps current on every release.

## Test plan

- [x] `astro build` succeeds for both `/` and `/ja/`
- [x] Verified rendered HTML: `meta[name=description]`, `og:description`, and JSON-LD `softwareVersion` all show the new/correct values on both locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)