### PR TITLE
fix(AppHeader): stop the narrow layout from overflowing off-screen

### DIFF
--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -94,9 +94,9 @@ export const Narrow: Story = {
     const trigger = await waitFor(() => canvas.getByTestId("header-more-trigger"));
     trigger.click();
     const panel = await waitFor(() => canvas.getByRole("group"));
-    // 3 buttons (GitHub, theme, licenses) + the language <select>.
+    // 5 buttons (import/export, check command, GitHub, theme, licenses) + the language <select>.
     const buttons = within(panel).getAllByRole("button");
-    expect(buttons).toHaveLength(3);
+    expect(buttons).toHaveLength(5);
     expect(within(panel).getByRole("combobox")).toBeVisible();
   },
 };

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -95,10 +95,6 @@ export function AppHeader({
           </Button>
         )}
 
-        <Button variant="ghost" size="sm" onClick={onImportExport}>
-          {t("header.import_export")}
-        </Button>
-
         <Button
           variant={snapshotsOpen ? "secondary" : "ghost"}
           size="sm"
@@ -107,9 +103,15 @@ export function AppHeader({
           {t("header.snapshots")}
         </Button>
 
-        <Button variant="ghost" size="sm" onClick={onCheckCommand}>
-          {t("header.check_command")}
-        </Button>
+        <div className="hidden @5xl:flex items-center gap-1">
+          <Button variant="ghost" size="sm" onClick={onImportExport}>
+            {t("header.import_export")}
+          </Button>
+
+          <Button variant="ghost" size="sm" onClick={onCheckCommand}>
+            {t("header.check_command")}
+          </Button>
+        </div>
       </div>
 
       <div
@@ -221,6 +223,20 @@ export function AppHeader({
                 />
               </div>
             )}
+            <button
+              type="button"
+              onClick={onImportExport}
+              className="flex w-full items-center rounded px-2 py-1.5 text-left text-sm text-muted hover:bg-hover hover:text-fg"
+            >
+              {t("header.import_export")}
+            </button>
+            <button
+              type="button"
+              onClick={onCheckCommand}
+              className="flex w-full items-center rounded px-2 py-1.5 text-left text-sm text-muted hover:bg-hover hover:text-fg"
+            >
+              {t("header.check_command")}
+            </button>
             <div className="flex items-center gap-2 px-2 py-1.5">
               <Icon name="globe" size={14} className="text-dim shrink-0" />
               <Select


### PR DESCRIPTION
## Summary
- At container widths below `@5xl` (1024px), the header's always-visible buttons plus the right-side status items needed ~1124px but only had ~820px available — content silently overflowed past the header's right edge, hiding the "more options" (⋯) trigger and part of the update-available button with no way to reach them.
- Import/Export and Check command both just open a dialog, so they now fold into the same `@5xl` collapse group as GitHub/Language/Theme/Licenses (into the "⋯" menu) instead of staying always-visible.
- Reordered the left cluster so the always-visible items (Refresh/Staged/External changes/Snapshots) sit together, with the newly-collapsible pair adjacent to each other rather than interleaved.
- Updated the `Narrow` story's interaction test to match the dropdown's new contents (5 buttons + language select, up from 3).

Found by actually rendering the `Narrow` Storybook story and screenshotting it at 820px — the existing play-function test still passed because it only checks the DOM, not visibility, so this overflow wasn't caught by CI.

## Test plan
- [x] `vitest run --project=storybook src/components/AppHeader/AppHeader.stories.tsx` — 9/9 passing
- [x] `biome lint src/components/AppHeader` — clean
- [x] Verified via Playwright screenshot at 820px width: header's `scrollWidth` now matches its `clientWidth` (820px, down from 1124px) — no more off-screen content

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>