### PR TITLE
chore: release v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 - **Critical variable warning** — staging changes to `SYSTEMROOT`, `WINDIR`, or `COMSPEC` shows a prominent warning in the Apply confirmation dialog
 - **Secret detection** — name-based + value-pattern detection across 35+ token formats (GitHub `ghp_`, GitLab `glpat-`, Slack `xoxb-`, Anthropic `sk-ant-`, npm `npm_`, PyPI `pypi-`, …); service badge shown on each match; **⚠ Secrets** sidebar tab; export confirmation lists affected services
 - **Admin elevation** — "Run as admin" button restarts the process elevated via UAC; system variables become editable; "Restart as admin →" inline hint appears in the detail panel when viewing a System variable without elevation
+- **Edit other accounts' variables** — when elevated, switch to any local account (including ones not currently logged in) to view/edit its per-user variables and PATH; the header account picker shows "My variables" until one is selected
 - **CLI mode** — read-only subcommands (`get`, `list`, `export`) run from a terminal without launching the GUI
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
 - **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -2,7 +2,7 @@ export const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
-export const VERSION = '1.4.0';
+export const VERSION = '1.5.0';
 export const WINGET_COMMAND = 'winget install Envarly.Envarly';
 
 export type LandingCopy = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envarly",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envarly",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/tauri.mjs dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.4.0"
+version = "1.5.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
## Summary
Version bump 1.4.0 → 1.5.0 (minor, per new user-facing feature since the last release).

Since v1.4.0:
- **feat:** edit other local accounts' environment variables while elevated, including PATH tooling (#62)
- **feat:** WinGet manifest auto-submission on release
- **fix:** AppHeader narrow-layout overflow, header item ordering/collapse, sidebar icon placement
- **fix:** 3 environment-diagnostic false positives
- LP: WinGet install command copy, GA4 event tracking, meta description sync

## Changes
- `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `lpContent.ts` version → 1.5.0 (via `npm version minor` / `sync-version.mjs`, verified with `npm run check-version`)
- Added a README bullet for the new account-switch feature

## Next steps after merge
- Tag `v1.5.0` on the merge commit and push to trigger the release workflow
- Verify the release build artifacts
- Write release notes, then publish (triggers WinGet submission automatically)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>