### PR TITLE
fix(lp): mention GUI explicitly in the meta description

### DIFF
--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -69,8 +69,8 @@ export type LandingCopy = {
 export const enCopy: LandingCopy = {
   lang: 'en',
   title: 'Envarly — Windows Environment Variable Manager',
-  description: 'Edit Windows environment variables safely — PATH editing with folder pickers, secret detection, change previews, and encrypted snapshots. Free & open source.',
-  ogDescription: 'Edit Windows environment variables safely — PATH editing with folder pickers, secret detection, change previews, and encrypted snapshots. Free & open source.',
+  description: 'A free, open-source GUI for Windows environment variables — safe PATH editing with folder pickers, secret detection, change previews, encrypted snapshots.',
+  ogDescription: 'A free, open-source GUI for Windows environment variables — safe PATH editing with folder pickers, secret detection, change previews, encrypted snapshots.',
   canonicalPath: '/envarly/',
   alternatePath: '/envarly/ja/',
   alternateLabel: '日本語',
@@ -177,8 +177,8 @@ export const enCopy: LandingCopy = {
 export const jaCopy: LandingCopy = {
   lang: 'ja',
   title: 'Envarly — Windows 環境変数マネージャー',
-  description: 'Windows の環境変数を安全に編集 — フォルダ選択付きの PATH 編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。無料のオープンソースアプリです。',
-  ogDescription: 'Windows の環境変数を安全に編集 — フォルダ選択付きの PATH 編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。無料のオープンソースアプリです。',
+  description: '無料のオープンソースGUIでWindowsの環境変数を安全に編集 — フォルダ選択付きのPATH編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。',
+  ogDescription: '無料のオープンソースGUIでWindowsの環境変数を安全に編集 — フォルダ選択付きのPATH編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。',
   canonicalPath: '/envarly/ja/',
   alternatePath: '/envarly/',
   alternateLabel: 'English',


### PR DESCRIPTION
## Summary
The English and Japanese meta descriptions never used the word "GUI", missing an exact-match opportunity for searches like "environment variable editor gui". This matters specifically here because Windows' own built-in System Properties dialog for editing env vars is itself a GUI, so people looking for an *alternative* to it tend to search with "gui" explicitly in the query.

Reworded both descriptions to lead with "free, open-source GUI" while keeping all four existing feature mentions (folder pickers, secret detection, change previews, encrypted snapshots):

- en: "A free, open-source GUI for Windows environment variables — safe PATH editing with folder pickers, secret detection, change previews, encrypted snapshots." (154 chars, was 157 without "GUI")
- ja: "無料のオープンソースGUIでWindowsの環境変数を安全に編集 — フォルダ選択付きのPATH編集、シークレット検出、変更プレビュー、暗号化スナップショットに対応。" (83 chars, was 88)

Both fit under the ~155-char practical limit for search snippets. `description` feeds `<meta name="description">`, `og:description`, `twitter:description`, and the JSON-LD `description` field all from one source, so this one change propagates everywhere.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified compiled `dist/index.html` and `dist/ja/index.html` both render the new description in the meta tag

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>