### PR TITLE
chore: release v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
 - **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts
 - **Check command** — find out why a command isn't found: searches the effective PATH (User + System merged, PATHEXT-aware) for a name or exe path and flags shadowed duplicates
+- **6 languages** — English, 日本語, 简体中文, Русский, 한국어, and Tiếng Việt; switch anytime from the header, including the ~150 built-in variable descriptions
 
 ## Stack
 

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -2,7 +2,7 @@ export const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
-export const VERSION = '1.5.0';
+export const VERSION = '1.6.0';
 export const WINGET_COMMAND = 'winget install Envarly.Envarly';
 
 export type LandingLang = 'en' | 'ja' | 'zh-CN' | 'ru' | 'ko' | 'vi';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envarly",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envarly",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/tauri.mjs dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.5.0"
+version = "1.6.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
## Summary
Version bump 1.5.0 → 1.6.0 (minor, per one standout user-facing feature since the last release).

Since v1.5.0:
- **feat:** 4 new app UI languages — Simplified Chinese, Russian, Korean, Vietnamese (6 languages total now)
- LP: localized landing pages for the same 4 languages, GA4 conversion tracking, meta description fix
- **feat:** automated screenshot + walkthrough-video regeneration pipeline (`media/`), wired into README and the LP carousel
- chore: npm audit fixes (root + lp), added missing lp audit coverage to CI

## Changes
- `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `lpContent.ts` version → 1.6.0 (via `npm version minor` / `sync-version.mjs`, verified with `npm run check-version`)
- Added a README bullet for the 6-language support

## Next steps after merge
- Tag `v1.6.0` on the merge commit and push to trigger the release workflow
- Verify the release build artifacts
- Write release notes, then publish (triggers WinGet submission automatically)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>