### PR TITLE
chore: fix npm audit vulnerability (js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5606,9 +5606,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
`security.yml`'s `npm-audit` job was failing on main again — one high severity issue this time: `js-yaml` (quadratic CPU consumption in `!!omap` resolution, CVE-2026-59870). Fix was available within the existing `package.json` semver range — lockfile-only change, no `package.json` edits.

## Test plan
- [x] `npm audit`: 0 vulnerabilities
- [x] `tsc --noEmit`, `npm run lint`, `npm test`: all pass (289/289)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>