### PR TITLE
chore: fix npm audit vulnerability (nanoid)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6360,9 +6360,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
`security.yml`'s `npm-audit` job caught another newly-disclosed transitive-dep CVE — `nanoid` this time (custom generators can loop indefinitely when size is zero). Fix was available within the existing `package.json` semver range — lockfile-only change, no `package.json` edits.

This is the third such fix in the last few days (previously brace-expansion/undici in #170, js-yaml in #174) — the weekly/on-push audit schedule is doing exactly what it's for, catching newly-disclosed advisories in fast-moving transitive deps rather than anything wrong with our own code.

## Test plan
- [x] `npm audit`: 0 vulnerabilities
- [x] `tsc --noEmit`, `npm run lint`, `npm test`: all pass (289/289)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>