### PR TITLE
docs: add a privacy note to README and the LP footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Windows environment variable manager built with Tauri v2, React, TypeScript, and
 
 ![Envarly walkthrough: fixing a broken PATH entry, staging the change, and reviewing the diff before applying it](docs/walkthrough.gif)
 
+## Privacy
+
+Envarly collects no telemetry and sends no data anywhere. The only network request the app makes is a passive daily check against the GitHub Releases API for a newer version — it sends nothing about you or your machine, just a GET request.
+
+(The [landing page](https://iray-tno.github.io/envarly/) uses standard web analytics to understand traffic — that's separate from the app itself, which has none.)
+
 ## Features
 
 - **2-pane UI** — sidebar variable list with search/filter and scope tabs (All / User / System), detail editor on the right

--- a/lp/src/components/LandingPage.astro
+++ b/lp/src/components/LandingPage.astro
@@ -321,6 +321,9 @@ const { copy } = Astro.props;
 
   <!-- Footer -->
   <footer class="border-t border-[var(--color-border)] mt-12">
+    <p class="mx-auto max-w-2xl px-6 pt-6 text-xs text-[var(--color-muted)] text-center leading-relaxed">
+      {copy.privacyNote}
+    </p>
     <div class="mx-auto max-w-5xl px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
       <span class="text-xs text-[var(--color-muted)]">{copy.footer.copyright}</span>
       <div class="flex items-center gap-6">

--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -70,6 +70,7 @@ export type LandingCopy = {
     label: string;
     items: string[];
   };
+  privacyNote: string;
   footer: {
     copyright: string;
     releases: string;
@@ -178,6 +179,7 @@ export const enCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: "No telemetry in the app — its only network call is a daily version check against GitHub. (This website uses analytics; the app doesn't.)",
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: 'Releases',
@@ -286,6 +288,7 @@ export const jaCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: 'アプリ本体にテレメトリはありません — 唯一の通信は GitHub への日次バージョンチェックだけです。(この Web サイトはアクセス解析を使っていますが、アプリ本体は使っていません。)',
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: 'リリース',
@@ -394,6 +397,7 @@ export const zhCNCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: '应用本身不含任何遥测 — 唯一的网络请求是每天向 GitHub 检查新版本。（本网站使用网站访问分析，应用本身不使用。）',
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: '发行版',
@@ -502,6 +506,7 @@ export const ruCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: 'В приложении нет телеметрии — единственный сетевой запрос — ежедневная проверка новой версии на GitHub. (Этот сайт использует веб-аналитику, само приложение — нет.)',
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: 'Релизы',
@@ -610,6 +615,7 @@ export const koCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: '앱에는 텔레메트리가 없습니다 — 유일한 네트워크 요청은 GitHub에서 매일 새 버전을 확인하는 것뿐입니다. (이 웹사이트는 방문자 분석을 사용하지만, 앱 자체는 사용하지 않습니다.)',
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: '릴리스',
@@ -718,6 +724,7 @@ export const viCopy: LandingCopy = {
     label: 'Built with',
     items: ['Tauri v2', 'React 19', 'TypeScript', 'Tailwind CSS v4', 'Rust'],
   },
+  privacyNote: 'Ứng dụng không thu thập dữ liệu từ xa — yêu cầu mạng duy nhất là kiểm tra phiên bản mới hằng ngày trên GitHub. (Trang web này sử dụng công cụ phân tích truy cập, bản thân ứng dụng thì không.)',
   footer: {
     copyright: '© 2026 Envarly · MIT License',
     releases: 'Bản phát hành',


### PR DESCRIPTION
## Summary
The app handles sensitive local data (registry values, and it has a whole secret-detection feature for tokens/keys/passwords), so privacy-conscious users specifically wonder about telemetry. Verified the claim before writing anything:
- Grepped `src-tauri/src` for network calls: exactly one, `commands/update.rs`'s daily GitHub Releases check — a GET request, no payload.
- Grepped `src` for analytics SDKs: none. The `SENTRY_` matches in `secrets.ts` are the secret-detection feature recognizing Sentry DSN tokens as a service to flag, not Envarly using Sentry itself.

## Changes
- `README.md`: new "Privacy" section.
- LP: new `privacyNote` field on `LandingCopy` (all 6 languages), rendered as a small line in the footer, above the copyright row.

Worded carefully to avoid two gotchas:
1. Conflating "no telemetry" with "zero network calls" — the daily update check is real, just payload-free, and the copy says so explicitly rather than claiming no network activity at all.
2. Staying silent about the LP's own GA4/Clarity usage — disclosed rather than hidden, since it's a different surface (marketing site) from the app itself, and pretending otherwise would look evasive if someone noticed independently.

## Test plan
- [x] `lp/npm run build` succeeds for all 6 locale pages
- [x] Drove the built LP in a real browser (`astro preview` + Playwright) and screenshotted the footer — note renders cleanly, doesn't crowd the copyright/links row

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>