### PR TITLE
feat(cli): add envarly import subcommand (issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Envarly collects no telemetry and sends no data anywhere. The only network reque
 - **Secret detection** — name-based + value-pattern detection across 35+ token formats (GitHub `ghp_`, GitLab `glpat-`, Slack `xoxb-`, Anthropic `sk-ant-`, npm `npm_`, PyPI `pypi-`, …); service badge shown on each match; **⚠ Secrets** sidebar tab; export confirmation lists affected services
 - **Admin elevation** — "Run as admin" button restarts the process elevated via UAC; system variables become editable; "Restart as admin →" inline hint appears in the detail panel when viewing a System variable without elevation
 - **Edit other accounts' variables** — when elevated, switch to any local account (including ones not currently logged in) to view/edit its per-user variables and PATH; the header account picker shows "My variables" until one is selected
-- **CLI mode** — read-only subcommands (`get`, `list`, `export`) run from a terminal without launching the GUI
+- **CLI mode** — read-only subcommands (`get`, `list`, `export`) plus `import` (merge/replace from a `.json`/`.reg` file) run from a terminal without launching the GUI; `import` is dry-run by default and only writes to the registry when passed `--apply`
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
 - **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts
 - **Check command** — find out why a command isn't found: searches the effective PATH (User + System merged, PATHEXT-aware) for a name or exe path and flags shadowed duplicates
@@ -151,6 +151,13 @@ envarly export --format dsc_v2   --output backup.ps1      # PowerShell DSC v2 co
 envarly export --format dsc_v3   --output backup.dsc.yaml # DSC v3 YAML
 envarly export --format ansible  --output backup.yml      # Ansible environment playbook
 envarly export --format json | jq '.user.PATH'
+
+# Import from a file — dry-run by default (prints the diff, writes nothing)
+envarly import backup.json
+envarly import backup.reg --format reg --scope user --strategy replace
+
+# Add --apply to actually write the changes to the registry
+envarly import backup.json --apply
 ```
 
 ## Demo mode

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::model::{EnvSnapshot, VarScope};
 /// Read-only CLI commands. No subcommand → the caller launches the GUI instead.
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -38,6 +39,23 @@ enum Command {
         #[arg(short, long)]
         output: Option<std::path::PathBuf>,
     },
+    /// Import environment variables from a previously exported file. Dry-run
+    /// by default — nothing is written to the registry unless --apply is
+    /// passed.
+    Import {
+        /// Path to a previously exported .json or .reg file
+        file: std::path::PathBuf,
+        #[arg(long, value_enum, default_value_t = ImportFormat::Json)]
+        format: ImportFormat,
+        #[arg(long, value_enum, default_value_t = ScopeArg::All)]
+        scope: ScopeArg,
+        #[arg(long, value_enum, default_value_t = StrategyArg::Merge)]
+        strategy: StrategyArg,
+        /// Actually write the changes to the registry. Without this flag,
+        /// only prints what would change.
+        #[arg(long)]
+        apply: bool,
+    },
     /// Internal: remove Envarly install directory from PATH. Called by the uninstaller.
     #[command(name = "path-cleanup", hide = true)]
     PathCleanup {
@@ -73,6 +91,20 @@ enum ExportFormat {
     Ansible,
 }
 
+#[derive(Clone, ValueEnum, Default)]
+enum ImportFormat {
+    #[default]
+    Json,
+    Reg,
+}
+
+#[derive(Clone, ValueEnum, Default)]
+enum StrategyArg {
+    #[default]
+    Merge,
+    Replace,
+}
+
 /// Parse CLI args and execute the subcommand. Never returns — exits the process.
 /// Only called when args.len() > 1.
 pub fn run() -> ! {
@@ -88,7 +120,6 @@ pub fn run() -> ! {
 fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
     use crate::env_store;
     use crate::export;
-    use crate::model::VarScope;
 
     match command {
         Command::Get { name, scope } => {
@@ -171,7 +202,126 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
                 None => print!("{}", content),
             }
         }
+
+        Command::Import {
+            file,
+            format,
+            scope,
+            strategy,
+            apply,
+        } => {
+            use crate::import::{diff_for_import, ImportStrategy};
+            use crate::model::EnvChange;
+
+            let content =
+                std::fs::read_to_string(&file).map_err(crate::error::EnvarlyError::Registry)?;
+            let imported = match format {
+                ImportFormat::Json => export::parse_json(&content)?,
+                ImportFormat::Reg => export::parse_reg(&content)?,
+            };
+            let current = env_store::read_snapshot()?;
+            let scopes: Vec<VarScope> = match scope {
+                ScopeArg::All => vec![VarScope::User, VarScope::System],
+                ScopeArg::User => vec![VarScope::User],
+                ScopeArg::System => vec![VarScope::System],
+            };
+            let import_strategy = match strategy {
+                StrategyArg::Merge => ImportStrategy::Merge,
+                StrategyArg::Replace => ImportStrategy::Replace,
+            };
+            let changes = diff_for_import(&current, &imported, &scopes, import_strategy);
+
+            if changes.is_empty() {
+                println!("Already up to date — nothing to change.");
+                return Ok(());
+            }
+
+            let strategy_label = match strategy {
+                StrategyArg::Merge => "merge",
+                StrategyArg::Replace => "replace",
+            };
+            let scope_label = match scope {
+                ScopeArg::All => "All",
+                ScopeArg::User => "User",
+                ScopeArg::System => "System",
+            };
+            println!(
+                "{} {} change{} ({}, scope: {}):",
+                if apply { "Applying" } else { "Would apply" },
+                changes.len(),
+                if changes.len() == 1 { "" } else { "s" },
+                strategy_label,
+                scope_label,
+            );
+            for change in &changes {
+                match change {
+                    EnvChange::Set {
+                        name, value, scope, ..
+                    } => match current_value(&current, scope, name) {
+                        Some(old) if old != value => {
+                            println!(
+                                "  ~ {}={} (was {})  [{}]",
+                                name,
+                                value,
+                                old,
+                                scope_tag(scope)
+                            )
+                        }
+                        Some(_) => println!("  ~ {}={}  [{}]", name, value, scope_tag(scope)),
+                        None => println!("  + {}={}  [{}]", name, value, scope_tag(scope)),
+                    },
+                    EnvChange::Delete { name, scope } => {
+                        println!("  - {}  [{}]", name, scope_tag(scope))
+                    }
+                }
+            }
+
+            if !apply {
+                println!("\nRun with --apply to write these changes to the registry.");
+                return Ok(());
+            }
+
+            println!();
+            let result = env_store::apply_changes(&changes, |index, total, change, result| {
+                let name = match change {
+                    EnvChange::Set { name, .. } | EnvChange::Delete { name, .. } => name,
+                };
+                match result {
+                    Ok(()) => println!("  [{}/{}] ok {}", index + 1, total, name),
+                    Err(e) => println!("  [{}/{}] FAILED {} ({})", index + 1, total, name, e),
+                }
+            });
+
+            match result {
+                Ok(()) => println!(
+                    "\nApplied {} change{}.",
+                    changes.len(),
+                    if changes.len() == 1 { "" } else { "s" }
+                ),
+                Err(e) => {
+                    eprintln!("\nApply failed, rolled back: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
     }
 
     Ok(())
+}
+
+fn current_value<'a>(current: &'a EnvSnapshot, scope: &VarScope, name: &str) -> Option<&'a str> {
+    let map = match scope {
+        VarScope::User => &current.user,
+        VarScope::System => &current.system,
+        VarScope::OtherUser => return None,
+    };
+    map.get(name).map(|v| v.value.as_str())
+}
+
+fn scope_tag(scope: &VarScope) -> &'static str {
+    match scope {
+        VarScope::User => "User",
+        VarScope::System => "System",
+        VarScope::OtherUser => "OtherUser",
+    }
 }

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -1,0 +1,327 @@
+//! Computes the diff (as `EnvChange`s) between the current registry state and
+//! an imported `EnvSnapshot`, for `envarly import`. Backend-agnostic and pure
+//! — no registry access here, so it's fully covered by unit tests alone.
+//!
+//! This mirrors the merge/replace semantics the GUI computes in the frontend
+//! (`src/hooks/stagingLogic.ts` / `src/lib/diff.ts`), but is a separate,
+//! CLI-only implementation: the CLI has no JS runtime to call into, and the
+//! frontend logic is left untouched.
+
+use std::collections::HashMap;
+
+use crate::model::{EnvChange, EnvSnapshot, EnvValue, EnvValueKind, VarScope};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportStrategy {
+    Merge,
+    Replace,
+}
+
+/// `%[^%]+%` — mirrors `src/lib/envValueKind.ts`'s `inferEnvValueKind`, used
+/// when an imported entry has no registry type (legacy export format).
+///
+/// Two consecutive `%` occurrences with more than 1 byte between them (i.e.
+/// at least one non-`%` byte in between, since `%` is single-byte ASCII and
+/// "consecutive" already rules out another `%` in that gap) is exactly a
+/// `%[^%]+%` match — this avoids pulling in the `regex` crate for one
+/// heuristic, and avoids manual byte-slicing (which would risk panicking on
+/// a non-char-boundary index for non-ASCII values).
+pub fn infer_env_value_kind(value: &str) -> EnvValueKind {
+    let positions: Vec<usize> = value.match_indices('%').map(|(i, _)| i).collect();
+    let has_reference = positions.windows(2).any(|w| w[1] > w[0] + 1);
+    if has_reference {
+        EnvValueKind::ExpandString
+    } else {
+        EnvValueKind::String
+    }
+}
+
+fn resolve_kind(value: &EnvValue) -> EnvValueKind {
+    value
+        .kind
+        .unwrap_or_else(|| infer_env_value_kind(&value.value))
+}
+
+fn scope_map(snapshot: &EnvSnapshot, scope: VarScope) -> Option<&HashMap<String, EnvValue>> {
+    match scope {
+        VarScope::User => Some(&snapshot.user),
+        VarScope::System => Some(&snapshot.system),
+        VarScope::OtherUser => snapshot.other_user.as_ref(),
+    }
+}
+
+/// Diff `imported` against `current`, restricted to `scopes`. `current` is
+/// the live registry snapshot; `imported` is what was parsed from the file.
+pub fn diff_for_import(
+    current: &EnvSnapshot,
+    imported: &EnvSnapshot,
+    scopes: &[VarScope],
+    strategy: ImportStrategy,
+) -> Vec<EnvChange> {
+    let mut changes = Vec::new();
+
+    for scope in scopes {
+        let current_map = scope_map(current, scope.clone())
+            .cloned()
+            .unwrap_or_default();
+        let imported_map = scope_map(imported, scope.clone())
+            .cloned()
+            .unwrap_or_default();
+
+        for (name, value) in &imported_map {
+            let value_kind = resolve_kind(value);
+            let unchanged = current_map.get(name).is_some_and(|existing| {
+                existing.value == value.value && resolve_kind(existing) == value_kind
+            });
+            if !unchanged {
+                changes.push(EnvChange::Set {
+                    name: name.clone(),
+                    value: value.value.clone(),
+                    value_kind,
+                    scope: scope.clone(),
+                });
+            }
+        }
+
+        if strategy == ImportStrategy::Replace {
+            for name in current_map.keys() {
+                if !imported_map.contains_key(name) {
+                    changes.push(EnvChange::Delete {
+                        name: name.clone(),
+                        scope: scope.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(user: &[(&str, &str)], system: &[(&str, &str)]) -> EnvSnapshot {
+        EnvSnapshot {
+            user: user
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_string(),
+                        EnvValue::typed(v.to_string(), EnvValueKind::String),
+                    )
+                })
+                .collect(),
+            system: system
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_string(),
+                        EnvValue::typed(v.to_string(), EnvValueKind::String),
+                    )
+                })
+                .collect(),
+            other_user: None,
+        }
+    }
+
+    #[test]
+    fn infers_expand_string_for_var_reference() {
+        assert_eq!(
+            infer_env_value_kind("%USERPROFILE%\\bin"),
+            EnvValueKind::ExpandString
+        );
+        assert_eq!(
+            infer_env_value_kind("C:\\Program Files"),
+            EnvValueKind::String
+        );
+        assert_eq!(infer_env_value_kind("100%"), EnvValueKind::String); // lone %, no closing
+        assert_eq!(infer_env_value_kind("%%"), EnvValueKind::String); // adjacent %s, empty middle
+        assert_eq!(infer_env_value_kind("%%FOO%"), EnvValueKind::ExpandString); // valid pair after an empty one
+    }
+
+    #[test]
+    fn merge_adds_new_and_updates_changed_leaves_extra_alone() {
+        let current = snap(&[("KEEP_ME", "1"), ("CHANGE_ME", "old")], &[]);
+        let imported = snap(&[("NEW_VAR", "v"), ("CHANGE_ME", "new")], &[]);
+
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Merge,
+        );
+
+        assert_eq!(changes.len(), 2);
+        assert!(changes.contains(&EnvChange::Set {
+            name: "NEW_VAR".into(),
+            value: "v".into(),
+            value_kind: EnvValueKind::String,
+            scope: VarScope::User,
+        }));
+        assert!(changes.contains(&EnvChange::Set {
+            name: "CHANGE_ME".into(),
+            value: "new".into(),
+            value_kind: EnvValueKind::String,
+            scope: VarScope::User,
+        }));
+        // KEEP_ME is untouched: no Set, no Delete.
+        assert!(!changes.iter().any(|c| matches!(c, EnvChange::Set { name, .. } | EnvChange::Delete { name, .. } if name == "KEEP_ME")));
+    }
+
+    #[test]
+    fn merge_with_no_differences_produces_no_changes() {
+        let current = snap(&[("SAME", "1")], &[]);
+        let imported = snap(&[("SAME", "1")], &[]);
+        assert!(diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Merge
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn replace_deletes_entries_missing_from_import() {
+        let current = snap(&[("KEEP_ME", "1"), ("REMOVE_ME", "gone")], &[]);
+        let imported = snap(&[("KEEP_ME", "1")], &[]);
+
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Replace,
+        );
+
+        assert_eq!(
+            changes,
+            vec![EnvChange::Delete {
+                name: "REMOVE_ME".into(),
+                scope: VarScope::User
+            }]
+        );
+    }
+
+    #[test]
+    fn scope_filter_ignores_other_scopes_in_both_snapshots() {
+        let current = snap(&[("U", "1")], &[("S", "1")]);
+        let imported = snap(&[("U", "2")], &[("S", "2")]);
+
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Merge,
+        );
+
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            &changes[0],
+            EnvChange::Set {
+                scope: VarScope::User,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn legacy_entry_without_kind_falls_back_to_inference() {
+        let current = EnvSnapshot {
+            user: HashMap::new(),
+            system: HashMap::new(),
+            other_user: None,
+        };
+        let mut imported = EnvSnapshot {
+            user: HashMap::new(),
+            system: HashMap::new(),
+            other_user: None,
+        };
+        imported.user.insert(
+            "PATHLIKE".into(),
+            EnvValue {
+                value: "%USERPROFILE%\\bin".into(),
+                kind: None,
+            },
+        );
+
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Merge,
+        );
+
+        assert_eq!(
+            changes,
+            vec![EnvChange::Set {
+                name: "PATHLIKE".into(),
+                value: "%USERPROFILE%\\bin".into(),
+                value_kind: EnvValueKind::ExpandString,
+                scope: VarScope::User,
+            }]
+        );
+    }
+
+    // --- End-to-end: parse -> diff -> apply, against MemBackend only.
+    // Zero real-registry interaction anywhere in this test.
+
+    #[test]
+    fn end_to_end_merge_applies_only_the_diff() {
+        use crate::env_store::{apply_changes_with, read_snapshot_with, MemBackend};
+        use crate::export::parse_json;
+
+        let backend = MemBackend::new().with_user([("KEEP_ME", "1"), ("CHANGE_ME", "old")]);
+
+        let file_contents = r#"{
+            "version": 2,
+            "user": {
+                "CHANGE_ME": { "value": "new", "kind": "String" },
+                "NEW_VAR": { "value": "v", "kind": "String" }
+            }
+        }"#;
+        let imported = parse_json(file_contents).expect("valid fixture JSON");
+        let current = read_snapshot_with(&backend).expect("read from MemBackend");
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Merge,
+        );
+
+        apply_changes_with(&backend, &changes, |_, _, _, _| {}).expect("apply against MemBackend");
+
+        let result = read_snapshot_with(&backend).expect("read back");
+        assert_eq!(result.user.len(), 3);
+        assert_eq!(result.user["KEEP_ME"].value, "1"); // untouched by merge
+        assert_eq!(result.user["CHANGE_ME"].value, "new");
+        assert_eq!(result.user["NEW_VAR"].value, "v");
+    }
+
+    #[test]
+    fn end_to_end_replace_deletes_what_merge_would_have_kept() {
+        use crate::env_store::{apply_changes_with, read_snapshot_with, MemBackend};
+        use crate::export::parse_json;
+
+        let backend = MemBackend::new().with_user([("KEEP_ME", "1"), ("REMOVE_ME", "gone")]);
+
+        let file_contents =
+            r#"{ "version": 2, "user": { "KEEP_ME": { "value": "1", "kind": "String" } } }"#;
+        let imported = parse_json(file_contents).expect("valid fixture JSON");
+        let current = read_snapshot_with(&backend).expect("read from MemBackend");
+        let changes = diff_for_import(
+            &current,
+            &imported,
+            &[VarScope::User],
+            ImportStrategy::Replace,
+        );
+
+        apply_changes_with(&backend, &changes, |_, _, _, _| {}).expect("apply against MemBackend");
+
+        let result = read_snapshot_with(&backend).expect("read back");
+        assert_eq!(result.user.len(), 1);
+        assert!(result.user.contains_key("KEEP_ME"));
+        assert!(!result.user.contains_key("REMOVE_ME"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod env_backend;
 mod env_store;
 mod error;
 pub mod export;
+mod import;
 mod model;
 #[cfg(windows)]
 mod path_backend;


### PR DESCRIPTION
## Summary
- Adds `envarly import <file>` — the CLI's first write capability, closing issue #6.
- Dry-run by default: parses the file, diffs it against the current registry, and prints a `+`/`~`/`-` summary without touching the registry. Only writes when `--apply` is passed.
- Supports `--format json|reg`, `--scope all|user|system`, `--strategy merge|replace`, mirroring the GUI's existing merge/replace semantics.
- New `src-tauri/src/import.rs`: a pure, backend-agnostic `diff_for_import` function (plus a ported `infer_env_value_kind` for legacy no-kind entries). Reuses existing `export::parse_json`/`parse_reg` and `env_store::apply_changes_with` rather than duplicating logic.
- Frontend/GUI diff logic (`src/hooks/stagingLogic.ts`, `src/lib/diff.ts`) is untouched — this is a separate, CLI-only implementation since the CLI has no JS runtime to call into.

## Test plan
- [x] `cargo test` — 102 passed, 1 pre-existing ignored (unrelated manual smoke test); new `import::` tests cover merge/replace/scope-filtering/legacy-kind-inference, plus two end-to-end parse→diff→apply tests against `MemBackend` (zero real-registry interaction anywhere in the automated suite)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [ ] Manual dry-run smoke test against a real exported file (read-only, safe by construction)
- [ ] Optional manual `--apply` smoke test with a single disposable User-scope variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)