### PR TITLE
feat(cli): add envarly set / envarly delete for single-variable writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Envarly collects no telemetry and sends no data anywhere. The only network reque
 - **Secret detection** — name-based + value-pattern detection across 35+ token formats (GitHub `ghp_`, GitLab `glpat-`, Slack `xoxb-`, Anthropic `sk-ant-`, npm `npm_`, PyPI `pypi-`, …); service badge shown on each match; **⚠ Secrets** sidebar tab; export confirmation lists affected services
 - **Admin elevation** — "Run as admin" button restarts the process elevated via UAC; system variables become editable; "Restart as admin →" inline hint appears in the detail panel when viewing a System variable without elevation
 - **Edit other accounts' variables** — when elevated, switch to any local account (including ones not currently logged in) to view/edit its per-user variables and PATH; the header account picker shows "My variables" until one is selected
-- **CLI mode** — read-only subcommands (`get`, `list`, `export`) plus `import` (merge/replace from a `.json`/`.reg` file) run from a terminal without launching the GUI; `import` is dry-run by default and only writes to the registry when passed `--apply`
+- **CLI mode** — read-only subcommands (`get`, `list`, `export`) plus write subcommands `import` (merge/replace from a `.json`/`.reg` file), `set`, and `delete` (single variable) run from a terminal without launching the GUI; every write subcommand is dry-run by default and only touches the registry when passed `--apply`
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
 - **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts
 - **Check command** — find out why a command isn't found: searches the effective PATH (User + System merged, PATHEXT-aware) for a name or exe path and flags shadowed duplicates
@@ -158,6 +158,12 @@ envarly import backup.reg --format reg --scope user --strategy replace
 
 # Add --apply to actually write the changes to the registry
 envarly import backup.json --apply
+
+# Set or delete a single variable — same dry-run-by-default / --apply model.
+# Unlike `setx`, this broadcasts WM_SETTINGCHANGE so running processes see the change.
+envarly set JAVA_HOME C:\jdk21 --scope user --apply
+envarly set MY_PATH "%JAVA_HOME%\bin" --kind expand-string --apply
+envarly delete OLD_VAR --scope user --apply
 ```
 
 ## Demo mode

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::model::{EnvSnapshot, VarScope};
+use crate::model::{EnvChange, EnvSnapshot, VarScope};
 /// Read-only CLI commands. No subcommand → the caller launches the GUI instead.
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -56,6 +56,34 @@ enum Command {
         #[arg(long)]
         apply: bool,
     },
+    /// Set a single environment variable. Dry-run by default — nothing is
+    /// written unless --apply is passed.
+    Set {
+        /// Variable name (matched case-sensitively against the registry, like `import`)
+        name: String,
+        /// New value
+        value: String,
+        #[arg(long, value_enum, default_value_t = WriteScopeArg::User)]
+        scope: WriteScopeArg,
+        #[arg(long, value_enum, default_value_t = KindArg::Auto)]
+        kind: KindArg,
+        /// Actually write the change to the registry. Without this flag,
+        /// only prints what would change.
+        #[arg(long)]
+        apply: bool,
+    },
+    /// Delete a single environment variable. Dry-run by default — nothing is
+    /// written unless --apply is passed.
+    Delete {
+        /// Variable name (matched case-sensitively against the registry, like `import`)
+        name: String,
+        #[arg(long, value_enum, default_value_t = WriteScopeArg::User)]
+        scope: WriteScopeArg,
+        /// Actually write the change to the registry. Without this flag,
+        /// only prints what would change.
+        #[arg(long)]
+        apply: bool,
+    },
     /// Internal: remove Envarly install directory from PATH. Called by the uninstaller.
     #[command(name = "path-cleanup", hide = true)]
     PathCleanup {
@@ -103,6 +131,22 @@ enum StrategyArg {
     #[default]
     Merge,
     Replace,
+}
+
+/// Scope for a single-variable write. No `All` — a write always targets one scope.
+#[derive(Clone, ValueEnum, Default)]
+enum WriteScopeArg {
+    #[default]
+    User,
+    System,
+}
+
+#[derive(Clone, Copy, ValueEnum, Default)]
+enum KindArg {
+    #[default]
+    Auto,
+    String,
+    ExpandString,
 }
 
 /// Parse CLI args and execute the subcommand. Never returns — exits the process.
@@ -211,7 +255,6 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
             apply,
         } => {
             use crate::import::{diff_for_import, ImportStrategy};
-            use crate::model::EnvChange;
 
             let content =
                 std::fs::read_to_string(&file).map_err(crate::error::EnvarlyError::Registry)?;
@@ -276,37 +319,113 @@ fn execute(command: Command) -> Result<(), crate::error::EnvarlyError> {
                 }
             }
 
-            if !apply {
-                println!("\nRun with --apply to write these changes to the registry.");
+            write_changes(&changes, apply)?;
+        }
+
+        Command::Set {
+            name,
+            value,
+            scope,
+            kind,
+            apply,
+        } => {
+            let write_scope = match scope {
+                WriteScopeArg::User => VarScope::User,
+                WriteScopeArg::System => VarScope::System,
+            };
+            let current = env_store::read_snapshot()?;
+            let existing = current_entry(&current, &write_scope, &name);
+            let value_kind = crate::import::resolve_set_kind(explicit_kind(kind), &value, existing);
+
+            let unchanged = existing
+                .is_some_and(|e| e.value == value && crate::import::resolve_kind(e) == value_kind);
+            if unchanged {
+                println!("Already up to date — nothing to change.");
                 return Ok(());
             }
 
-            println!();
-            let result = env_store::apply_changes(&changes, |index, total, change, result| {
-                let name = match change {
-                    EnvChange::Set { name, .. } | EnvChange::Delete { name, .. } => name,
-                };
-                match result {
-                    Ok(()) => println!("  [{}/{}] ok {}", index + 1, total, name),
-                    Err(e) => println!("  [{}/{}] FAILED {} ({})", index + 1, total, name, e),
-                }
-            });
-
-            match result {
-                Ok(()) => println!(
-                    "\nApplied {} change{}.",
-                    changes.len(),
-                    if changes.len() == 1 { "" } else { "s" }
+            match existing {
+                Some(e) if e.value != value => println!(
+                    "  ~ {}={} (was {})  [{}]",
+                    name,
+                    value,
+                    e.value,
+                    scope_tag(&write_scope)
                 ),
-                Err(e) => {
-                    eprintln!("\nApply failed, rolled back: {}", e);
-                    std::process::exit(1);
-                }
+                Some(_) => println!("  ~ {}={}  [{}]", name, value, scope_tag(&write_scope)),
+                None => println!("  + {}={}  [{}]", name, value, scope_tag(&write_scope)),
             }
+            print_critical_warning(&write_scope, &name);
+
+            let changes = vec![EnvChange::Set {
+                name,
+                value,
+                value_kind,
+                scope: write_scope,
+            }];
+            write_changes(&changes, apply)?;
+        }
+
+        Command::Delete { name, scope, apply } => {
+            let write_scope = match scope {
+                WriteScopeArg::User => VarScope::User,
+                WriteScopeArg::System => VarScope::System,
+            };
+            let current = env_store::read_snapshot()?;
+            if current_entry(&current, &write_scope, &name).is_none() {
+                eprintln!(
+                    "Variable '{}' not found in {} scope",
+                    name,
+                    scope_tag(&write_scope)
+                );
+                std::process::exit(1);
+            }
+
+            println!("  - {}  [{}]", name, scope_tag(&write_scope));
+            print_critical_warning(&write_scope, &name);
+
+            let changes = vec![EnvChange::Delete {
+                name,
+                scope: write_scope,
+            }];
+            write_changes(&changes, apply)?;
         }
     }
 
     Ok(())
+}
+
+fn write_changes(changes: &[EnvChange], apply: bool) -> Result<(), crate::error::EnvarlyError> {
+    if !apply {
+        println!("\nRun with --apply to write these changes to the registry.");
+        return Ok(());
+    }
+
+    println!();
+    let result = crate::env_store::apply_changes(changes, |index, total, change, result| {
+        let name = match change {
+            EnvChange::Set { name, .. } | EnvChange::Delete { name, .. } => name,
+        };
+        match result {
+            Ok(()) => println!("  [{}/{}] ok {}", index + 1, total, name),
+            Err(e) => println!("  [{}/{}] FAILED {} ({})", index + 1, total, name, e),
+        }
+    });
+
+    match result {
+        Ok(()) => {
+            println!(
+                "\nApplied {} change{}.",
+                changes.len(),
+                if changes.len() == 1 { "" } else { "s" }
+            );
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("\nApply failed, rolled back: {}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 fn current_value<'a>(current: &'a EnvSnapshot, scope: &VarScope, name: &str) -> Option<&'a str> {
@@ -323,5 +442,41 @@ fn scope_tag(scope: &VarScope) -> &'static str {
         VarScope::User => "User",
         VarScope::System => "System",
         VarScope::OtherUser => "OtherUser",
+    }
+}
+
+fn current_entry<'a>(
+    current: &'a EnvSnapshot,
+    scope: &VarScope,
+    name: &str,
+) -> Option<&'a crate::model::EnvValue> {
+    let map = match scope {
+        VarScope::User => &current.user,
+        VarScope::System => &current.system,
+        VarScope::OtherUser => return None,
+    };
+    map.get(name)
+}
+
+fn explicit_kind(kind: KindArg) -> Option<crate::model::EnvValueKind> {
+    match kind {
+        KindArg::Auto => None,
+        KindArg::String => Some(crate::model::EnvValueKind::String),
+        KindArg::ExpandString => Some(crate::model::EnvValueKind::ExpandString),
+    }
+}
+
+/// Mirrors `CRITICAL_VARS` in `src/components/StagedModal/StagedModal.tsx` —
+/// informational only, doesn't block the write.
+const CRITICAL_VARS: [&str; 3] = ["SYSTEMROOT", "WINDIR", "COMSPEC"];
+
+fn print_critical_warning(scope: &VarScope, name: &str) {
+    if matches!(scope, VarScope::System)
+        && CRITICAL_VARS.contains(&name.to_ascii_uppercase().as_str())
+    {
+        println!(
+            "  ⚠ {} is a critical system variable — changing it can break Windows or running applications.",
+            name
+        );
     }
 }

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -36,10 +36,27 @@ pub fn infer_env_value_kind(value: &str) -> EnvValueKind {
     }
 }
 
-fn resolve_kind(value: &EnvValue) -> EnvValueKind {
+pub fn resolve_kind(value: &EnvValue) -> EnvValueKind {
     value
         .kind
         .unwrap_or_else(|| infer_env_value_kind(&value.value))
+}
+
+/// Resolves the kind for `envarly set`. Mirrors the frontend's
+/// `resolveEnvValueKind` (`src/lib/envValueKind.ts`): an explicit kind wins
+/// outright; `None` (the CLI's "auto" selection) preserves the target
+/// variable's existing stored kind if it already has one, otherwise infers
+/// from the new value.
+pub fn resolve_set_kind(
+    explicit_kind: Option<EnvValueKind>,
+    value: &str,
+    existing: Option<&EnvValue>,
+) -> EnvValueKind {
+    explicit_kind.unwrap_or_else(|| {
+        existing
+            .and_then(|v| v.kind)
+            .unwrap_or_else(|| infer_env_value_kind(value))
+    })
 }
 
 fn scope_map(snapshot: &EnvSnapshot, scope: VarScope) -> Option<&HashMap<String, EnvValue>> {
@@ -261,6 +278,50 @@ mod tests {
                 value_kind: EnvValueKind::ExpandString,
                 scope: VarScope::User,
             }]
+        );
+    }
+
+    #[test]
+    fn resolve_set_kind_explicit_wins_regardless_of_existing() {
+        let existing = EnvValue::typed("old".into(), EnvValueKind::ExpandString);
+        assert_eq!(
+            resolve_set_kind(Some(EnvValueKind::String), "new", Some(&existing)),
+            EnvValueKind::String
+        );
+    }
+
+    #[test]
+    fn resolve_set_kind_auto_preserves_existing_stored_kind() {
+        let existing = EnvValue::typed("old".into(), EnvValueKind::ExpandString);
+        // New value has no %VAR% reference, so inference alone would say
+        // String — but the existing stored kind should win under Auto.
+        assert_eq!(
+            resolve_set_kind(None, "plain value", Some(&existing)),
+            EnvValueKind::ExpandString
+        );
+    }
+
+    #[test]
+    fn resolve_set_kind_auto_infers_when_no_existing_entry() {
+        assert_eq!(
+            resolve_set_kind(None, "%USERPROFILE%\\bin", None),
+            EnvValueKind::ExpandString
+        );
+        assert_eq!(
+            resolve_set_kind(None, "plain value", None),
+            EnvValueKind::String
+        );
+    }
+
+    #[test]
+    fn resolve_set_kind_auto_infers_when_existing_entry_has_no_kind() {
+        let existing = EnvValue {
+            value: "irrelevant".into(),
+            kind: None,
+        };
+        assert_eq!(
+            resolve_set_kind(None, "%USERPROFILE%\\bin", Some(&existing)),
+            EnvValueKind::ExpandString
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds `envarly set NAME VALUE` and `envarly delete NAME` — single-variable writes, the gap identified when comparing against RapidEE's CLI.
- Same dry-run-by-default / `--apply` convention as `import` (PR #177): preview by default, `--apply` to actually write.
- `--kind auto|string|expand-string` mirrors the GUI's `Auto`/`String`/`ExpandString` model (`src/lib/envValueKind.ts`): `auto` preserves the variable's existing stored kind if it already has one, otherwise infers from the value.
- Real advantage over `setx`/`[Environment]::SetEnvironmentVariable`: those don't broadcast `WM_SETTINGCHANGE`, so already-running processes don't see the change until logoff/logon. Envarly's write path already does.
- `--scope` for these is `user`/`system` only (no `all` — a single write always targets one scope), a new `WriteScopeArg` separate from the existing `ScopeArg`.
- Optional informational warning (not a hard block, consistent with `import`) when writing `SYSTEMROOT`/`WINDIR`/`COMSPEC` in System scope — mirrors the GUI's `CRITICAL_VARS` warning in `StagedModal.tsx`.
- Extracted the shared apply-gate/progress-print/summary tail out of `Command::Import` into `write_changes()`, now reused by `import`, `set`, and `delete` — no behavior change for `import`.
- `resolve_set_kind` lives in `import.rs` (not `cli.rs`) specifically so its unit tests run in CI — `cli.rs` is `#[cfg(windows)]`-gated and CI's Rust job runs on `ubuntu-latest`.

## Test plan
- [x] `cargo test` — 106 passed, 1 pre-existing ignored; new `resolve_set_kind` tests cover explicit-kind-wins, auto-preserves-existing-kind, auto-infers-with-no-existing-entry, auto-infers-when-existing-entry-has-no-kind
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] Manual dry-run smoke test against the real registry (`envarly set ENVARLY_SMOKE_TEST_VAR hello`, `envarly delete <nonexistent>`) — confirmed read-only, correct output
- [ ] Optional manual `--apply` smoke test with a disposable User-scope variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)