### PR TITLE
chore: release 1.7.0

### DIFF
--- a/lp/src/lib/lpContent.ts
+++ b/lp/src/lib/lpContent.ts
@@ -2,7 +2,7 @@ export const GITHUB_URL = 'https://github.com/iray-tno/envarly';
 export const RELEASE_URL = 'https://github.com/iray-tno/envarly/releases/latest';
 export const STORYBOOK_URL = '/envarly/storybook/';
 export const REPORTS_URL = '/envarly/reports/';
-export const VERSION = '1.6.0';
+export const VERSION = '1.7.0';
 export const WINGET_COMMAND = 'winget install Envarly.Envarly';
 
 export type LandingLang = 'en' | 'ja' | 'zh-CN' | 'ru' | 'ko' | 'vi';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envarly",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envarly",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envarly",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "node scripts/tauri.mjs dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "envarly"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envarly"
-version = "1.6.0"
+version = "1.7.0"
 description = "Modern Windows environment variable manager"
 authors = ["zigza"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Envarly",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "com.envarly.app",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
## Summary
- Version bump 1.6.0 → 1.7.0 (minor — new CLI functionality since the last release).
- `npm version minor` synced `package.json`, `tauri.conf.json`, `Cargo.toml`/`Cargo.lock`, and `lp/src/lib/lpContent.ts`.

## What's new since 1.6.0
- `envarly import` — CLI import from `.json`/`.reg`, merge or replace, dry-run by default (#177)
- `envarly set` / `envarly delete` — single-variable CLI writes, same dry-run/`--apply` model, `--kind auto|string|expand-string` (#178)
- DESIGN.md's CLI write-path documentation brought back in sync with the above (#179)

## Test plan
- [x] `npm run check-version` (implicit via `sync-version.mjs`, already run by `npm version`)
- [ ] After merge: push the `v1.7.0` tag to trigger the Release workflow (matches the timing of prior releases — tag pushed post-merge so the build runs against the merge commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)