### PR TITLE
docs: brand Storybook and Allure report pages as Envarly

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -78,6 +78,14 @@ jobs:
       - name: Build HTML reports
         run: npx allure generate junit-reports --clean -o site/reports
 
+      - name: Brand Allure report head
+        # Allure's generated page has generic "Allure Report" branding with no
+        # site identity — inject Envarly branding so it's identifiable if
+        # crawled/shared, using Allure's own <!-- allure-core-head --> anchor.
+        run: |
+          sed -i 's#<title>Allure Report</title>#<title>Envarly — Test Reports</title>#' site/reports/index.html
+          sed -i 's#<!-- allure-core-head:start -->#<!-- allure-core-head:start -->\n    <meta property="og:site_name" content="Envarly" />\n    <meta property="og:title" content="Envarly — Test Reports" />\n    <meta name="description" content="CI test reports for Envarly, the Windows environment variable manager (https://iray-tno.github.io/envarly/)." />#' site/reports/index.html
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,30 @@
+<meta property="og:site_name" content="Envarly" />
+<meta property="og:title" content="Envarly — Component Storybook" />
+<meta
+  name="description"
+  content="Component explorer for Envarly, the Windows environment variable manager (https://iray-tno.github.io/envarly/)."
+/>
+<script>
+  // Storybook's own runtime overwrites document.title after mount (to a bare
+  // "Storybook"), ignoring theme.brandTitle — so a plain static <title> tag
+  // gets clobbered. Re-assert ours whenever Storybook changes it.
+  (function () {
+    var desired = "Envarly — Component Storybook";
+    function apply() {
+      if (document.title !== desired) document.title = desired;
+    }
+    function watch(titleEl) {
+      apply();
+      new MutationObserver(apply).observe(titleEl, { childList: true });
+    }
+    var existing = document.querySelector("title");
+    if (existing) {
+      watch(existing);
+    } else {
+      new MutationObserver(function () {
+        var t = document.querySelector("title");
+        if (t) watch(t);
+      }).observe(document.head, { childList: true });
+    }
+  })();
+</script>

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,10 @@
+import { addons } from "storybook/manager-api";
+import { create } from "storybook/theming";
+
+addons.setConfig({
+  theme: create({
+    base: "light",
+    brandTitle: "Envarly",
+    brandUrl: "https://iray-tno.github.io/envarly/",
+  }),
+});


### PR DESCRIPTION
## Summary
- Follow-up to the "why does Google show GitHub Pages documentation" question — `/storybook/` and `/reports/` are served under the same `iray-tno.github.io/envarly` domain as the marketing LP, but both are unbranded auto-generated tool output (`<title>storybook - Storybook</title>`, `<title>Allure Report</title>`, no OGP tags at all).
- Decided against `noindex`/`robots.txt` disallow (that would need Google to already have crawled the page to see the noindex tag, and doing it prematurely can leave an already-indexed page stuck showing "no info available") — instead just giving both pages correct Envarly branding so they're identifiable if crawled or shared, rather than hiding them.
- `.storybook/manager.ts` — sets `theme.brandTitle` to "Envarly" (visible sidebar/header branding).
- `.storybook/manager-head.html` — adds `og:site_name`/`og:title`/description, plus a small script that re-asserts the document title against Storybook's own runtime (confirmed via a local Playwright check: Storybook overwrites `<title>` to a bare "Storybook" after mount, ignoring `brandTitle`, so a static-only `<title>` tag gets clobbered).
- `storybook.yml` — CI build now patches Allure's generated `site/reports/index.html` (title + og tags) via Allure's own `<!-- allure-core-head -->` anchor comment, since we don't control Allure's template directly. Verified the `sed` patch against a copy of the live generated HTML.

## Test plan
- [x] `npm run build-storybook` succeeds locally
- [x] Verified with Playwright against the built output: page title renders as "Envarly — Component Storybook" (confirmed the naive static-title approach fails — Storybook's JS resets it — before adding the MutationObserver re-assertion)
- [x] Verified the Allure `sed` injection against a saved copy of the current live `/reports/` HTML — title and OGP tags land correctly around the `allure-core-head` anchor
- [ ] After merge/deploy: spot-check `https://iray-tno.github.io/envarly/storybook/` and `/reports/` render the new branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)