### PR TITLE
feat(lp): add llms.txt

### DIFF
--- a/lp/src/pages/llms.txt.ts
+++ b/lp/src/pages/llms.txt.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+import {
+  enCopy,
+  GITHUB_URL,
+  RELEASE_URL,
+  REPORTS_URL,
+  STORYBOOK_URL,
+  VERSION,
+  WINGET_COMMAND,
+} from "../lib/lpContent";
+
+// https://llmstxt.org/ — a curated summary for LLMs/AI agents, kept separate
+// from robots.txt (crawl rules) and sitemap.xml (page list for search
+// engines). Hand-authored English content; not localized like the LP itself,
+// matching how CLI output and DESIGN.md also stay English-only in this repo.
+export const GET: APIRoute = ({ site }) => {
+  const base = import.meta.env.BASE_URL;
+  const url = (path: string) => new URL(`${base}${path}`, site).toString();
+  // STORYBOOK_URL/REPORTS_URL are already origin-relative ("/envarly/...").
+  const absolute = (path: string) => new URL(path, site).toString();
+
+  const body = `# Envarly
+
+> ${enCopy.description}
+
+Envarly is a free, open-source desktop app for Windows 10/11 (Tauri v2 + React + Rust) that lets developers and power users view, edit, import, and export User and System environment variables — with PATH-entry validation, secret detection, change previews, encrypted snapshots, and a dry-run-by-default CLI mode. No telemetry in the app itself.
+
+## Docs
+
+- [Landing page](${url("")}): Overview, screenshots, download links. Also available in 日本語, 简体中文, Русский, 한국어, and Tiếng Việt.
+- [GitHub repository](${GITHUB_URL}): Source, README, DESIGN.md architecture notes, issue tracker.
+- [Latest release](${RELEASE_URL}): Windows installer (.exe), MSI, and portable .zip downloads. Current version: ${VERSION}.
+- [Component Storybook](${absolute(STORYBOOK_URL)}): Interactive UI component explorer, not the app itself.
+- [CI test reports](${absolute(REPORTS_URL)}): Automated test/lint report archive, not user-facing documentation.
+
+## Optional
+
+- Install via WinGet: \`${WINGET_COMMAND}\`
+`;
+
+  return new Response(body, { headers: { "Content-Type": "text/plain; charset=utf-8" } });
+};

--- a/lp/src/pages/llms.txt.ts
+++ b/lp/src/pages/llms.txt.ts
@@ -23,7 +23,7 @@ export const GET: APIRoute = ({ site }) => {
 
 > ${enCopy.description}
 
-Envarly is a free, open-source desktop app for Windows 10/11 (Tauri v2 + React + Rust) that lets developers and power users view, edit, import, and export User and System environment variables — with PATH-entry validation, secret detection, change previews, encrypted snapshots, and a dry-run-by-default CLI mode. No telemetry in the app itself.
+Envarly is a free, open-source GUI (desktop app) for Windows 10/11 (Tauri v2 + React + Rust) that lets developers and power users view, edit, import, and export User and System environment variables — with PATH-entry validation, secret detection, change previews, encrypted snapshots, and a dry-run-by-default CLI mode. No telemetry in the app itself.
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- Reviewed `robots.txt` (`lp/src/pages/robots.txt.ts`) and the sitemap first, as requested — both are already correct: `robots.txt` allows everything and points at the real `sitemap-index.xml`; the sitemap contains exactly the 6 LP language pages and correctly excludes non-page routes (`robots.txt`, `og-image.png`). No changes needed there.
- Adds `lp/src/pages/llms.txt.ts` — a curated markdown summary for LLMs/AI agents per the [llms.txt](https://llmstxt.org/) convention. Separate from `robots.txt` (crawl rules for search engines) and `sitemap.xml` (page list); not an official web standard yet, but cheap to add and no downside.
- Built from existing `lpContent.ts` exports (`GITHUB_URL`, `RELEASE_URL`, `STORYBOOK_URL`, `REPORTS_URL`, `WINGET_COMMAND`, `VERSION`, `enCopy.description`) instead of duplicating that copy — stays in sync automatically (e.g. version bumps via `npm version`).
- English-only, matching the existing precedent for non-localized content (CLI output, `DESIGN.md`).

## Test plan
- [x] `npm run build` in `lp/` — confirmed `dist/llms.txt` renders with correct absolute URLs (`STORYBOOK_URL`/`REPORTS_URL` are origin-relative in `lpContent.ts`, so they needed `new URL(path, site)` rather than being used as-is)
- [x] Confirmed `dist/robots.txt` and `dist/sitemap-index.xml` are unaffected by the new route
- [x] `npx biome check --write` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)