### PR TITLE
docs: fix stale CLI read-only descriptions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,7 +43,8 @@ src-tauri/src/          Rust backend
   snapshot.rs           Snapshot save/list/restore + DPAPI encryption
   crypto.rs             DPAPI wrapper (protect/unprotect)
   export.rs             JSON, .reg, and IaC format (PS1, DSC v2/v3, Ansible) import/export
-  cli.rs                Read-only CLI subcommands (clap); export supports all GUI formats
+  import.rs             Backend-agnostic diff for `envarly import`/`set` (merge/replace, kind inference)
+  cli.rs                CLI subcommands (clap): get/list/export are read-only; import/set/delete write behind --apply
   error.rs              EnvarlyError (thiserror)
 ```
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,5 +1,10 @@
+//! CLI subcommands. No subcommand → the caller launches the GUI instead.
+//!
+//! `get`/`list`/`export` are read-only. `import`/`set`/`delete` can write to
+//! the registry, but are dry-run by default and only do so when `--apply` is
+//! passed.
+
 use crate::model::{EnvChange, EnvSnapshot, VarScope};
-/// Read-only CLI commands. No subcommand → the caller launches the GUI instead.
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]


### PR DESCRIPTION
## Summary
Confirmed the report: two leftover "CLI is read-only" descriptions, stale since `import`/`set`/`delete` (#177, #178) gave the CLI a write path.

- `src-tauri/src/cli.rs` — the module doc comment said "Read-only CLI commands," and was also oddly placed as a `///` comment sandwiched between two `use` statements (leftover from an earlier `cargo fmt` import reorder). Replaced with a proper `//!` module doc comment that correctly distinguishes the read-only (`get`/`list`/`export`) from write (`import`/`set`/`delete`, `--apply`-gated) subcommands.
- `DESIGN.md`'s file-map table — same stale "Read-only CLI subcommands" description for `cli.rs`; also added the missing `import.rs` row while in there.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)