### PR TITLE
docs: fix stale claims found in comment audit

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,7 +79,7 @@ Pre-op and post-op values are both pushed as checkpoints when a structural chang
 
 ### Read-only until confirmed
 
-**GUI writes require explicit confirmation.** Import preview is parsed into a structure staged locally; the user must click "Apply N staged changes" and confirm in the diff modal before any write happens. No GUI mutation escapes the `commands::set_env_var` / `commands::delete_env_var` handlers.
+**GUI writes require explicit confirmation.** Import preview is parsed into a structure staged locally; the user must click "Apply N staged changes" and confirm in the diff modal before any write happens. No GUI mutation escapes the `commands::set_env_var` / `commands::delete_env_var` / `commands::apply_env_changes` handlers — the latter is what "Apply N staged changes" actually calls.
 
 The CLI's `get`/`list`/`export` are read-only. `import`/`set`/`delete` are a separate, intentional write path — see [CLI mode](#cli-mode) — gated by an explicit `--apply` flag instead of a confirmation dialog, since there's no GUI to show one.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Envarly collects no telemetry and sends no data anywhere. The only network reque
 - **WM\_SETTINGCHANGE broadcast** — running apps pick up changes without a restart
 - **Resizable panels** — drag the sidebar and snapshots panel to the width you want; sizes persist across restarts
 - **Check command** — find out why a command isn't found: searches the effective PATH (User + System merged, PATHEXT-aware) for a name or exe path and flags shadowed duplicates
-- **6 languages** — English, 日本語, 简体中文, Русский, 한국어, and Tiếng Việt; switch anytime from the header, including the ~150 built-in variable descriptions
+- **6 languages** — English, 日本語, 简体中文, Русский, 한국어, and Tiếng Việt; switch anytime from the header, including the ~140 built-in variable descriptions
 
 ## Stack
 

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -20,7 +20,5 @@ export function useI18n() {
     i18n.changeLanguage(lang);
   };
 
-  const toggleLanguage = () => setLanguage(language === "ja" ? "en" : "ja");
-
-  return { t, language, setLanguage, toggleLanguage };
+  return { t, language, setLanguage };
 }


### PR DESCRIPTION
## Summary
Follow-up to the #183 CLI read-only cleanup — ran a broader audit for stale/incorrect absolute claims in comments and docs. Three confirmed findings:

- **`DESIGN.md`'s security invariant** — "No GUI mutation escapes `commands::set_env_var` / `commands::delete_env_var`" named only 2 of the 3 write-capable Tauri commands. Missing `apply_env_changes`, which is what the main "Apply N staged changes" flow actually calls (`commands/env.rs:53-78`) — it even auto-saves a pre-apply snapshot, so it's arguably the *primary* write path, not a minor omission. README.md's own Architecture Notes section already correctly documents `apply_env_changes`, so the two docs disagreed with each other.
- **README's "~150 built-in variable descriptions"** — actual count is 138 `env_desc` entries, verified directly against all 6 locale JSON files (consistent across all of them). Updated to "~140".
- **`src/hooks/useI18n.ts`'s `toggleLanguage`** — dead code, a hardcoded `"ja" ? "en" : "ja"` binary toggle that predates the zh-CN/ru/ko/vi expansion (now 6 languages). Confirmed unused anywhere in `src/` via grep. Removed.

## Test plan
- [x] `npx biome check` clean on the changed file
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` on `src/hooks` — 115 passed
- [x] Verified the 138 count directly against all 6 `src/locales/*.json` files (all consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)