### PR TITLE
chore(lp): npm audit fix — nanoid

### DIFF
--- a/lp/package-lock.json
+++ b/lp/package-lock.json
@@ -3878,9 +3878,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- The `lp npm audit` job on the Security Audit workflow started failing after PR #184 merged — 1 high-severity finding: `nanoid <3.3.18` (GHSA-2v37-7h3g-55p8, custom generators can loop indefinitely when size is zero).
- Transitive dependency: `@tailwindcss/vite` → `vite` → `postcss` → `nanoid`. `npm audit fix` bumped `lp/package-lock.json`'s pin from 3.3.17 → 3.3.18, no other changes.
- Also checked root `npm audit --audit-level=high` (0 vulnerabilities) and `cargo audit` (clean exit 0, only the same 18 pre-existing allowed warnings as before) — neither needed changes.

## Test plan
- [x] `npm audit --audit-level=high` in `lp/` — 0 vulnerabilities
- [x] `npm run build` in `lp/` — succeeds
- [x] Root `npm audit --audit-level=high` — 0 vulnerabilities (unaffected, checked for completeness)
- [x] `cargo audit` — exit 0, unaffected (checked for completeness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)