### PR TITLE
docs: add language links to README pointing at the localized LP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Platform: Windows](https://img.shields.io/badge/Platform-Windows%2010%2F11-blue.svg)](https://github.com/iray-tno/envarly/releases)
 [![Tauri v2](https://img.shields.io/badge/Tauri-v2-yellow.svg)](https://tauri.app)
 
+[English](https://iray-tno.github.io/envarly/) | [日本語](https://iray-tno.github.io/envarly/ja/) | [简体中文](https://iray-tno.github.io/envarly/zh-cn/) | [Русский](https://iray-tno.github.io/envarly/ru/) | [한국어](https://iray-tno.github.io/envarly/ko/) | [Tiếng Việt](https://iray-tno.github.io/envarly/vi/)
+
 Windows environment variable manager built with Tauri v2, React, TypeScript, and Rust.
 
 ## Screenshot


### PR DESCRIPTION
## Summary
- Adds a one-line language-links row under the README badges (English + the 5 LP locales), linking to the corresponding localized LP page for each.
- README itself stays English-only — this is just a signpost for non-English readers landing on GitHub directly (e.g. via search or WinGet catalog links), pointing them to the LP's existing localized content instead of duplicating the README.
- Order/labels match `lp/src/lib/lpContent.ts`'s `LANDING_LANGS`.

## Test plan
- [x] Rendered the markdown locally to confirm the link row renders correctly.
- [x] Manually spot-checked each URL resolves to the correct locale on the live site.