### PR TITLE
fix(lp): language select unreadable on hover in native dropdown

### DIFF
--- a/lp/src/styles/global.css
+++ b/lp/src/styles/global.css
@@ -12,6 +12,11 @@
 
 html {
   scroll-behavior: smooth;
+  /* Site is dark-only (no light variant). Without this, native form
+     controls — notably the language <select>'s option list and its
+     hover highlight — default to light UI chrome, which clashes with
+     our custom text color and becomes unreadable on hover. */
+  color-scheme: dark;
 }
 
 body {


### PR DESCRIPTION
## Summary
- The LP is dark-only (no light theme variant), but nothing set `color-scheme`, so the browser rendered native form-control chrome — specifically the language `<select>`'s option list and hover highlight — using light UI defaults.
- That clashed with the custom muted text color, making option text hard to read on hover (reported: text washes out against the native hover highlight).
- Fix: `color-scheme: dark` on `html` in `lp/src/styles/global.css`, so the browser draws native form controls (select popup background/text/highlight, scrollbars, etc.) with dark-appropriate defaults site-wide.

## Test plan
- [x] `astro dev`, confirmed via Playwright that `getComputedStyle` reports `color-scheme: dark` on both `<html>` and `#lang-select`.
- [x] Visual check of the closed select control (unaffected, already readable).
- [ ] Native dropdown popup hover state can't be captured via automated screenshot (OS-level popup, outside page compositing) — worth a manual eyeball after merge.