### PR TITLE
fix(lp): language select option text still faded on hover

### DIFF
--- a/lp/src/styles/global.css
+++ b/lp/src/styles/global.css
@@ -24,3 +24,14 @@ body {
   color: var(--color-text);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
+
+/* #lang-select's trigger uses a hover:text-* utility for its own closed-state
+   affordance. `color` is inherited, and browsers keep the <select>'s :hover
+   state active while its native popup is open, so without this the option
+   list's text color flips with the trigger's hover state and clashes with
+   the OS-drawn per-row highlight. Pin it so options always use a fixed,
+   readable color regardless of the trigger's hover state. */
+#lang-select option {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- Follow-up to #187 — the `color-scheme: dark` fix wasn't the whole story.
- `#lang-select`'s `hover:text-[var(--color-text)]` utility is meant for the closed trigger's own hover affordance, but `color` is inherited and browsers keep a `<select>`'s `:hover` state active while its native option popup is open — so the option list's inherited text color was flipping every time the trigger was hovered, clashing with the OS-drawn per-row highlight.
- Fix: pin `#lang-select option { color; background-color }` to fixed values so option text no longer depends on the trigger's hover state.

## Test plan
- [x] `astro dev` + Playwright: confirmed computed `color`/`background-color` on `#lang-select option` is now identical whether or not the select is hovered.