### PR TITLE
chore(ci): migrate Allure test reports from allure-commandline (v2) to allure (v3)

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -76,15 +76,14 @@ jobs:
           mv storybook-static site/storybook
 
       - name: Build HTML reports
-        run: npx allure generate junit-reports --clean -o site/reports
+        run: npx allure generate --report-name "Envarly — Test Reports" -o site/reports junit-reports
 
       - name: Brand Allure report head
-        # Allure's generated page has generic "Allure Report" branding with no
-        # site identity — inject Envarly branding so it's identifiable if
-        # crawled/shared, using Allure's own <!-- allure-core-head --> anchor.
+        # Allure 3's generated page sets <title> from --report-name above but
+        # emits no OGP/description metadata of its own — inject Envarly
+        # branding so it's identifiable if crawled/shared.
         run: |
-          sed -i 's#<title>Allure Report</title>#<title>Envarly — Test Reports</title>#' site/reports/index.html
-          sed -i 's#<!-- allure-core-head:start -->#<!-- allure-core-head:start -->\n    <meta property="og:site_name" content="Envarly" />\n    <meta property="og:title" content="Envarly — Test Reports" />\n    <meta name="description" content="CI test reports for Envarly, the Windows environment variable manager (https://iray-tno.github.io/envarly/)." />#' site/reports/index.html
+          sed -i 's#</head>#    <meta property="og:site_name" content="Envarly" />\n    <meta property="og:title" content="Envarly — Test Reports" />\n    <meta name="description" content="CI test reports for Envarly, the Windows environment variable manager (https://iray-tno.github.io/envarly/)." />\n</head>#' site/reports/index.html
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@vitest/browser-playwright": "^4.1.10",
         "@vitest/coverage-v8": "^4.1.9",
         "@xmldom/xmldom": "^0.9.10",
-        "allure-commandline": "^2.32.0",
+        "allure": "^3.16.0",
         "jsdom": "^29.1.1",
         "license-checker-rseidelsohn": "^5.0.1",
         "playwright": "^1.61.1",
@@ -57,6 +57,753 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@allurereport/aql": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.16.0.tgz",
+      "integrity": "sha512-Iyh0SVspuoWObREZ5fDVTpE3zuVfD8k1njrlM+PkU/tuwCzkuBVpHPuClUmzVz2QwkHLTcVKy65o4dfSNgWTqg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@allurereport/charts-api": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.16.0.tgz",
+      "integrity": "sha512-tQh/Qgtpraq29FxORqfBKxX674MoxiwdGIn2nlg+Al9I+3A8H2Rkw6iySxjj4VkkyQJ3r2lFuX5inBAXUYqB/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "d3-shape": "^3.2.0"
+      }
+    },
+    "node_modules/@allurereport/ci": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.16.0.tgz",
+      "integrity": "sha512-bRJjq1Jiq8cVwA3Gr1xBixWKzV44nbgZEIotmjlSCC+ZrMNPf4plY9b/v/3WORiQdNkJTTQZ1rWZh+4Je5Ymgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/cli-commons": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/cli-commons/-/cli-commons-3.16.0.tgz",
+      "integrity": "sha512-yZT24ggyAQ8CNAsFz7eFqeZ8PPGlW+wdmA5yrvv9V4hLW0mHpaUbqvG03UUaPHdo8MuPkcr1tM95adcd4loTRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      }
+    },
+    "node_modules/@allurereport/core": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.16.0.tgz",
+      "integrity": "sha512-2CBLe8iseNlFGYLTO0UliW+BqTUwwHckpP7fk+5Rew57PqXcogOQa8dRHKI9hiFNBiPhdHI6H4wh5icx6T31tw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/ci": "3.16.0",
+        "@allurereport/cli-commons": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-agent": "3.16.0",
+        "@allurereport/plugin-allure2": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/plugin-awesome": "3.16.0",
+        "@allurereport/plugin-classic": "3.16.0",
+        "@allurereport/plugin-csv": "3.16.0",
+        "@allurereport/plugin-dashboard": "3.16.0",
+        "@allurereport/plugin-jira": "3.16.0",
+        "@allurereport/plugin-log": "3.16.0",
+        "@allurereport/plugin-progress": "3.16.0",
+        "@allurereport/plugin-slack": "3.16.0",
+        "@allurereport/plugin-testops": "3.16.0",
+        "@allurereport/plugin-testplan": "3.16.0",
+        "@allurereport/reader": "3.16.0",
+        "@allurereport/reader-api": "3.16.0",
+        "@allurereport/service": "3.16.0",
+        "@allurereport/summary": "3.16.0",
+        "glob": "^13.0.6",
+        "handlebars": "^4.7.9",
+        "jiti": "^2.5.1",
+        "node-stream-zip": "^1.15.0",
+        "p-limit": "^7.3.0",
+        "yaml": "^2.8.3",
+        "yoctocolors": "^2.1.2",
+        "zip-stream": "^7.0.5"
+      }
+    },
+    "node_modules/@allurereport/core-api": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.16.0.tgz",
+      "integrity": "sha512-U9Sj3QilaXFHLbV/v2sVhRRTOKengNTQwYi+syI+gHJM1t2+Z4KXRzOZ9NCEl0vD/bmQSxxC1IqCFHlKl3arbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "d3-shape": "^3.2.0"
+      }
+    },
+    "node_modules/@allurereport/directory-watcher": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.16.0.tgz",
+      "integrity": "sha512-SyQ5QeFXywbLRuElTrauXihZLWM6F39FLHn1Ywair36H077WgymKT+TJoPKT/b5WQ3EWs2u5sF4aSCeTPRiJyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chokidar": "^5.0.0"
+      }
+    },
+    "node_modules/@allurereport/git": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/git/-/git-3.16.0.tgz",
+      "integrity": "sha512-TccGFGhj2fOAeyz24F14GGzR3SnAFhIN44XnbqSqSxIq4zh/k3wgBVdUl/LE4+yLy1O8YqveLXEgo0fF84VW3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-agent": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-agent/-/plugin-agent-3.16.0.tgz",
+      "integrity": "sha512-AqIuGrYvCB/sW8SAjjxsdzZwRfYn+JFoYPV8vku04PnzKQlkBh3tAvQZRZcPSBvBymhgkNL0PQ07anXzY9yxXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.16.0.tgz",
+      "integrity": "sha512-Rr8tTpgwzR25oZUyjTyiA0pYqQovFpduhtSPiUcz+fzgqDYLTT5FS0WRPnHa04wyQhyhseVVOBhOEYZNvgk2Hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "find-up": "^8.0.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/plugin-api": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.16.0.tgz",
+      "integrity": "sha512-l3migZVxBy1+Fvmz6kxLGfwc+CNi2wh0ZZl3Q6nryXq6PCcglln/MaPT5QenAgMeZJHgSbAteLlldMU3GL1uCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-awesome": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.16.0.tgz",
+      "integrity": "sha512-wHNdOCzrUBGEgtaIXsSgnobSUM2yxFEQ1JPwGQOljn09gYh+zoCTMigjfpt7X8dvhH8PlGKKgRnY4+hqDfSWrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/web-awesome": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9",
+        "markdown-it": "^14.2.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-classic": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.16.0.tgz",
+      "integrity": "sha512-jAi9h34ylU1XGL42wlQZDtxSDSzht8xGm3fvzAvmt4v01gilzJpqOOpbrRvq02AkAcP1y85Gk96/kdVI7Cr6vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/web-awesome": "3.16.0",
+        "@allurereport/web-classic": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9",
+        "markdown-it": "^14.2.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-csv": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.16.0.tgz",
+      "integrity": "sha512-NO1MLLZYxcRFm7EsF0n5vp1ySCH1YMXKr+uIlbc/FnTGHxbZFL41+frtxgUy6mVHMuMwX/90PiSvxMIHEB8DdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-dashboard": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.16.0.tgz",
+      "integrity": "sha512-vXuG/1uWqYeGuej1g2J/7hhy4zQ2l7i50rWBhfVsTlMHaZdndjVfCbsTAPWItY1M4rFkZtVgnYrcggWNzDz81Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@allurereport/web-dashboard": "3.16.0",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/plugin-jira": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.16.0.tgz",
+      "integrity": "sha512-sMwqo1tW31MNvbG1gxFuzfScpdTTDuG0g4zqS1GlmdPxGgt9L8380T85taVnwsHIkwtANTl9Kc5SK6ts0rC4tQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "axios": "^1.18.1"
+      }
+    },
+    "node_modules/@allurereport/plugin-log": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.16.0.tgz",
+      "integrity": "sha512-yNI8YThJI0jgHrca2QuSChSax28ffnpjVruf6n6EzZApg6KCcibk0UGS/jP+rnvcrpp0G7KBVeL2w5wdO/NveA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "yoctocolors": "^2.1.2"
+      }
+    },
+    "node_modules/@allurereport/plugin-progress": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.16.0.tgz",
+      "integrity": "sha512-p5zT/N5igjpYvKpMm82JssJU/tToL3eA1cZORKHtJV9wp/gzYceKBEFkA8uEFytIa1vDrMFtAKzMsKkenVhCag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "yoctocolors": "^2.1.2"
+      }
+    },
+    "node_modules/@allurereport/plugin-server-reload": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.16.0.tgz",
+      "integrity": "sha512-JrcIIy4rA4pcZc9HSI9TtditEgkK6f3bY3x06Uv4FiWgyGnTM8m178OSNsP3uLLKTnkJFKZp/S6cE/uBrFx79w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/static-server": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-slack": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.16.0.tgz",
+      "integrity": "sha512-xzogbVIlDXeuH9YwN+LBXdK58+498w6TOQbnBiFPVutFeX5948B+X7CyMoHtlf8KRVWRvTPVfvj2/ojkU9YQYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-testops": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.16.0.tgz",
+      "integrity": "sha512-C7s469CLMDCcyPRs885TLc0RdUe+zetff42CRD1Y5Do2hpcRUw8RG8D/GxxwNTqk7ZvPksi6OhUB8xP2BxADaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/ci": "3.16.0",
+        "@allurereport/cli-commons": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/git": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/reader-api": "3.16.0",
+        "@allurereport/service": "3.16.0",
+        "axios": "^1.18.1",
+        "form-data": "^4.0.6",
+        "lodash-es": "^4.18.1",
+        "p-limit": "^7.3.0",
+        "yoctocolors": "^2"
+      }
+    },
+    "node_modules/@allurereport/plugin-testplan": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.16.0.tgz",
+      "integrity": "sha512-3M3PEZRMyGdIMPM5oxihqSNmTTeB5Mdce84PkKkJI61Qn4NwGrJxk+zJwDSzc4eENMgn5aYkQrB9GV+ZZrcxxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0"
+      }
+    },
+    "node_modules/@allurereport/reader": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.16.0.tgz",
+      "integrity": "sha512-Egr1lxOSAYzF/rcvauLXXRgNM4LCrZSnEaZY1fOqjN1UxV0vm6IyiAgVOilQ0ZYNK/zzTAZO8TNT++Q5v04gaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/reader-api": "3.16.0",
+        "fast-xml-parser": "^5.7.0"
+      }
+    },
+    "node_modules/@allurereport/reader-api": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.16.0.tgz",
+      "integrity": "sha512-6LUJD383CaFXZ5ap/5JA+UpYGrS1mJ1a7DtbtjvVHxn7CL4zKMaHqJIMKsHBQkf913jfLncNTSYGOTgIkPoXxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "mime-types": "^2.1.35"
+      }
+    },
+    "node_modules/@allurereport/service": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.16.0.tgz",
+      "integrity": "sha512-+COrag8XPznfSj2glUgJG/qLeu/B8mnPTemQY+fynxSlU/Ztbp7xs16VxPO0Um5q8da+PBwKghmPYNN/JaEhDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "axios": "^1.18.1",
+        "open": "^11.0.0"
+      }
+    },
+    "node_modules/@allurereport/service/node_modules/open": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+      "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.5.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.2.1",
+        "wsl-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/service/node_modules/wsl-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/service/node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/static-server": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.16.0.tgz",
+      "integrity": "sha512-ueIcNUZMmjXjh1Kdkg16vf/FVI+/jhurKC5S8OKFBmmNmHCH9Qz49FHE1Orsw3x9fpmJZJnWMLgvohDfdIQP6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/directory-watcher": "3.16.0",
+        "open": "^11.0.0"
+      }
+    },
+    "node_modules/@allurereport/static-server/node_modules/open": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+      "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.5.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.2.1",
+        "wsl-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/static-server/node_modules/wsl-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/static-server/node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/summary": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.16.0.tgz",
+      "integrity": "sha512-ZgvtQdFw63Fdlf8HocI7m6TzJzE7HdNe2id5EGD2W6Q31YAg2vsD9ofuHvwjMOozu63D9TeIxILRqUtbdVkwBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/web-summary": "3.16.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/web-awesome": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.16.0.tgz",
+      "integrity": "sha512-8fZKftOfYlMdo+BS7jUnXif87PLNo/sB52fX32/aMHmYd9RmbWySCOf1HAa4D8XSxzZ+A/Zhw0h2SnNvwRHMDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@allurereport/web-components": "3.16.0",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "d3-shape": "^3.2.0",
+        "i18next": "^24.0.2",
+        "md5": "^2.3.0",
+        "minisearch": "^7.2.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0"
+      }
+    },
+    "node_modules/@allurereport/web-awesome/node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@allurereport/web-classic": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.16.0.tgz",
+      "integrity": "sha512-rxsnli83eQOoUN3IqRkQZnjSXK6XgREOBaX/jdWm/BZYCJFh0bkZP3CtbVpPzvyaSyiHxFiFOGnAB7uuvKLI8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@allurereport/web-components": "3.16.0",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "d3-shape": "^3.2.0",
+        "i18next": "^24.0.2",
+        "md5": "^2.3.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0",
+        "split.js": "^1.6.5"
+      }
+    },
+    "node_modules/@allurereport/web-classic/node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@allurereport/web-commons": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.16.0.tgz",
+      "integrity": "sha512-llGfA7Lbmo1MbKNwxHxmF3fWwpcXxpYwEvw5RqV6S86PDVmT6eadZV9U3ah/zS1MT4/qvaB1j6mShjM5UW5Ryg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/aql": "3.16.0",
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@preact/signals": "^2.6.1",
+        "@preact/signals-core": "^1.12.2",
+        "ansi-to-html": "^0.7.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "dompurify": "^3.4.0",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "node_modules/@allurereport/web-commons/node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@allurereport/web-components": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.16.0.tgz",
+      "integrity": "sha512-xhJcadqSFwpQxTIA/qORFWJo0Dxp1ZaRSAJ9DTzgkwP/V+SG2gcJ+xynMS/me5iJgwPbckNujdZAG4XTLLZ8Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@floating-ui/dom": "^1.7.4",
+        "@nivo/bar": "^0.99.0",
+        "@nivo/core": "^0.99.0",
+        "@nivo/funnel": "^0.99.0",
+        "@nivo/heatmap": "^0.99.0",
+        "@nivo/line": "^0.99.0",
+        "@nivo/pie": "^0.99.0",
+        "@nivo/text": "^0.99.0",
+        "@nivo/theming": "^0.99.0",
+        "@nivo/tooltip": "^0.99.0",
+        "@nivo/treemap": "^0.99.0",
+        "@preact/compat": "^18.3.1",
+        "@preact/signals": "^2.6.1",
+        "@react-spring/web": "^10.0.3",
+        "clsx": "^2.1.1",
+        "d3-array": "^3.2.4",
+        "d3-axis": "^3.0.0",
+        "d3-brush": "^3.0.0",
+        "d3-format": "^3.1.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-regression": "^1.3.10",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-tip": "^0.9.1",
+        "d3-transition": "^3.0.1",
+        "lodash": "^4.18.1",
+        "markdown-it": "^14.2.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0",
+        "react": "npm:@preact/compat@*",
+        "react-dom": "npm:@preact/compat@*",
+        "sortablejs": "^1.15.7",
+        "use-debounce": "^10.0.6"
+      }
+    },
+    "node_modules/@allurereport/web-dashboard": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.16.0.tgz",
+      "integrity": "sha512-f6iAPYDLTsHQ0lqFH7IYrfzD1Kd2BNT/iLIKV5cXjy4lCbv1QTUfPHV+Wi+ET5vOmQbN8XTBDt+D4tjPiG3wxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@allurereport/web-components": "3.16.0",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "i18next": "^24.0.2",
+        "preact": "^10.28.2"
+      }
+    },
+    "node_modules/@allurereport/web-dashboard/node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@allurereport/web-summary": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.16.0.tgz",
+      "integrity": "sha512-1izyINQxJNJsrvTM8Wg9EJu3GONAYQYTMqMY76CR2ATADJNRHm/5BgTzI7m7cpWD4SHdBg6hs+kgvQKGUHkYog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/web-commons": "3.16.0",
+        "@allurereport/web-components": "3.16.0",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "i18next": "^24.0.2",
+        "preact": "^10.28.2"
+      }
+    },
+    "node_modules/@allurereport/web-summary/node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -1377,6 +2124,34 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@gar/promise-retry": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
@@ -1508,6 +2283,396 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nivo/annotations": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
+      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/arcs": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.99.0.tgz",
+      "integrity": "sha512-UcvWLQPl+A3APk2Gm74N5xDfT+ATnVs2XkP73WxhYPWJk+dBzF00cndA5g/dptOwdFBvvo62VgcCsNiwUsjKTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
+      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nivo/bar": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.99.0.tgz",
+      "integrity": "sha512-9yfMn7H6UF/TqtCwVZ/vihVAXUff9wWvSaeF2Z1DCfgr5S07qs31Qb2p0LZA+YgCWpaU7zqkeb3VZ4WCpZbrDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/canvas": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/canvas": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/canvas/-/canvas-0.99.0.tgz",
+      "integrity": "sha512-UxA8zb+NPwqmNm81hoyUZSMAikgjU1ukLf4KybVNyV8ejcJM+BUFXsb8DxTcLdt4nmCFHqM56GaJQv2hnAHmzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nivo/funnel": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/funnel/-/funnel-0.99.0.tgz",
+      "integrity": "sha512-1wiAeY/+Xl1W7Y6S2aNTatEjXXtKX2BW94+zlICML8eWxx/ke7wyiiMsiu3XtJD+tADepzx9DsZKeXUyErat+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/heatmap": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/heatmap/-/heatmap-0.99.0.tgz",
+      "integrity": "sha512-cnd5V6XYLvHtQ8GObUyYyEgmAUa5/ERYVmNXR1znA+yzmB+tGthJsOeGar+ntCb43pIL5HbhEaD3YpsYzBxOhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
+      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/line": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.99.0.tgz",
+      "integrity": "sha512-bAqTXSjpnpcGMs341qWFUi7hJTqQiNoSeJHsYPuPS3icuXPcp3WETQH+zRZACeEF79ZigeOWCW+dzODgne1y9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@nivo/voronoi": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/pie": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.99.0.tgz",
+      "integrity": "sha512-zUbo8UdLndp2RMljrOqitAKKEnl7YypkJrOzjKLk8jQGU7qqUKtgFoJIPhiBsvNPs3xtX2KwgtS1+JKNTNns7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/arcs": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/scales": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
+      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/treemap": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/treemap/-/treemap-0.99.0.tgz",
+      "integrity": "sha512-zGVQyR+e38UqUsMrsnio8Ulz7IYDZ4HpUv+iVKSYX29Fa8TS39yHGyaGXTXt6PvL6owjvdwhJ/7TQAeO/qcWaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-hierarchy": "^3.1.7",
+        "d3-hierarchy": "^3.1.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/voronoi": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.99.0.tgz",
+      "integrity": "sha512-KfmMdidbYzhiUCki1FG4X4nHEFT4loK8G5bMBnmCl9U+S78W+gvkfrgD2Aoqp/Q9yKQvr3Y8UcZKSFZnn3HgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "d3-delaunay": "^6.0.4",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@npmcli/agent": {
       "version": "4.0.2",
@@ -2554,6 +3719,123 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@preact/compat": {
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-18.3.2.tgz",
+      "integrity": "sha512-5vSl55K5yLMvocT7PBKxDOHGgYPjMrKQqqr6roSNjIXcJOtSgDDMjpiCAF3s7klRdmGrN75b/Przmjw8gmlg/w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "*"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.11.1.tgz",
+      "integrity": "sha512-uYoD+USkacTNU02kfCBkJEV7xabKTmA78W5pnT2GymsuGEC9n/ZO+UT4S96l0dIL6KLDk77VJyUFuOMBvftVHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.1.2.tgz",
+      "integrity": "sha512-yAsQ/bbp6+vko7WNCI1M00c6KLE9XKTGCrgRhQqS4JcK3oF5qBV4rHYrQEprvEvYXxt+1H5FsLS2eVValEPfFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-lPGOAg0V+PV3ucopOajD+YCxoe8twALqAeG4c/+sqVjBsyUNNdx8qfz/DcNSPKA8PV3+AyQELlCxlDfap9cmBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.1.2.tgz",
+      "integrity": "sha512-KC6vSFZyPnRJ2rXqipV9QqR4SaYbYXjvKfdYKWipNK2mWuV79gr20WmpVUOsTiEHGRY3WSOdWCHN+P9Pdaqb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.1.2.tgz",
+      "integrity": "sha512-47/8bNQ/o0uEmxEnPBuERlC29VSqiTn5P9ln9tUMSVkYKYxBtouYE686F5kAGj+eHRPoNCw7drxWE9nv2d1LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.1.2.tgz",
+      "integrity": "sha512-G4CWowmVPz+rDG1y9QRVq/prZNxiNwQaHC0kgT/MgY6jAGgdRgTV4VThpvJDwWvUitk3xZB4soP4d36fjeQ09g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.1.2.tgz",
+      "integrity": "sha512-KxDB3zaDqy9qFsu7fdxjyraAxweHH4k5TW5WGT/OuMK6hKaxSDfhrQfRBzfFaSVvMBf+NghbJFanllV4ia6i7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/core": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2",
+        "csstype": "^3.2.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3999,6 +5281,92 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4058,6 +5426,14 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4298,6 +5674,19 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4311,6 +5700,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4321,14 +5720,43 @@
         "node": ">= 14"
       }
     },
-    "node_modules/allure-commandline": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.43.0.tgz",
-      "integrity": "sha512-nsqccDOgi80fi9WjvBapZjlFlugodVWudotNtWx6XKiSI7NuN6oTWEkXnkxQBzNg02Yf9lZLtCFlKvjAlcpu6Q==",
+    "node_modules/allure": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/allure/-/allure-3.16.0.tgz",
+      "integrity": "sha512-pgPwDadzT2N6Z0yz0NoGx/vPaxDeERukz6pE8kim6UTE++1fCNWXDiOB7SVDqzZonW2Tp81SrHfAGdZeP38Djg==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.16.0",
+        "@allurereport/ci": "3.16.0",
+        "@allurereport/core": "3.16.0",
+        "@allurereport/core-api": "3.16.0",
+        "@allurereport/directory-watcher": "3.16.0",
+        "@allurereport/plugin-agent": "3.16.0",
+        "@allurereport/plugin-allure2": "3.16.0",
+        "@allurereport/plugin-api": "3.16.0",
+        "@allurereport/plugin-awesome": "3.16.0",
+        "@allurereport/plugin-classic": "3.16.0",
+        "@allurereport/plugin-csv": "3.16.0",
+        "@allurereport/plugin-dashboard": "3.16.0",
+        "@allurereport/plugin-jira": "3.16.0",
+        "@allurereport/plugin-log": "3.16.0",
+        "@allurereport/plugin-progress": "3.16.0",
+        "@allurereport/plugin-server-reload": "3.16.0",
+        "@allurereport/plugin-slack": "3.16.0",
+        "@allurereport/reader-api": "3.16.0",
+        "@allurereport/service": "3.16.0",
+        "@allurereport/static-server": "3.16.0",
+        "adm-zip": "^0.6.0",
+        "clipanion": "^4.0.0-rc.4",
+        "glob": "^13.0.6",
+        "lodash.omit": "^4.18.0",
+        "prompts": "^2.4.2",
+        "typanion": "^3.14.0",
+        "yoctocolors": "^2.1.2"
+      },
       "bin": {
-        "allure": "bin/allure"
+        "allure": "cli.js"
       }
     },
     "node_modules/ansi-regex": {
@@ -4355,6 +5783,45 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ansi-to-html": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+      "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.2.0"
+      },
+      "bin": {
+        "ansi-to-html": "bin/ansi-to-html"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/ansi-to-html/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4424,6 +5891,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axe-core": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
@@ -4432,6 +5906,46 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -4458,6 +5972,27 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
@@ -4546,6 +6081,31 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4592,6 +6152,20 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -4667,6 +6241,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -4675,6 +6259,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -4692,6 +6292,22 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/clipanion": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+      "integrity": "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ],
+      "dependencies": {
+        "typanion": "^3.8.0"
+      },
+      "peerDependencies": {
+        "typanion": "*"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4732,6 +6348,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
@@ -4740,6 +6369,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/convert-source-map": {
@@ -4772,6 +6418,43 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-tree": {
@@ -4813,6 +6496,295 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-regression": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tip": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/d3-tip/-/d3-tip-0.9.1.tgz",
+      "integrity": "sha512-EVBfG9d+HnjIoyVXfhpytWxlF59JaobwizqMX9EBXtsFmJytjwHeYiUs74ldHQjE7S9vzfKTx2LCtvUrIbuFYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3-collection": "^1.0.4",
+        "d3-selection": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=4.2.6"
+      }
+    },
+    "node_modules/d3-tip/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -4863,9 +6835,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4903,6 +6875,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -4953,6 +6945,31 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.377",
@@ -5016,6 +7033,16 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -5031,6 +7058,35 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -5129,6 +7185,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5145,6 +7221,47 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5168,6 +7285,61 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^8.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -5215,6 +7387,45 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -5233,11 +7444,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5247,6 +7503,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -5403,6 +7688,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
@@ -5452,6 +7758,16 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
@@ -5466,6 +7782,13 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
@@ -5499,6 +7822,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -5523,6 +7859,32 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/is-wsl": {
@@ -5742,6 +8104,16 @@
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/license-checker-rseidelsohn": {
       "version": "5.0.1",
@@ -6039,10 +8411,74 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6148,6 +8584,69 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+      "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -6155,11 +8654,41 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -6317,6 +8846,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/minizlib": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
@@ -6386,6 +8922,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-gyp": {
       "version": "12.4.0",
@@ -6471,6 +9014,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-stream-zip": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.16.0.tgz",
+      "integrity": "sha512-ObaRrRoR8T68wF6suxHd7R4XQNamij6ZQHrwG7Dx1D2zeHcDNLsIOBcWrIwtDm7AsCXBguaPHgXhcjxDa2szrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -6485,6 +9042,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-bundled": {
@@ -6730,6 +9297,54 @@
         "@oxc-resolver/binding-win32-x64-msvc": "11.23.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.2.tgz",
+      "integrity": "sha512-Ll0w3fU24vYpXoZmjjZIee6bJQDgG0oAyo1PdmFYI8UDwJJddaHAypxIH9avUu+t+lSsAwKVsb1jDCMIIChliw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
@@ -6841,6 +9456,22 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-parse": {
@@ -7019,6 +9650,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -7043,6 +9706,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -7051,6 +9724,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proggy": {
@@ -7083,10 +9766,44 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7223,6 +9940,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-cmd-shim": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
@@ -7231,6 +9959,37 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recast": {
@@ -7314,6 +10073,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -7370,6 +10136,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7461,6 +10248,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -7501,6 +10295,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -7619,6 +10420,13 @@
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
+    },
+    "node_modules/split.js": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
+      "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ssri": {
       "version": "13.0.1",
@@ -7802,6 +10610,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7823,6 +10641,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/stylis": {
@@ -8091,6 +10925,16 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/typanion": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+      "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ]
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -8105,6 +10949,27 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -8113,6 +10978,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unplugin": {
@@ -8160,6 +11038,19 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -8459,6 +11350,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/write-file-atomic": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
@@ -8520,6 +11418,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -8533,6 +11447,63 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@vitest/browser-playwright": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.9",
     "@xmldom/xmldom": "^0.9.10",
-    "allure-commandline": "^2.32.0",
+    "allure": "^3.16.0",
     "jsdom": "^29.1.1",
     "license-checker-rseidelsohn": "^5.0.1",
     "playwright": "^1.61.1",

--- a/src/assets/oss-licenses.json
+++ b/src/assets/oss-licenses.json
@@ -7,6 +7,204 @@
       "repository": "https://github.com/adobe/css-tools"
     },
     {
+      "name": "@allurereport/aql",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/charts-api",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/ci",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/cli-commons",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/core",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/core-api",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/directory-watcher",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/git",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-agent",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-allure2",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-api",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-awesome",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-classic",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-csv",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-dashboard",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-jira",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-log",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-progress",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-server-reload",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-slack",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-testops",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/plugin-testplan",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/reader",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/reader-api",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/service",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/static-server",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/summary",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-awesome",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-classic",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-commons",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-components",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-dashboard",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
+      "name": "@allurereport/web-summary",
+      "version": "3.16.0",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/allure-framework/allure3"
+    },
+    {
       "name": "@asamuzakjp/css-color",
       "version": "5.1.11",
       "license": "MIT",
@@ -343,6 +541,24 @@
       "repository": "https://github.com/ExodusOSS/bytes"
     },
     {
+      "name": "@floating-ui/core",
+      "version": "1.8.0",
+      "license": "MIT",
+      "repository": "https://github.com/floating-ui/floating-ui"
+    },
+    {
+      "name": "@floating-ui/dom",
+      "version": "1.8.0",
+      "license": "MIT",
+      "repository": "https://github.com/floating-ui/floating-ui"
+    },
+    {
+      "name": "@floating-ui/utils",
+      "version": "0.2.12",
+      "license": "MIT",
+      "repository": "https://github.com/floating-ui/floating-ui"
+    },
+    {
       "name": "@gar/promise-retry",
       "version": "1.0.3",
       "license": "MIT",
@@ -407,6 +623,120 @@
       "version": "1.1.6",
       "license": "MIT",
       "repository": "https://github.com/napi-rs/napi-rs"
+    },
+    {
+      "name": "@nivo/annotations",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/arcs",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/axes",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/bar",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/canvas",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/colors",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/core",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/funnel",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/heatmap",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/legends",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/line",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/pie",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/scales",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/text",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/theming",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/tooltip",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/treemap",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nivo/voronoi",
+      "version": "0.99.0",
+      "license": "MIT",
+      "repository": "https://github.com/plouc/nivo"
+    },
+    {
+      "name": "@nodable/entities",
+      "version": "3.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/nodable/val-parsers"
     },
     {
       "name": "@npmcli/agent",
@@ -515,6 +845,60 @@
       "version": "1.0.0-next.29",
       "license": "MIT",
       "repository": "https://github.com/lukeed/polka"
+    },
+    {
+      "name": "@preact/compat",
+      "version": "18.3.2",
+      "license": "MIT",
+      "repository": "https://github.com/preactjs/compat-alias-package"
+    },
+    {
+      "name": "@preact/signals",
+      "version": "2.11.1",
+      "license": "MIT",
+      "repository": "https://github.com/preactjs/signals"
+    },
+    {
+      "name": "@preact/signals-core",
+      "version": "1.14.4",
+      "license": "MIT",
+      "repository": "https://github.com/preactjs/signals"
+    },
+    {
+      "name": "@react-spring/animated",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
+    },
+    {
+      "name": "@react-spring/core",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
+    },
+    {
+      "name": "@react-spring/rafz",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
+    },
+    {
+      "name": "@react-spring/shared",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
+    },
+    {
+      "name": "@react-spring/types",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
+    },
+    {
+      "name": "@react-spring/web",
+      "version": "10.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/pmndrs/react-spring"
     },
     {
       "name": "@rolldown/pluginutils",
@@ -775,6 +1159,78 @@
       "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
     },
     {
+      "name": "@types/d3-color",
+      "version": "3.1.3",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-delaunay",
+      "version": "6.0.4",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-format",
+      "version": "1.4.5",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-hierarchy",
+      "version": "3.1.7",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-interpolate",
+      "version": "3.0.4",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-path",
+      "version": "3.1.1",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-scale",
+      "version": "4.0.9",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-scale-chromatic",
+      "version": "3.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-shape",
+      "version": "3.2.0",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-time",
+      "version": "1.1.4",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-time-format",
+      "version": "2.3.4",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/d3-time-format",
+      "version": "3.0.4",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
       "name": "@types/deep-eql",
       "version": "4.0.2",
       "license": "MIT",
@@ -819,6 +1275,12 @@
     {
       "name": "@types/resolve",
       "version": "1.20.6",
+      "license": "MIT",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
+    },
+    {
+      "name": "@types/trusted-types",
+      "version": "2.0.7",
       "license": "MIT",
       "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped"
     },
@@ -937,10 +1399,28 @@
       "repository": "https://github.com/npm/abbrev-js"
     },
     {
+      "name": "abort-controller",
+      "version": "3.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/mysticatea/abort-controller"
+    },
+    {
       "name": "acorn",
       "version": "8.17.0",
       "license": "MIT",
       "repository": "https://github.com/acornjs/acorn"
+    },
+    {
+      "name": "adm-zip",
+      "version": "0.6.0",
+      "license": "MIT",
+      "repository": "https://github.com/cthackers/adm-zip"
+    },
+    {
+      "name": "agent-base",
+      "version": "6.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/TooTallNate/node-agent-base"
     },
     {
       "name": "agent-base",
@@ -949,10 +1429,10 @@
       "repository": "https://github.com/TooTallNate/proxy-agents"
     },
     {
-      "name": "allure-commandline",
-      "version": "2.43.0",
+      "name": "allure",
+      "version": "3.16.0",
       "license": "Apache-2.0",
-      "repository": "https://github.com/allure-framework/allure-npm"
+      "repository": "https://github.com/allure-framework/allure3"
     },
     {
       "name": "ansi-regex",
@@ -971,6 +1451,18 @@
       "version": "5.2.0",
       "license": "MIT",
       "repository": "https://github.com/chalk/ansi-styles"
+    },
+    {
+      "name": "ansi-to-html",
+      "version": "0.7.2",
+      "license": "MIT",
+      "repository": "https://github.com/rburns/ansi-to-html"
+    },
+    {
+      "name": "anynum",
+      "version": "1.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/anynum"
     },
     {
       "name": "argparse",
@@ -1009,10 +1501,22 @@
       "repository": "https://github.com/AriPerkkio/ast-v8-to-istanbul"
     },
     {
+      "name": "asynckit",
+      "version": "0.4.0",
+      "license": "MIT",
+      "repository": "https://github.com/alexindigo/asynckit"
+    },
+    {
       "name": "axe-core",
       "version": "4.12.1",
       "license": "MPL-2.0",
       "repository": "https://github.com/dequelabs/axe-core"
+    },
+    {
+      "name": "axios",
+      "version": "1.20.0",
+      "license": "MIT",
+      "repository": "https://github.com/axios/axios"
     },
     {
       "name": "babel-plugin-macros",
@@ -1025,6 +1529,12 @@
       "version": "4.0.4",
       "license": "MIT",
       "repository": "https://github.com/juliangruber/balanced-match"
+    },
+    {
+      "name": "base64-js",
+      "version": "1.5.1",
+      "license": "MIT",
+      "repository": "https://github.com/beatgammit/base64-js"
     },
     {
       "name": "baseline-browser-mapping",
@@ -1046,7 +1556,7 @@
     },
     {
       "name": "brace-expansion",
-      "version": "5.0.8",
+      "version": "5.0.9",
       "license": "MIT",
       "repository": "https://github.com/juliangruber/brace-expansion"
     },
@@ -1055,6 +1565,12 @@
       "version": "4.28.4",
       "license": "MIT",
       "repository": "https://github.com/browserslist/browserslist"
+    },
+    {
+      "name": "buffer",
+      "version": "6.0.3",
+      "license": "MIT",
+      "repository": "https://github.com/feross/buffer"
     },
     {
       "name": "bundle-name",
@@ -1067,6 +1583,12 @@
       "version": "20.0.4",
       "license": "ISC",
       "repository": "https://github.com/npm/cacache"
+    },
+    {
+      "name": "call-bind-apply-helpers",
+      "version": "1.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/call-bind-apply-helpers"
     },
     {
       "name": "callsites",
@@ -1099,10 +1621,22 @@
       "repository": "https://github.com/chalk/chalk"
     },
     {
+      "name": "charenc",
+      "version": "0.0.2",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/pvorb/node-charenc"
+    },
+    {
       "name": "check-error",
       "version": "2.1.3",
       "license": "MIT",
       "repository": "https://github.com/chaijs/check-error"
+    },
+    {
+      "name": "chokidar",
+      "version": "5.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/paulmillr/chokidar"
     },
     {
       "name": "chownr",
@@ -1115,6 +1649,12 @@
       "version": "2.5.1",
       "license": "MIT",
       "repository": "https://github.com/JedWatson/classnames"
+    },
+    {
+      "name": "clipanion",
+      "version": "4.0.0-rc.4",
+      "license": "MIT",
+      "repository": "https://github.com/arcanis/clipanion"
     },
     {
       "name": "clsx",
@@ -1141,10 +1681,22 @@
       "repository": "https://github.com/colorjs/color-name"
     },
     {
+      "name": "combined-stream",
+      "version": "1.0.8",
+      "license": "MIT",
+      "repository": "https://github.com/felixge/node-combined-stream"
+    },
+    {
       "name": "common-ancestor-path",
       "version": "2.0.0",
       "license": "BlueOak-1.0.0",
       "repository": "https://github.com/isaacs/common-ancestor-path"
+    },
+    {
+      "name": "compress-commons",
+      "version": "7.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/archiverjs/node-compress-commons"
     },
     {
       "name": "convert-source-map",
@@ -1163,6 +1715,24 @@
       "version": "7.1.0",
       "license": "MIT",
       "repository": "https://github.com/davidtheclark/cosmiconfig"
+    },
+    {
+      "name": "crc-32",
+      "version": "1.2.2",
+      "license": "Apache-2.0",
+      "repository": "https://github.com/SheetJS/js-crc32"
+    },
+    {
+      "name": "crc32-stream",
+      "version": "7.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/archiverjs/node-crc32-stream"
+    },
+    {
+      "name": "crypt",
+      "version": "0.0.2",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/pvorb/node-crypt"
     },
     {
       "name": "css-tree",
@@ -1187,6 +1757,162 @@
       "version": "3.2.3",
       "license": "MIT",
       "repository": "https://github.com/frenic/csstype"
+    },
+    {
+      "name": "d3-array",
+      "version": "3.2.4",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-array"
+    },
+    {
+      "name": "d3-axis",
+      "version": "3.0.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-axis"
+    },
+    {
+      "name": "d3-brush",
+      "version": "3.0.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-brush"
+    },
+    {
+      "name": "d3-collection",
+      "version": "1.0.7",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-collection"
+    },
+    {
+      "name": "d3-color",
+      "version": "3.1.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-color"
+    },
+    {
+      "name": "d3-delaunay",
+      "version": "6.0.4",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-delaunay"
+    },
+    {
+      "name": "d3-dispatch",
+      "version": "3.0.1",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-dispatch"
+    },
+    {
+      "name": "d3-drag",
+      "version": "3.0.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-drag"
+    },
+    {
+      "name": "d3-ease",
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-ease"
+    },
+    {
+      "name": "d3-format",
+      "version": "1.4.5",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-format"
+    },
+    {
+      "name": "d3-format",
+      "version": "3.1.2",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-format"
+    },
+    {
+      "name": "d3-hierarchy",
+      "version": "3.1.2",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-hierarchy"
+    },
+    {
+      "name": "d3-interpolate",
+      "version": "3.0.1",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-interpolate"
+    },
+    {
+      "name": "d3-path",
+      "version": "3.1.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-path"
+    },
+    {
+      "name": "d3-regression",
+      "version": "1.3.10",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/HarryStevens/d3-regression"
+    },
+    {
+      "name": "d3-scale",
+      "version": "4.0.2",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-scale"
+    },
+    {
+      "name": "d3-scale-chromatic",
+      "version": "3.1.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-scale-chromatic"
+    },
+    {
+      "name": "d3-selection",
+      "version": "1.4.2",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-selection"
+    },
+    {
+      "name": "d3-selection",
+      "version": "3.0.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-selection"
+    },
+    {
+      "name": "d3-shape",
+      "version": "3.2.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-shape"
+    },
+    {
+      "name": "d3-time",
+      "version": "1.1.0",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-time"
+    },
+    {
+      "name": "d3-time",
+      "version": "3.1.0",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-time"
+    },
+    {
+      "name": "d3-time-format",
+      "version": "3.0.0",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/d3/d3-time-format"
+    },
+    {
+      "name": "d3-timer",
+      "version": "3.0.1",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-timer"
+    },
+    {
+      "name": "d3-tip",
+      "version": "0.9.1",
+      "license": "MIT",
+      "repository": "https://github.com/Caged/d3-tip"
+    },
+    {
+      "name": "d3-transition",
+      "version": "3.0.1",
+      "license": "ISC",
+      "repository": "https://github.com/d3/d3-transition"
     },
     {
       "name": "data-urls",
@@ -1214,7 +1940,7 @@
     },
     {
       "name": "default-browser",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "repository": "https://github.com/sindresorhus/default-browser"
     },
@@ -1229,6 +1955,18 @@
       "version": "3.0.0",
       "license": "MIT",
       "repository": "https://github.com/sindresorhus/define-lazy-prop"
+    },
+    {
+      "name": "delaunator",
+      "version": "5.1.0",
+      "license": "ISC",
+      "repository": "https://github.com/mapbox/delaunator"
+    },
+    {
+      "name": "delayed-stream",
+      "version": "1.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/felixge/node-delayed-stream"
     },
     {
       "name": "dequal",
@@ -1267,6 +2005,18 @@
       "repository": "https://github.com/eps1lon/dom-accessibility-api"
     },
     {
+      "name": "dompurify",
+      "version": "3.4.14",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "repository": "https://github.com/cure53/DOMPurify"
+    },
+    {
+      "name": "dunder-proto",
+      "version": "1.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/es-shims/dunder-proto"
+    },
+    {
       "name": "electron-to-chromium",
       "version": "1.5.377",
       "license": "ISC",
@@ -1283,6 +2033,18 @@
       "version": "5.21.6",
       "license": "MIT",
       "repository": "https://github.com/webpack/enhanced-resolve"
+    },
+    {
+      "name": "entities",
+      "version": "2.2.0",
+      "license": "BSD-2-Clause",
+      "repository": "https://github.com/fb55/entities"
+    },
+    {
+      "name": "entities",
+      "version": "4.5.0",
+      "license": "BSD-2-Clause",
+      "repository": "https://github.com/fb55/entities"
     },
     {
       "name": "entities",
@@ -1303,6 +2065,12 @@
       "repository": "https://github.com/qix-/node-error-ex"
     },
     {
+      "name": "es-define-property",
+      "version": "1.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/es-define-property"
+    },
+    {
       "name": "es-errors",
       "version": "1.3.0",
       "license": "MIT",
@@ -1313,6 +2081,18 @@
       "version": "2.1.0",
       "license": "MIT",
       "repository": "https://github.com/guybedford/es-module-lexer"
+    },
+    {
+      "name": "es-object-atoms",
+      "version": "1.1.2",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/es-object-atoms"
+    },
+    {
+      "name": "es-set-tostringtag",
+      "version": "2.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/es-shims/es-set-tostringtag"
     },
     {
       "name": "esbuild",
@@ -1357,6 +2137,18 @@
       "repository": "https://github.com/estools/esutils"
     },
     {
+      "name": "event-target-shim",
+      "version": "5.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/mysticatea/event-target-shim"
+    },
+    {
+      "name": "events",
+      "version": "3.3.0",
+      "license": "MIT",
+      "repository": "https://github.com/Gozala/events"
+    },
+    {
       "name": "expect-type",
       "version": "1.3.0",
       "license": "Apache-2.0",
@@ -1369,6 +2161,18 @@
       "repository": "https://github.com/coveooss/exponential-backoff"
     },
     {
+      "name": "fast-xml-builder",
+      "version": "1.3.1",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/fast-xml-builder"
+    },
+    {
+      "name": "fast-xml-parser",
+      "version": "5.11.1",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/fast-xml-parser"
+    },
+    {
       "name": "fdir",
       "version": "6.5.0",
       "license": "MIT",
@@ -1379,6 +2183,24 @@
       "version": "1.1.0",
       "license": "MIT",
       "repository": "https://github.com/js-n/find-root"
+    },
+    {
+      "name": "find-up",
+      "version": "8.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/find-up"
+    },
+    {
+      "name": "follow-redirects",
+      "version": "1.16.0",
+      "license": "MIT",
+      "repository": "https://github.com/follow-redirects/follow-redirects"
+    },
+    {
+      "name": "form-data",
+      "version": "4.0.6",
+      "license": "MIT",
+      "repository": "https://github.com/form-data/form-data"
     },
     {
       "name": "fs-minipass",
@@ -1399,10 +2221,28 @@
       "repository": "https://github.com/loganfsmyth/gensync"
     },
     {
+      "name": "get-intrinsic",
+      "version": "1.3.0",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/get-intrinsic"
+    },
+    {
+      "name": "get-proto",
+      "version": "1.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/get-proto"
+    },
+    {
       "name": "glob",
       "version": "13.0.6",
       "license": "BlueOak-1.0.0",
       "repository": "https://github.com/isaacs/node-glob"
+    },
+    {
+      "name": "gopd",
+      "version": "1.2.0",
+      "license": "MIT",
+      "repository": "https://github.com/ljharb/gopd"
     },
     {
       "name": "graceful-fs",
@@ -1411,10 +2251,28 @@
       "repository": "https://github.com/isaacs/node-graceful-fs"
     },
     {
+      "name": "handlebars",
+      "version": "4.7.9",
+      "license": "MIT",
+      "repository": "https://github.com/handlebars-lang/handlebars.js"
+    },
+    {
       "name": "has-flag",
       "version": "4.0.0",
       "license": "MIT",
       "repository": "https://github.com/sindresorhus/has-flag"
+    },
+    {
+      "name": "has-symbols",
+      "version": "1.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/inspect-js/has-symbols"
+    },
+    {
+      "name": "has-tostringtag",
+      "version": "1.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/inspect-js/has-tostringtag"
     },
     {
       "name": "hasown",
@@ -1466,9 +2324,21 @@
     },
     {
       "name": "https-proxy-agent",
+      "version": "5.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/TooTallNate/node-https-proxy-agent"
+    },
+    {
+      "name": "https-proxy-agent",
       "version": "7.0.6",
       "license": "MIT",
       "repository": "https://github.com/TooTallNate/proxy-agents"
+    },
+    {
+      "name": "i18next",
+      "version": "24.2.3",
+      "license": "MIT",
+      "repository": "https://github.com/i18next/i18next"
     },
     {
       "name": "i18next",
@@ -1481,6 +2351,12 @@
       "version": "0.7.3",
       "license": "MIT",
       "repository": "https://github.com/pillarjs/iconv-lite"
+    },
+    {
+      "name": "ieee754",
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/feross/ieee754"
     },
     {
       "name": "ignore-walk",
@@ -1507,6 +2383,12 @@
       "repository": "https://github.com/npm/ini"
     },
     {
+      "name": "internmap",
+      "version": "2.0.3",
+      "license": "ISC",
+      "repository": "https://github.com/mbostock/internmap"
+    },
+    {
       "name": "ip-address",
       "version": "10.3.1",
       "license": "MIT",
@@ -1517,6 +2399,12 @@
       "version": "0.2.1",
       "license": "MIT",
       "repository": "https://github.com/qix-/node-is-arrayish"
+    },
+    {
+      "name": "is-buffer",
+      "version": "1.1.6",
+      "license": "MIT",
+      "repository": "https://github.com/feross/is-buffer"
     },
     {
       "name": "is-core-module",
@@ -1531,6 +2419,12 @@
       "repository": "https://github.com/sindresorhus/is-docker"
     },
     {
+      "name": "is-in-ssh",
+      "version": "1.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/is-in-ssh"
+    },
+    {
       "name": "is-inside-container",
       "version": "1.0.0",
       "license": "MIT",
@@ -1541,6 +2435,18 @@
       "version": "1.0.1",
       "license": "MIT",
       "repository": "https://github.com/mathiasbynens/is-potential-custom-element-name"
+    },
+    {
+      "name": "is-stream",
+      "version": "4.0.1",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/is-stream"
+    },
+    {
+      "name": "is-unsafe",
+      "version": "2.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/is-unsafe"
     },
     {
       "name": "is-wsl",
@@ -1592,7 +2498,7 @@
     },
     {
       "name": "js-yaml",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "repository": "https://github.com/nodeca/js-yaml"
     },
@@ -1651,6 +2557,12 @@
       "repository": "https://github.com/angus-c/just"
     },
     {
+      "name": "kleur",
+      "version": "3.0.3",
+      "license": "MIT",
+      "repository": "https://github.com/lukeed/kleur"
+    },
+    {
       "name": "license-checker-rseidelsohn",
       "version": "5.0.1",
       "license": "BSD-3-Clause",
@@ -1675,8 +2587,44 @@
       "repository": "https://github.com/eventualbuddha/lines-and-columns"
     },
     {
+      "name": "linkify-it",
+      "version": "5.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/markdown-it/linkify-it"
+    },
+    {
+      "name": "locate-path",
+      "version": "8.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/locate-path"
+    },
+    {
+      "name": "lodash",
+      "version": "4.18.1",
+      "license": "MIT",
+      "repository": "https://github.com/lodash/lodash"
+    },
+    {
+      "name": "lodash-es",
+      "version": "4.18.1",
+      "license": "MIT",
+      "repository": "https://github.com/lodash/lodash"
+    },
+    {
       "name": "lodash.clonedeep",
       "version": "4.5.0",
+      "license": "MIT",
+      "repository": "https://github.com/lodash/lodash"
+    },
+    {
+      "name": "lodash.debounce",
+      "version": "4.0.8",
+      "license": "MIT",
+      "repository": "https://github.com/lodash/lodash"
+    },
+    {
+      "name": "lodash.omit",
+      "version": "4.18.0",
       "license": "MIT",
       "repository": "https://github.com/lodash/lodash"
     },
@@ -1735,16 +2683,52 @@
       "repository": "https://github.com/npm/make-fetch-happen"
     },
     {
+      "name": "markdown-it",
+      "version": "14.3.1",
+      "license": "MIT",
+      "repository": "https://github.com/markdown-it/markdown-it"
+    },
+    {
+      "name": "math-intrinsics",
+      "version": "1.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/es-shims/math-intrinsics"
+    },
+    {
+      "name": "md5",
+      "version": "2.3.0",
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/pvorb/node-md5"
+    },
+    {
       "name": "mdn-data",
       "version": "2.27.1",
       "license": "CC0-1.0",
       "repository": "https://github.com/mdn/data"
     },
     {
+      "name": "mdurl",
+      "version": "2.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/markdown-it/mdurl"
+    },
+    {
       "name": "memoize-one",
       "version": "6.0.0",
       "license": "MIT",
       "repository": "https://github.com/alexreardon/memoize-one"
+    },
+    {
+      "name": "mime-db",
+      "version": "1.52.0",
+      "license": "MIT",
+      "repository": "https://github.com/jshttp/mime-db"
+    },
+    {
+      "name": "mime-types",
+      "version": "2.1.35",
+      "license": "MIT",
+      "repository": "https://github.com/jshttp/mime-types"
     },
     {
       "name": "min-indent",
@@ -1807,6 +2791,12 @@
       "repository": "https://github.com/isaacs/minipass-sized"
     },
     {
+      "name": "minisearch",
+      "version": "7.2.0",
+      "license": "MIT",
+      "repository": "https://github.com/lucaong/minisearch"
+    },
+    {
       "name": "minizlib",
       "version": "3.1.0",
       "license": "MIT",
@@ -1832,7 +2822,13 @@
     },
     {
       "name": "nanoid",
-      "version": "3.3.16",
+      "version": "3.3.18",
+      "license": "MIT",
+      "repository": "https://github.com/ai/nanoid"
+    },
+    {
+      "name": "nanoid",
+      "version": "5.1.16",
       "license": "MIT",
       "repository": "https://github.com/ai/nanoid"
     },
@@ -1841,6 +2837,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "repository": "https://github.com/jshttp/negotiator"
+    },
+    {
+      "name": "neo-async",
+      "version": "2.6.2",
+      "license": "MIT",
+      "repository": "https://github.com/suguru03/neo-async"
     },
     {
       "name": "node-gyp",
@@ -1855,6 +2857,12 @@
       "repository": "https://github.com/chicoxyzzy/node-releases"
     },
     {
+      "name": "node-stream-zip",
+      "version": "1.16.0",
+      "license": "MIT",
+      "repository": "https://github.com/antelle/node-stream-zip"
+    },
+    {
       "name": "nopt",
       "version": "7.2.1",
       "license": "ISC",
@@ -1865,6 +2873,12 @@
       "version": "9.0.0",
       "license": "ISC",
       "repository": "https://github.com/npm/nopt"
+    },
+    {
+      "name": "normalize-path",
+      "version": "3.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/jonschlinkert/normalize-path"
     },
     {
       "name": "npm-bundled",
@@ -1921,6 +2935,12 @@
       "repository": "https://github.com/sindresorhus/open"
     },
     {
+      "name": "open",
+      "version": "11.0.2",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/open"
+    },
+    {
       "name": "oxc-parser",
       "version": "0.127.0",
       "license": "MIT",
@@ -1931,6 +2951,24 @@
       "version": "11.23.0",
       "license": "MIT",
       "repository": "https://github.com/oxc-project/oxc-resolver"
+    },
+    {
+      "name": "p-limit",
+      "version": "4.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/p-limit"
+    },
+    {
+      "name": "p-limit",
+      "version": "7.3.2",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/p-limit"
+    },
+    {
+      "name": "p-locate",
+      "version": "6.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/p-locate"
     },
     {
       "name": "p-map",
@@ -1967,6 +3005,12 @@
       "version": "8.0.1",
       "license": "MIT",
       "repository": "https://github.com/inikulin/parse5"
+    },
+    {
+      "name": "path-expression-matcher",
+      "version": "1.6.2",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/path-expression-matcher"
     },
     {
       "name": "path-parse",
@@ -2041,16 +3085,46 @@
       "repository": "https://github.com/postcss/postcss-selector-parser"
     },
     {
+      "name": "powershell-utils",
+      "version": "0.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/powershell-utils"
+    },
+    {
+      "name": "powershell-utils",
+      "version": "0.2.1",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/powershell-utils"
+    },
+    {
+      "name": "preact",
+      "version": "10.29.8",
+      "license": "MIT",
+      "repository": "https://github.com/preactjs/preact"
+    },
+    {
       "name": "pretty-format",
       "version": "27.5.1",
       "license": "MIT",
       "repository": "https://github.com/facebook/jest"
     },
     {
+      "name": "prismjs",
+      "version": "1.30.0",
+      "license": "MIT",
+      "repository": "https://github.com/PrismJS/prism"
+    },
+    {
       "name": "proc-log",
       "version": "6.1.0",
       "license": "ISC",
       "repository": "https://github.com/npm/proc-log"
+    },
+    {
+      "name": "process",
+      "version": "0.11.10",
+      "license": "MIT",
+      "repository": "https://github.com/shtylman/node-process"
     },
     {
       "name": "proggy",
@@ -2071,7 +3145,25 @@
       "repository": "https://github.com/isaacs/promise-call-limit"
     },
     {
+      "name": "prompts",
+      "version": "2.4.2",
+      "license": "MIT",
+      "repository": "https://github.com/terkelg/prompts"
+    },
+    {
+      "name": "proxy-from-env",
+      "version": "2.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/Rob--W/proxy-from-env"
+    },
+    {
       "name": "punycode",
+      "version": "2.3.1",
+      "license": "MIT",
+      "repository": "https://github.com/mathiasbynens/punycode.js"
+    },
+    {
+      "name": "punycode.js",
       "version": "2.3.1",
       "license": "MIT",
       "repository": "https://github.com/mathiasbynens/punycode.js"
@@ -2131,10 +3223,28 @@
       "repository": "https://github.com/facebook/react"
     },
     {
+      "name": "react-virtualized-auto-sizer",
+      "version": "1.0.26",
+      "license": "MIT",
+      "repository": "https://github.com/bvaughn/react-virtualized-auto-sizer"
+    },
+    {
       "name": "read-cmd-shim",
       "version": "6.0.0",
       "license": "ISC",
       "repository": "https://github.com/npm/read-cmd-shim"
+    },
+    {
+      "name": "readable-stream",
+      "version": "4.7.0",
+      "license": "MIT",
+      "repository": "https://github.com/nodejs/readable-stream"
+    },
+    {
+      "name": "readdirp",
+      "version": "5.1.1",
+      "license": "MIT",
+      "repository": "https://github.com/paulmillr/readdirp"
     },
     {
       "name": "recast",
@@ -2167,6 +3277,12 @@
       "repository": "https://github.com/sindresorhus/resolve-from"
     },
     {
+      "name": "robust-predicates",
+      "version": "3.0.3",
+      "license": "Unlicense",
+      "repository": "https://github.com/mourner/robust-predicates"
+    },
+    {
       "name": "rollup",
       "version": "4.62.2",
       "license": "MIT",
@@ -2177,6 +3293,12 @@
       "version": "7.1.0",
       "license": "MIT",
       "repository": "https://github.com/sindresorhus/run-applescript"
+    },
+    {
+      "name": "safe-buffer",
+      "version": "5.2.1",
+      "license": "MIT",
+      "repository": "https://github.com/feross/safe-buffer"
     },
     {
       "name": "safer-buffer",
@@ -2233,6 +3355,12 @@
       "repository": "https://github.com/lukeed/sirv"
     },
     {
+      "name": "sisteransi",
+      "version": "1.0.5",
+      "license": "MIT",
+      "repository": "https://github.com/terkelg/sisteransi"
+    },
+    {
       "name": "smart-buffer",
       "version": "4.2.0",
       "license": "MIT",
@@ -2249,6 +3377,12 @@
       "version": "8.0.5",
       "license": "MIT",
       "repository": "https://github.com/TooTallNate/proxy-agents"
+    },
+    {
+      "name": "sortablejs",
+      "version": "1.15.7",
+      "license": "MIT",
+      "repository": "https://github.com/SortableJS/Sortable"
     },
     {
       "name": "source-map",
@@ -2317,6 +3451,12 @@
       "repository": "https://github.com/kemitchell/spdx-satisfies.js"
     },
     {
+      "name": "split.js",
+      "version": "1.6.5",
+      "license": "MIT",
+      "repository": "https://github.com/nathancahill/split"
+    },
+    {
       "name": "ssri",
       "version": "13.0.1",
       "license": "ISC",
@@ -2341,6 +3481,12 @@
       "repository": "https://github.com/storybookjs/storybook"
     },
     {
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "license": "MIT",
+      "repository": "https://github.com/nodejs/string_decoder"
+    },
+    {
       "name": "strip-bom",
       "version": "3.0.0",
       "license": "MIT",
@@ -2357,6 +3503,12 @@
       "version": "4.1.1",
       "license": "MIT",
       "repository": "https://github.com/sindresorhus/strip-indent"
+    },
+    {
+      "name": "strnum",
+      "version": "2.4.2",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/strnum"
     },
     {
       "name": "stylis",
@@ -2515,10 +3667,28 @@
       "repository": "https://github.com/theupdateframework/tuf-js"
     },
     {
+      "name": "typanion",
+      "version": "3.14.0",
+      "license": "MIT",
+      "repository": "https://github.com/arcanis/typanion"
+    },
+    {
       "name": "typescript",
       "version": "5.8.3",
       "license": "Apache-2.0",
       "repository": "https://github.com/microsoft/TypeScript"
+    },
+    {
+      "name": "uc.micro",
+      "version": "2.1.0",
+      "license": "MIT",
+      "repository": "https://github.com/markdown-it/uc.micro"
+    },
+    {
+      "name": "uglify-js",
+      "version": "3.19.3",
+      "license": "BSD-2-Clause",
+      "repository": "https://github.com/mishoo/UglifyJS"
     },
     {
       "name": "undici",
@@ -2528,9 +3698,15 @@
     },
     {
       "name": "undici",
-      "version": "7.28.0",
+      "version": "7.29.0",
       "license": "MIT",
       "repository": "https://github.com/nodejs/undici"
+    },
+    {
+      "name": "unicorn-magic",
+      "version": "0.3.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/unicorn-magic"
     },
     {
       "name": "unplugin",
@@ -2543,6 +3719,12 @@
       "version": "1.2.3",
       "license": "MIT",
       "repository": "https://github.com/browserslist/update-db"
+    },
+    {
+      "name": "use-debounce",
+      "version": "10.1.1",
+      "license": "MIT",
+      "repository": "https://github.com/xnimorz/use-debounce"
     },
     {
       "name": "use-sync-external-store",
@@ -2629,6 +3811,12 @@
       "repository": "https://github.com/mafintosh/why-is-node-running"
     },
     {
+      "name": "wordwrap",
+      "version": "1.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/substack/node-wordwrap"
+    },
+    {
       "name": "write-file-atomic",
       "version": "7.0.1",
       "license": "ISC",
@@ -2647,10 +3835,22 @@
       "repository": "https://github.com/sindresorhus/wsl-utils"
     },
     {
+      "name": "wsl-utils",
+      "version": "1.0.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/wsl-utils"
+    },
+    {
       "name": "xml-name-validator",
       "version": "5.0.0",
       "license": "Apache-2.0",
       "repository": "https://github.com/jsdom/xml-name-validator"
+    },
+    {
+      "name": "xml-naming",
+      "version": "0.3.0",
+      "license": "MIT",
+      "repository": "https://github.com/NaturalIntelligence/xml-naming"
     },
     {
       "name": "xmlchars",
@@ -2681,6 +3881,30 @@
       "version": "1.10.3",
       "license": "ISC",
       "repository": "https://github.com/eemeli/yaml"
+    },
+    {
+      "name": "yaml",
+      "version": "2.9.0",
+      "license": "ISC",
+      "repository": "https://github.com/eemeli/yaml"
+    },
+    {
+      "name": "yocto-queue",
+      "version": "1.2.2",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/yocto-queue"
+    },
+    {
+      "name": "yoctocolors",
+      "version": "2.2.0",
+      "license": "MIT",
+      "repository": "https://github.com/sindresorhus/yoctocolors"
+    },
+    {
+      "name": "zip-stream",
+      "version": "7.0.5",
+      "license": "MIT",
+      "repository": "https://github.com/archiverjs/node-zip-stream"
     }
   ],
   "rust": [
@@ -2746,7 +3970,7 @@
     },
     {
       "name": "anyhow",
-      "version": "1.0.103",
+      "version": "1.0.104",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/anyhow"
     },
@@ -2806,7 +4030,7 @@
     },
     {
       "name": "async-trait",
-      "version": "0.1.89",
+      "version": "0.1.91",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/async-trait"
     },
@@ -2866,7 +4090,7 @@
     },
     {
       "name": "bitflags",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/bitflags/bitflags"
     },
@@ -2914,7 +4138,7 @@
     },
     {
       "name": "bytemuck",
-      "version": "1.25.0",
+      "version": "1.25.2",
       "license": "Zlib OR Apache-2.0 OR MIT",
       "repository": "https://github.com/Lokathor/bytemuck"
     },
@@ -2926,7 +4150,7 @@
     },
     {
       "name": "bytes",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "repository": "https://github.com/tokio-rs/bytes"
     },
@@ -2944,7 +4168,7 @@
     },
     {
       "name": "camino",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/camino-rs/camino"
     },
@@ -2968,7 +4192,7 @@
     },
     {
       "name": "cc",
-      "version": "1.2.65",
+      "version": "1.4.0",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/cc-rs"
     },
@@ -3004,19 +4228,19 @@
     },
     {
       "name": "clap",
-      "version": "4.6.1",
+      "version": "4.6.4",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/clap-rs/clap"
     },
     {
       "name": "clap_builder",
-      "version": "4.6.0",
+      "version": "4.6.2",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/clap-rs/clap"
     },
     {
       "name": "clap_derive",
-      "version": "4.6.1",
+      "version": "4.6.4",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/clap-rs/clap"
     },
@@ -3088,13 +4312,13 @@
     },
     {
       "name": "crossbeam-channel",
-      "version": "0.5.15",
+      "version": "0.5.16",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/crossbeam-rs/crossbeam"
     },
     {
       "name": "crossbeam-utils",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/crossbeam-rs/crossbeam"
     },
@@ -3148,7 +4372,7 @@
     },
     {
       "name": "dbus",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "Apache-2.0/MIT",
       "repository": "https://github.com/diwic/dbus-rs"
     },
@@ -3280,7 +4504,7 @@
     },
     {
       "name": "embed-resource",
-      "version": "3.0.9",
+      "version": "3.0.11",
       "license": "MIT",
       "repository": "https://github.com/nabijaczleweli/rust-embed-resource"
     },
@@ -3334,7 +4558,7 @@
     },
     {
       "name": "fastrand",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/smol-rs/fastrand"
     },
@@ -3388,7 +4612,7 @@
     },
     {
       "name": "foreign-types-macros",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT/Apache-2.0",
       "repository": "https://github.com/sfackler/foreign-types"
     },
@@ -3412,25 +4636,25 @@
     },
     {
       "name": "futures-channel",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-core",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-executor",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-io",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
@@ -3442,25 +4666,25 @@
     },
     {
       "name": "futures-macro",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-sink",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-task",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
     {
       "name": "futures-util",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/futures-rs"
     },
@@ -3562,7 +4786,7 @@
     },
     {
       "name": "glob",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/glob"
     },
@@ -3640,13 +4864,13 @@
     },
     {
       "name": "http-body",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "repository": "https://github.com/hyperium/http-body"
     },
     {
       "name": "http-body-util",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "repository": "https://github.com/hyperium/http-body"
     },
@@ -3658,7 +4882,7 @@
     },
     {
       "name": "hyper",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "repository": "https://github.com/hyperium/hyper"
     },
@@ -3838,7 +5062,7 @@
     },
     {
       "name": "js-sys",
-      "version": "0.3.102",
+      "version": "0.3.103",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys"
     },
@@ -3874,7 +5098,7 @@
     },
     {
       "name": "libc",
-      "version": "0.2.186",
+      "version": "0.2.189",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/libc"
     },
@@ -3892,7 +5116,7 @@
     },
     {
       "name": "libredox",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "repository": "https://gitlab.redox-os.org/redox-os/libredox.git"
     },
@@ -3928,7 +5152,7 @@
     },
     {
       "name": "memchr",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "Unlicense OR MIT",
       "repository": "https://github.com/BurntSushi/memchr"
     },
@@ -3952,7 +5176,7 @@
     },
     {
       "name": "mio",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "repository": "https://github.com/tokio-rs/mio"
     },
@@ -4126,7 +5350,7 @@
     },
     {
       "name": "open",
-      "version": "5.3.5",
+      "version": "5.4.0",
       "license": "MIT",
       "repository": "https://github.com/Byron/open-rs"
     },
@@ -4195,12 +5419,6 @@
       "version": "0.9.12",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/Amanieu/parking_lot"
-    },
-    {
-      "name": "pathdiff",
-      "version": "0.2.3",
-      "license": "MIT/Apache-2.0",
-      "repository": "https://github.com/Manishearth/pathdiff"
     },
     {
       "name": "percent-encoding",
@@ -4330,7 +5548,7 @@
     },
     {
       "name": "proc-macro2",
-      "version": "1.0.106",
+      "version": "1.0.107",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/proc-macro2"
     },
@@ -4342,7 +5560,7 @@
     },
     {
       "name": "quote",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/quote"
     },
@@ -4384,25 +5602,25 @@
     },
     {
       "name": "ref-cast",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/ref-cast"
     },
     {
       "name": "ref-cast-impl",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/ref-cast"
     },
     {
       "name": "regex",
-      "version": "1.12.4",
+      "version": "1.13.1",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/regex"
     },
     {
       "name": "regex-automata",
-      "version": "0.4.14",
+      "version": "0.4.16",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/regex"
     },
@@ -4432,7 +5650,7 @@
     },
     {
       "name": "rustc-hash",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/rust-lang/rustc-hash"
     },
@@ -4444,13 +5662,13 @@
     },
     {
       "name": "rustls-pki-types",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rustls/pki-types"
     },
     {
       "name": "rustversion",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/rustversion"
     },
@@ -4522,19 +5740,19 @@
     },
     {
       "name": "serde",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/serde-rs/serde"
     },
     {
       "name": "serde_core",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/serde-rs/serde"
     },
     {
       "name": "serde_derive",
-      "version": "1.0.228",
+      "version": "1.0.229",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/serde-rs/serde"
     },
@@ -4546,13 +5764,13 @@
     },
     {
       "name": "serde_json",
-      "version": "1.0.150",
+      "version": "1.0.151",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/serde-rs/json"
     },
     {
       "name": "serde_repr",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/serde-repr"
     },
@@ -4624,7 +5842,7 @@
     },
     {
       "name": "simd-adler32",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "repository": "https://github.com/mcountryman/simd-adler32"
     },
@@ -4648,7 +5866,7 @@
     },
     {
       "name": "socket2",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/rust-lang/socket2"
     },
@@ -4708,7 +5926,13 @@
     },
     {
       "name": "syn",
-      "version": "2.0.118",
+      "version": "2.0.119",
+      "license": "MIT OR Apache-2.0",
+      "repository": "https://github.com/dtolnay/syn"
+    },
+    {
+      "name": "syn",
+      "version": "3.0.3",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/syn"
     },
@@ -4750,7 +5974,7 @@
     },
     {
       "name": "tauri",
-      "version": "2.11.3",
+      "version": "2.11.5",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/tauri-apps/tauri"
     },
@@ -4780,7 +6004,7 @@
     },
     {
       "name": "tauri-plugin-dialog",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/tauri-apps/plugins-workspace"
     },
@@ -4804,7 +6028,7 @@
     },
     {
       "name": "tauri-runtime-wry",
-      "version": "2.11.3",
+      "version": "2.11.4",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/tauri-apps/tauri"
     },
@@ -4828,7 +6052,7 @@
     },
     {
       "name": "tendril",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/servo/html5ever"
     },
@@ -4840,7 +6064,7 @@
     },
     {
       "name": "thiserror",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/thiserror"
     },
@@ -4852,13 +6076,13 @@
     },
     {
       "name": "thiserror-impl",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/dtolnay/thiserror"
     },
     {
       "name": "time",
-      "version": "0.3.51",
+      "version": "0.3.54",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/time-rs/time"
     },
@@ -4870,7 +6094,7 @@
     },
     {
       "name": "time-macros",
-      "version": "0.2.30",
+      "version": "0.2.32",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/time-rs/time"
     },
@@ -4882,7 +6106,7 @@
     },
     {
       "name": "tinyvec",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Zlib OR Apache-2.0 OR MIT",
       "repository": "https://github.com/Lokathor/tinyvec"
     },
@@ -4894,13 +6118,13 @@
     },
     {
       "name": "tokio",
-      "version": "1.52.3",
+      "version": "1.53.1",
       "license": "MIT",
       "repository": "https://github.com/tokio-rs/tokio"
     },
     {
       "name": "tokio-macros",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "repository": "https://github.com/tokio-rs/tokio"
     },
@@ -4912,7 +6136,7 @@
     },
     {
       "name": "tokio-util",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "MIT",
       "repository": "https://github.com/tokio-rs/tokio"
     },
@@ -4930,7 +6154,7 @@
     },
     {
       "name": "toml",
-      "version": "1.1.2+spec-1.1.0",
+      "version": "1.1.3+spec-1.1.0",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/toml-rs/toml"
     },
@@ -4966,7 +6190,7 @@
     },
     {
       "name": "toml_edit",
-      "version": "0.25.12+spec-1.1.0",
+      "version": "0.25.13+spec-1.1.0",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/toml-rs/toml"
     },
@@ -4978,7 +6202,7 @@
     },
     {
       "name": "toml_writer",
-      "version": "1.1.1+spec-1.1.0",
+      "version": "1.1.2+spec-1.1.0",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/toml-rs/toml"
     },
@@ -5109,12 +6333,6 @@
       "repository": "https://github.com/denoland/rust-urlpattern"
     },
     {
-      "name": "utf-8",
-      "version": "0.7.6",
-      "license": "MIT OR Apache-2.0",
-      "repository": "https://github.com/SimonSapin/rust-utf8"
-    },
-    {
       "name": "utf8_iter",
       "version": "1.0.4",
       "license": "Apache-2.0 OR MIT",
@@ -5128,7 +6346,7 @@
     },
     {
       "name": "uuid",
-      "version": "1.23.3",
+      "version": "1.24.0",
       "license": "Apache-2.0 OR MIT",
       "repository": "https://github.com/uuid-rs/uuid"
     },
@@ -5188,31 +6406,31 @@
     },
     {
       "name": "wasm-bindgen",
-      "version": "0.2.125",
+      "version": "0.2.126",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen"
     },
     {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.75",
+      "version": "0.4.76",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures"
     },
     {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.125",
+      "version": "0.2.126",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro"
     },
     {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.125",
+      "version": "0.2.126",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support"
     },
     {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.125",
+      "version": "0.2.126",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared"
     },
@@ -5230,7 +6448,7 @@
     },
     {
       "name": "web-sys",
-      "version": "0.3.102",
+      "version": "0.3.103",
       "license": "MIT OR Apache-2.0",
       "repository": "https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys"
     },
@@ -5584,13 +6802,19 @@
     },
     {
       "name": "winnow",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "repository": "https://github.com/winnow-rs/winnow"
     },
     {
       "name": "winreg",
       "version": "0.55.0",
+      "license": "MIT",
+      "repository": "https://github.com/gentoo90/winreg-rs"
+    },
+    {
+      "name": "winreg",
+      "version": "0.56.0",
       "license": "MIT",
       "repository": "https://github.com/gentoo90/winreg-rs"
     },
@@ -5638,19 +6862,19 @@
     },
     {
       "name": "zbus",
-      "version": "5.16.0",
+      "version": "5.18.0",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     },
     {
       "name": "zbus_macros",
-      "version": "5.16.0",
+      "version": "5.18.0",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     },
     {
       "name": "zbus_names",
-      "version": "4.3.2",
+      "version": "4.3.4",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     },
@@ -5692,25 +6916,25 @@
     },
     {
       "name": "zmij",
-      "version": "1.0.21",
+      "version": "1.0.23",
       "license": "MIT",
       "repository": "https://github.com/dtolnay/zmij"
     },
     {
       "name": "zvariant",
-      "version": "5.12.0",
+      "version": "5.13.1",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     },
     {
       "name": "zvariant_derive",
-      "version": "5.12.0",
+      "version": "5.13.1",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     },
     {
       "name": "zvariant_utils",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "repository": "https://github.com/z-galaxy/zbus/"
     }


### PR DESCRIPTION
## Why

`allure-commandline` (Allure 2, Java-based) has a pure-JS/TS successor: the `allure` npm package (Allure Report 3, stable since Dec 2025, currently 3.16.0). It reads the same JUnit-XML `junit-reports/` this repo already produces, so this is a drop-in swap rather than a pipeline rework.

## What changed

- `package.json`: `allure-commandline ^2.32.0` → `allure ^3.16.0`.
- `.github/workflows/storybook.yml`:
  - `allure generate` now takes `--report-name` directly, which sets `<title>` — dropped the sed that rewrote it after the fact.
  - v3's generated `index.html` has no `<!-- allure-core-head -->` anchor (different report engine/template), so the OGP + description meta injection now targets `</head>` instead.
- Regenerated `src/assets/oss-licenses.json` — the npm dependency tree changed (`allure-commandline`'s single package → `allure`'s ~15 `@allurereport/*` packages plus their own deps).

## Bonus

No more implicit dependency on the runner's bundled Java — `allure` (v3) is plain Node.

## Verification

Ran the actual pipeline locally end-to-end outside CI:
- `npx vitest run --project=unit --reporter=junit` → `scripts/normalize-junit.mjs` → `scripts/biome-to-junit.mjs` → `npx allure generate --report-name "Envarly — Test Reports" -o <dir> junit-reports`, using real results (290 passing tests).
- Confirmed `<title>` is set correctly, `summary.json` reflects the correct pass count, and the `</head>`-targeted sed correctly injects the OGP/description meta tags.
- `biome check src` is clean relative to `main` (same 3 pre-existing, unrelated formatting findings either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)