### PR TITLE
chore: fix pre-existing biome format drift

### DIFF
--- a/src/components/DetailPanel/DetailHeader.tsx
+++ b/src/components/DetailPanel/DetailHeader.tsx
@@ -37,9 +37,7 @@ export function DetailHeader({
     <div className="flex items-center gap-3 px-6 h-[60px] border-b border-rim-subtle shrink-0">
       <div className="flex items-center gap-2 flex-1 min-w-0">
         <h2 className="font-mono font-semibold text-base text-fg truncate">{name}</h2>
-        <Badge
-          variant={scope === "User" ? "user" : scope === "System" ? "system" : "otherUser"}
-        >
+        <Badge variant={scope === "User" ? "user" : scope === "System" ? "system" : "otherUser"}>
           {scope}
         </Badge>
         {readOnly && (

--- a/src/components/DetailPanel/DetailPanel.tsx
+++ b/src/components/DetailPanel/DetailPanel.tsx
@@ -162,7 +162,11 @@ export function DetailPanel({
   // OtherUser has no PATH tooling of its own yet — treat it as already present
   // so the hint never offers an action that would write to the wrong hive.
   const pathInEnvForScope =
-    variable.scope === "System" ? systemPathInEnv : variable.scope === "User" ? userPathInEnv : true;
+    variable.scope === "System"
+      ? systemPathInEnv
+      : variable.scope === "User"
+        ? userPathInEnv
+        : true;
   const showAddToPathHint =
     isPathVar &&
     !pathInEnvForScope &&

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -50,10 +50,7 @@ export function Sidebar({
   personalScopeLabel,
 }: Props) {
   const { t } = useI18n();
-  const scopeTabs = useMemo(
-    () => ["All", personalScope, "System"] as const,
-    [personalScope],
-  );
+  const scopeTabs = useMemo(() => ["All", personalScope, "System"] as const, [personalScope]);
   const { width, isDragging, handleProps } = useResizableWidth({ ...SIDEBAR_WIDTH, side: "left" });
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>("All");


### PR DESCRIPTION
## Why

Found while verifying #190 didn't introduce new lint failures: 3 files had already drifted from biome's formatting on \`main\` (unrelated to that change).

## What changed

- \`npx biome check --write src\` — \`Sidebar.tsx\`, \`DetailHeader.tsx\`, \`DetailPanel.tsx\`. Pure formatting (line-wrap), no logic change.

## Rust side

Checked as requested: \`cargo fmt --check\` and \`cargo clippy --all-targets\` in \`src-tauri/\` are both already clean — nothing to fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)