### PR TITLE
fix(ci): fix Allure Biome-report bug, add cross-run history/trend

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,14 +75,35 @@ jobs:
           cp -r lp/dist/. site/
           mv storybook-static site/storybook
 
+      - name: Fetch previous Allure history
+        # Feeds the last run's trend data back in so the report can show
+        # pass/fail history and regression status per test instead of just
+        # this run's isolated snapshot. First run (or a 404 from a fresh
+        # deploy) just starts a new history file — allurerc.mjs's
+        # appendHistory handles either case.
+        run: |
+          mkdir -p allure-history
+          curl -fsSL https://iray-tno.github.io/envarly/reports/history/allure-history.jsonl -o allure-history/allure-history.jsonl || rm -f allure-history/allure-history.jsonl
+
       - name: Build HTML reports
-        run: npx allure generate --report-name "Envarly — Test Reports" -o site/reports junit-reports
+        # Report name and history settings come from allurerc.mjs, auto-
+        # discovered from the repo root this runs in.
+        run: npx allure generate -o site/reports junit-reports
+
+      - name: Persist Allure history
+        # Publish the history file this run just updated so the next run's
+        # "Fetch previous Allure history" step above can pick it back up.
+        run: |
+          mkdir -p site/reports/history
+          cp allure-history/allure-history.jsonl site/reports/history/allure-history.jsonl
 
       - name: Brand Allure report head
-        # Allure 3's generated page sets <title> from --report-name above but
+        # Allure 3's generated page sets <title> from allurerc.mjs's `name`
+        # (padded with stray spaces by its own template — trim those) but
         # emits no OGP/description metadata of its own — inject Envarly
         # branding so it's identifiable if crawled/shared.
         run: |
+          sed -i 's#<title> Envarly — Test Reports </title>#<title>Envarly — Test Reports</title>#' site/reports/index.html
           sed -i 's#</head>#    <meta property="og:site_name" content="Envarly" />\n    <meta property="og:title" content="Envarly — Test Reports" />\n    <meta name="description" content="CI test reports for Envarly, the Windows environment variable manager (https://iray-tno.github.io/envarly/)." />\n</head>#' site/reports/index.html
 
       - uses: actions/upload-pages-artifact@v3

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -1,0 +1,15 @@
+// Config for `npx allure generate` (Allure Report 3), used by the Pages
+// workflow to build the CI test report published at /envarly/reports/.
+// Auto-discovered by the CLI from the working directory it's run from
+// (the repo root) — no --config flag needed.
+export default {
+  name: 'Envarly — Test Reports',
+  // Accumulates one entry per run across CI invocations so the report can
+  // show pass/fail trend and regression status per test, not just a single
+  // isolated snapshot. The workflow fetches the previous run's copy of this
+  // file from the live site before generating, and republishes the updated
+  // copy after — see .github/workflows/pages.yml.
+  historyPath: './allure-history/allure-history.jsonl',
+  appendHistory: true,
+  historyLimit: 30,
+};

--- a/scripts/biome-to-junit.mjs
+++ b/scripts/biome-to-junit.mjs
@@ -11,7 +11,16 @@ try {
   data = { diagnostics: [] };
 }
 
-const diags = (data.diagnostics ?? []).filter(d => d.location?.path?.file);
+// Biome's --json diagnostics report `location.path` as a plain string
+// (e.g. "src/foo.tsx"), not `{ file: "..." }` as biome-to-junit assumed
+// pre-2.x. That mismatch silently dropped every diagnostic here, so this
+// always emitted "all clear" regardless of real biome check results.
+function pathOf(location) {
+  const path = location?.path;
+  return typeof path === 'string' ? path : path?.file;
+}
+
+const diags = (data.diagnostics ?? []).filter(d => pathOf(d.location));
 const failures = diags.length;
 const tests = Math.max(failures, 1);
 
@@ -28,11 +37,15 @@ if (failures === 0) {
   cases = '    <testcase name="all clear" classname="biome" />\n';
 } else {
   for (const d of diags) {
-    const file = d.location.path.file;
-    const line = d.location?.span?.start?.line ?? 1;
-    const msg = d.description ?? 'lint violation';
+    const file = pathOf(d.location);
+    const line = d.location?.start?.line ?? 1;
+    const msg = d.message ?? d.description ?? 'lint violation';
     const sev = d.severity ?? 'warning';
-    cases += `    <testcase name="${esc(file)}:${line}" classname="${esc(msg.slice(0, 80))}">\n`;
+    // d.category is biome's rule id (e.g. "lint/suspicious/noDebugger", or
+    // "format" for formatting drift) — a much stabler grouping key than a
+    // slice of the free-text message.
+    const classname = d.category ?? msg.slice(0, 80);
+    cases += `    <testcase name="${esc(file)}:${line}" classname="${esc(classname)}">\n`;
     cases += `      <failure message="${esc(msg)}" type="${esc(sev)}">${esc(msg)}\n  at ${esc(file)}:${line}</failure>\n`;
     cases += `    </testcase>\n`;
   }


### PR DESCRIPTION
Follow-up to #190. Two independent changes, both found while looking into report readability — no test implementation touched.

## 1. Biome-report bug (real correctness bug, not a readability tweak)

`scripts/biome-to-junit.mjs` assumed `location.path` was `{ file: "..." }`. Biome's actual `--json` output has `location.path` as a plain string, the message text is `.message` (not `.description`), and the diagnostic span is `location.start` (not `location.span.start`). The old filter (`d.location?.path?.file`) silently dropped every diagnostic, so the "Biome" suite in the Allure report has **always shown "all clear" regardless of real `biome check` results**.

Confirmed live: right after #190 merged, `main` had 3 real formatting errors (fixed since in #192) but the deployed report showed `{"total":375,"passed":375}` — 0 failures.

Also switched the failing testcase's `classname` to Biome's own rule id (e.g. `lint/suspicious/noDebugger`) instead of a truncated slice of the free-text message, for stabler grouping across runs.

## 2. Cross-run history/trend

Added `allurerc.mjs` (auto-discovered by `allure generate` from the repo root) turning on `historyPath`/`appendHistory`, plus two new `pages.yml` steps:
- **Fetch previous Allure history** — pulls last run's `history/allure-history.jsonl` from the live site before generating (tolerates a 404 on the first run).
- **Persist Allure history** — republishes the updated file after generating, for the next run to pick up.

This gets pass/fail trend and per-test regression status (`transition: "regressed"` etc.) into the report across CI runs, instead of every run looking like an isolated first run.

## Bonus

Trimmed the stray leading/trailing spaces Allure 3's own title template leaves in `<title>` (cosmetic only).

## Verification

- Reproduced Biome's real `--json` shape with both a lint-rule violation (`noDebugger`) and a formatter diagnostic; confirmed the fixed script now reports them as failures with the right file/line/classname.
- `npm run test:reports` (normalize-junit unit tests) still green.
- Simulated two successive CI runs end-to-end (fetch → generate → persist → fetch again → generate) using real vitest+biome results: history accumulated correctly and `newTests` went 290 → 0 on the second run, confirming the trend mechanism works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)