### PR TITLE
docs: fix documentation inconsistencies in README, DESIGN, and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,23 @@ chore: update tauri to 2.x
 ### PR checklist
 
 - [ ] `npm test` passes
+- [ ] `npm run lint` passes (Biome)
+- [ ] `npm run check-version` passes (if version files are touched)
 - [ ] `cargo test` passes (if Rust changed)
-- [ ] No direct registry writes added outside `commands::set_env_var` / `commands::delete_env_var`
+- [ ] No direct registry writes added outside `commands/env.rs` / `apply_env_changes`
 - [ ] New UI is keyboard-navigable and has appropriate ARIA roles
+
+## Adding or updating translations
+
+Envarly supports multiple languages using `react-i18next`. Translation resources live under `src/locales/`:
+
+- `src/locales/<lang>/translation.json` — UI labels, tooltips, dialogs, and messages
+- `src/locales/<lang>/descriptions.json` — Explanations for ~140 standard Windows environment variables
+
+When adding a new language:
+1. Create `src/locales/<lang>/` with `translation.json` and `descriptions.json`.
+2. Register the language resource in `src/i18n.ts`.
+3. Add the language option to the header language switcher in `src/components/AppHeader/LanguageMenu.tsx`.
 
 ## Setting up branch protection
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,13 +37,17 @@ src/                    React frontend (TypeScript)
 
 src-tauri/src/          Rust backend
   lib.rs                Entry point: CLI dispatch or Tauri run
-  commands.rs           Tauri command handlers (thin — delegate to domain modules)
+  commands/             Tauri command handlers per domain (env, export, launch, path, snapshot, update, users)
   env_store.rs          Registry read/write via winreg; EnvBackend trait + MemBackend for tests
+  env_backend.rs        Windows registry implementation (WinregBackend)
+  model.rs              Shared domain types and serialization
   path_manage.rs        PATH status check (userHasEntry / systemHasEntry) + propose-add
+  path_backend.rs       PATH manipulation backend trait
   snapshot.rs           Snapshot save/list/restore + DPAPI encryption
   crypto.rs             DPAPI wrapper (protect/unprotect)
-  export.rs             JSON, .reg, and IaC format (PS1, DSC v2/v3, Ansible) import/export
+  export/               JSON, .reg, and IaC format (PS1, DSC v2/v3, Ansible) export implementations
   import.rs             Backend-agnostic diff for `envarly import`/`set` (merge/replace, kind inference)
+  user_hive.rs          Loading and editing other local accounts' registry hives
   cli.rs                CLI subcommands (clap): get/list/export are read-only; import/set/delete write behind --apply
   error.rs              EnvarlyError (thiserror)
 ```
@@ -135,8 +139,13 @@ The JSON payload contains a `version` field. Current version is **1**.
   "createdAt": "2024-06-15T12:00:00Z",
   "label": "before npm install",
   "snapshot": {
-    "user":   { "VAR": "value", ... },
-    "system": { "PATH": "...", ... }
+    "user": {
+      "VAR": { "value": "my_value", "kind": "String" }
+    },
+    "system": {
+      "PATH": { "value": "C:\\Tools;...", "kind": "ExpandString" }
+    },
+    "otherUser": null
   }
 }
 ```
@@ -187,4 +196,4 @@ Spacing follows a 4px/8px grid. Tailwind class mapping:
 
 ## Storybook
 
-Deployed to GitHub Pages at `/envarly/storybook/` on push to `main`. The `/envarly/` root is reserved for a future landing page. Theme toggle (dark/light) uses `globalTypes` — the `backgrounds` addon is not used.
+Deployed to GitHub Pages at `/envarly/storybook/` on push to `main` (handled by `pages.yml`). The multi-language landing page (built with Astro in `lp/`) lives at the `/envarly/` root. Theme toggle (dark/light) uses `globalTypes` — the `backgrounds` addon is not used.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ session, use `mise exec -- npm run dev`.
 npm test                       # Vitest in watch mode
 npm run coverage               # coverage report (V8)
 npx vitest run                 # single run (used in CI)
+npm run test:storybook -- --run # Storybook accessibility (a11y) test
 cd src-tauri && cargo test     # Rust unit tests (runs on Linux/macOS too)
 ```
 
@@ -149,8 +150,8 @@ envarly list --scope system --format json
 envarly export --format json     --output backup.json
 envarly export --format reg      --output backup.reg
 envarly export --format ps1      --output backup.ps1      # PowerShell [Environment]::SetEnvironmentVariable
-envarly export --format dsc_v2   --output backup.ps1      # PowerShell DSC v2 configuration
-envarly export --format dsc_v3   --output backup.dsc.yaml # DSC v3 YAML
+envarly export --format dsc-v2   --output backup.ps1      # PowerShell DSC v2 configuration
+envarly export --format dsc-v3   --output backup.dsc.yaml # DSC v3 YAML
 envarly export --format ansible  --output backup.yml      # Ansible environment playbook
 envarly export --format json | jq '.user.PATH'
 
@@ -255,14 +256,16 @@ Detected secrets are shown with a `⚠ ServiceName` badge (e.g. `⚠ AWS`, `⚠ 
 
 ## Snapshots
 
-Snapshots are stored as JSON files under `%LOCALAPPDATA%\Envarly\snapshots\`. Each file contains the full user and system environment at the time of the snapshot. They can be listed, restored, or deleted from within the app.
+Snapshots are stored as DPAPI-encrypted `.snap` files under `%LOCALAPPDATA%\Envarly\snapshots\`. Only the Windows user account that created the snapshot on the same machine can decrypt it. Each file contains the full user and system environment at the time of the snapshot. They can be listed, restored, or deleted from within the app.
 
 ## CI
 
 | Workflow | Trigger | Jobs |
 |---|---|---|
-| `test.yml` | Every push | Frontend (vitest) + Rust (cargo test) + version consistency check |
-| `release.yml` | Tag push `v*` or manual | Windows build → GitHub Releases |
+| `test.yml` | Every push / PR | Frontend (vitest + storybook a11y) + Rust (cargo test) + version consistency & lint |
+| `release.yml` | Tag push `v*` or manual | Windows build (NSIS, WiX MSI, portable ZIP) → GitHub Releases |
+| `pages.yml` | Push to `main` | Storybook, Allure report, and landing page deployment to GitHub Pages |
+| `winget.yml` | GitHub Release published or manual | Updates and submits WinGet package manifest |
 | `security.yml` | Weekly (Mon 09:00 UTC) or manual | npm audit + cargo audit |
 
 ## Project structure


### PR DESCRIPTION
## Summary

Addresses outdated descriptions, inconsistencies with current implementations, and missing guides across `README.md`, `DESIGN.md`, and `CONTRIBUTING.md`.

### README.md
- **CLI export format**: Fixed `--format dsc_v2` / `dsc_v3` to kebab-case (`dsc-v2` / `dsc-v3`) matching the `clap::ValueEnum` parser in `src-tauri/src/cli.rs`.
- **Testing section**: Added `npm run test:storybook -- --run` for local Storybook accessibility (a11y) test execution.
- **Snapshots**: Updated format description from plain JSON to DPAPI-encrypted `.snap` files.
- **CI Workflows**: Added `pages.yml` (Storybook, Allure, LP) and `winget.yml` (WinGet submission) to the CI table.

### DESIGN.md
- **Rust backend file tree**: Updated structure to reflect modularized `commands/` and `export/` directories and new backend modules (`model.rs`, `user_hive.rs`, etc.).
- **Snapshot struct example**: Updated the v1 struct JSON example to reflect typed values (`{"value": "...", "kind": "String"}`) and the `otherUser` field.
- **Landing Page status**: Updated note from "reserved for a future landing page" to reflect the live multi-language Astro landing page at root.

### CONTRIBUTING.md
- **PR checklist**: Added Biome lint (`npm run lint`) and version consistency (`npm run check-version`) checks, and updated registry write path to `commands/env.rs` / `apply_env_changes`.
- **Translations (i18n)**: Added a guide explaining how to add or update language resources under `src/locales/`.

## Verification
- `npm run lint` (Biome) passed
- `npm run check-version` passed
- `npm test` (31 test files, 289 tests) passed
