### PR TITLE
docs(lp): replace default starter kit template in README with minimal guide

### DIFF
--- a/lp/README.md
+++ b/lp/README.md
@@ -1,43 +1,22 @@
-# Astro Starter Kit: Minimal
+# Envarly Landing Page
+
+This directory contains the multi-language landing page for [Envarly](https://github.com/iray-tno/envarly), built with [Astro](https://astro.build/) and deployed to [GitHub Pages](https://iray-tno.github.io/envarly/).
+
+For general information about Envarly, architecture, and desktop app development, see the [main README](../README.md).
+
+## Development
+
+Run from the `lp` directory:
 
 ```sh
-npm create astro@latest -- --template minimal
+npm install      # install dependencies
+npm run dev      # start dev server at http://localhost:4321
+npm run build    # build static output to ./dist/
+npm run preview  # preview production build locally
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Structure
 
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+- `src/pages/` — Page routes for each supported language (`/`, `/ja/`, `/zh-cn/`, `/ko/`, `/ru/`, `/vi/`)
+- `src/lib/lpContent.ts` — Localized copy, translations, and metadata (version is synced automatically with `npm version` in the repository root)
+- `src/components/` — UI components used across the landing page


### PR DESCRIPTION
## Summary

Replaces the default Astro starter kit template in `lp/README.md` with a clean, minimal guide for the Envarly landing page project.

- Links to the main repository README for core development & architecture
- Documents local commands (`npm run dev`, `build`, `preview`)
- Summarizes the `lp/` directory structure (`src/pages/`, `src/lib/lpContent.ts`, `src/components/`)
