### PR TITLE
docs(lp): reference AGENTS.md from CLAUDE.md to prevent duplication

### DIFF
--- a/lp/CLAUDE.md
+++ b/lp/CLAUDE.md
@@ -1,22 +1,2 @@
-## Development
+See [AGENTS.md](./AGENTS.md) for development instructions and documentation links.
 
-When starting the dev server, use background mode:
-
-```
-astro dev --background
-```
-
-Manage the background server with `astro dev stop`, `astro dev status`, and `astro dev logs`.
-
-## Documentation
-
-Full documentation: https://docs.astro.build
-
-Consult these guides before working on related tasks:
-
-- [Adding pages, dynamic routes, or middleware](https://docs.astro.build/en/guides/routing/)
-- [Working with Astro components](https://docs.astro.build/en/basics/astro-components/)
-- [Using React, Vue, Svelte, or other framework components](https://docs.astro.build/en/guides/framework-components/)
-- [Adding or managing content](https://docs.astro.build/en/guides/content-collections/)
-- [Adding styles or using Tailwind](https://docs.astro.build/en/guides/styling/)
-- [Supporting multiple languages](https://docs.astro.build/en/guides/internationalization/)

--- a/lp/CLAUDE.md
+++ b/lp/CLAUDE.md
@@ -1,2 +1,1 @@
-See [AGENTS.md](./AGENTS.md) for development instructions and documentation links.
-
+@AGENTS.md


### PR DESCRIPTION
## Summary

Updates `lp/CLAUDE.md` to reference `lp/AGENTS.md` instead of duplicating identical development instructions and documentation links.
